### PR TITLE
Add VoiceOver announcements for capture lifecycle

### DIFF
--- a/TinyClips/Services/SaveService.swift
+++ b/TinyClips/Services/SaveService.swift
@@ -2,6 +2,57 @@ import AppKit
 import UserNotifications
 import CryptoKit
 
+@MainActor
+final class AccessibilityAnnouncementService {
+    static let shared = AccessibilityAnnouncementService()
+
+    private init() {}
+
+    func announceCaptureStart(for type: CaptureType, countdownCompleted: Bool) {
+        let message: String
+
+        switch type {
+        case .screenshot:
+            message = countdownCompleted ? "Countdown complete. Taking screenshot." : "Taking screenshot."
+        case .video:
+            message = countdownCompleted ? "Countdown complete. Starting video recording." : "Starting video recording."
+        case .gif:
+            message = countdownCompleted ? "Countdown complete. Starting GIF recording." : "Starting GIF recording."
+        }
+
+        announce(message, priority: .high)
+    }
+
+    func announceRecordingStopped(for type: CaptureType) {
+        announce("\(type.label) recording stopped.", priority: .high)
+    }
+
+    func announceSaveSuccess(for type: CaptureType, url: URL) {
+        announce("\(type.label) saved as \(url.lastPathComponent).", priority: .medium)
+    }
+
+    func announceError(_ message: String) {
+        announce("Error. \(message) Press OK to dismiss.", priority: .high)
+    }
+
+    func announce(_ message: String, priority: NSAccessibilityPriorityLevel) {
+        let userInfo: [NSAccessibility.NotificationUserInfoKey: Any] = [
+            .announcement: message,
+            .priority: priority.rawValue
+        ]
+
+        NSAccessibility.post(
+            element: announcementElement(),
+            notification: .announcementRequested,
+            userInfo: userInfo
+        )
+    }
+
+    private func announcementElement() -> Any {
+        NSApp.mainWindow ?? NSApp.keyWindow ?? NSApp.windows.first ?? NSApp
+    }
+}
+
 class SaveService: NSObject, UNUserNotificationCenterDelegate {
     static let shared = SaveService()
     private let notificationURLKey = "savedFileURL"
@@ -192,6 +243,8 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
             copyToClipboard(url: url, type: type)
         }
 
+        AccessibilityAnnouncementService.shared.announceSaveSuccess(for: type, url: url)
+
         if settings.showInFinder {
             NSWorkspace.shared.activateFileViewerSelecting([url])
         }
@@ -304,6 +357,8 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 
     @MainActor
     func showError(_ message: String) {
+        AccessibilityAnnouncementService.shared.announceError(message)
+
         let alert = NSAlert()
         alert.messageText = "TinyClips"
         alert.informativeText = message

--- a/TinyClips/TinyClipsApp.swift
+++ b/TinyClips/TinyClipsApp.swift
@@ -453,6 +453,10 @@ class CaptureManager: ObservableObject {
         let doCapture = { [weak self] in
             guard let self else { return }
             self.dismissRegionIndicator()
+            AccessibilityAnnouncementService.shared.announceCaptureStart(
+                for: .screenshot,
+                countdownCompleted: countdownEnabled
+            )
             Task {
                 do {
                     let settings = CaptureSettings.shared
@@ -535,6 +539,10 @@ class CaptureManager: ObservableObject {
 
         let doRecord = { [weak self] in
             guard let self else { return }
+            AccessibilityAnnouncementService.shared.announceCaptureStart(
+                for: .video,
+                countdownCompleted: countdownEnabled
+            )
             Task {
                 let shouldSaveImmediately = !settings.showTrimmer || settings.saveImmediatelyVideo
                 let url = shouldSaveImmediately
@@ -622,6 +630,10 @@ class CaptureManager: ObservableObject {
         resetRecordingAudioStatus()
         let doRecord = { [weak self] in
             guard let self else { return }
+            AccessibilityAnnouncementService.shared.announceCaptureStart(
+                for: .gif,
+                countdownCompleted: countdownEnabled
+            )
             Task {
                 do {
                     let writer = GifWriter()
@@ -655,6 +667,15 @@ class CaptureManager: ObservableObject {
     }
 
     private func stopRecordingFlow() async {
+        let stoppedRecordingType: CaptureType?
+        if videoRecorder != nil {
+            stoppedRecordingType = .video
+        } else if gifWriter != nil {
+            stoppedRecordingType = .gif
+        } else {
+            stoppedRecordingType = nil
+        }
+
         var savedVideoURL: URL?
 
         if let recorder = videoRecorder {
@@ -701,6 +722,10 @@ class CaptureManager: ObservableObject {
         dismissStopPanel()
         dismissRegionIndicator()
         resetRecordingAudioStatus()
+
+        if let stoppedRecordingType {
+            AccessibilityAnnouncementService.shared.announceRecordingStopped(for: stoppedRecordingType)
+        }
 
         // Show editor windows AFTER all recording resources are released
         // and UI state is cleaned up, so AVPlayer doesn't contend with


### PR DESCRIPTION
## Why

TinyClips already has better labels and keyboard support, but key capture-state changes were still mostly visual. This adds explicit VoiceOver announcements so blind and low-vision users get spoken feedback when capture starts, recording stops, saves succeed, and save errors occur.

## What changed

- Added a centralized `AccessibilityAnnouncementService` that posts AppKit accessibility announcements with appropriate priority.
- Wired screenshot, video, and GIF flows to announce the final countdown transition together with capture or recording start.
- Announce recording stop from the real stop path so spoken feedback matches the actual lifecycle event.
- Extended `SaveService` to announce successful saves and errors surfaced through `showError(...)`, which also covers editor and trimmer save paths.

## Notes for reviewers

- Countdown announcements intentionally fire only for the final transition, not every second.
- The announcements are attached to the real coordinator and save/error paths rather than panel presentation, to avoid false positives.

## Validation

- Reviewed the patch for AppKit accessibility API usage and lifecycle wiring.
- `xcodebuild` could not be run in this session because the workspace is on Windows and the tool is unavailable here.
- Manual follow-up on macOS: verify VoiceOver announcements for screenshot start, video/GIF start, recording stop, save success, and save error flows in both `TinyClips` and `TinyClipsMAS`.