### PR TITLE
Fix trimmer saves using the final save flow

### DIFF
--- a/TinyClips/CaptureManager.swift
+++ b/TinyClips/CaptureManager.swift
@@ -683,7 +683,7 @@ class CaptureManager: ObservableObject {
                     }
 
                     updateProcessingProgress(1.0, status: "Done")
-                    showGifTrimmer(gifData: gifData, outputURL: url, saveImmediately: shouldSaveImmediately)
+                    showGifTrimmer(gifData: gifData, outputURL: url)
                 } else {
                     try await writer.stop(outputURL: url)
                     updateProcessingProgress(0.5, status: "Applying overlays…")
@@ -865,13 +865,11 @@ class CaptureManager: ObservableObject {
         }
     }
 
-    private func showGifTrimmer(gifData: GifCaptureData, outputURL: URL, saveImmediately: Bool) {
+    private func showGifTrimmer(gifData: GifCaptureData, outputURL: URL) {
         let window = GifTrimmerWindow(gifData: gifData, outputURL: outputURL) { [weak self] resultURL in
             guard let self else { return }
             if let resultURL {
-                if !saveImmediately {
-                    SaveService.shared.handleSavedFile(url: resultURL, type: .gif)
-                }
+                SaveService.shared.handleSavedFile(url: resultURL, type: .gif)
             }
             DispatchQueue.main.async {
                 self.gifTrimmerWindow = nil

--- a/TinyClips/Views/GifTrimmerWindow.swift
+++ b/TinyClips/Views/GifTrimmerWindow.swift
@@ -275,7 +275,7 @@ private struct GifTrimmerView: View {
         DispatchQueue.main.async {
             if let url = viewModel.exportGif(to: destinationURL, trimmed: true) {
                 isSaving = false
-                SaveService.shared.handleSavedFile(url: url, type: .gif)
+                onDone(url)
             } else {
                 isSaving = false
             }

--- a/TinyClips/Views/VideoTrimmerWindow.swift
+++ b/TinyClips/Views/VideoTrimmerWindow.swift
@@ -222,14 +222,14 @@ private struct VideoTrimmerView: View {
                     Divider()
 
                     Button("Save Without Trimming", systemImage: "film") {
-                        SaveService.shared.handleSavedFile(url: videoURL, type: .video)
+                        onDone(videoURL)
                     }
                     .help("Save the original video without trimming.")
 
                     Button("Save Trimmed", systemImage: "scissors") {
                         viewModel.exportTrimmed { resultURL in
                             guard let resultURL else { return }
-                            SaveService.shared.handleSavedFile(url: resultURL, type: .video)
+                            onDone(resultURL)
                         }
                     }
                     .help("Export only the selected trimmed segment.")


### PR DESCRIPTION
## Summary

A colleague ran into this on a fresh install: after saving from the video/GIF trimmer, it looked like TinyClips did not save anything unless "Show in Finder" was enabled. I hit a similar version too, where clicking Save in the trimmer felt like nothing happened.

The trimmer views were calling `SaveService` directly for their save actions, which skipped the `CaptureManager` completion path that owns the final save handling and closes out the trimmer flow. This routes video and GIF trimmer saves back through that callback, so save completion, Finder reveal, notifications, uploads, and cleanup all happen from the same place.

## QA notes

- Confirmed the video trimmer `Save Without Trimming` and `Save Trimmed` actions now return through `onDone`.
- Confirmed trimmed GIF saves return through `onDone`.
- Confirmed the GIF trimmer handoff no longer carries the stale `saveImmediately` flag. The actual Save immediately setting still works; that decision still happens before the trimmer is shown.

## Checks

- `git diff --check`