### PR TITLE
[Windows] Add multi-monitor target selection and monitor-aware indicators

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -10,6 +10,10 @@ own `CHANGELOG.md` at the repository root.
   badge (a rounded black pill with white text) in the bottom-right corner, matching the macOS app.
   It is burned into screenshots, every GIF frame, and every video frame; the badge scales with the
   capture height. Off by default.
+- **Multi-monitor capture targeting** — on multi-display setups, Settings now includes a capture
+  target mode (**Ask every time**, **Display under cursor**, or **Main display**) for Screen/Region
+  captures. Region selection now works across all monitors when needed, and countdown/recording/
+  processing overlays are anchored to the selected display.
 - **Microphone & system-audio toggles in the recording bar** — while recording a video, the
   floating recording bar now shows two small icon toggles (microphone and system audio) next to
   Stop. Toggling them updates the audio defaults used for your next recording, so you can quickly

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -31,6 +31,7 @@ public partial class App : Application
     private const string GlyphVideo = "\uE714";
     private const string GlyphGif = "\uE8B9";
     private const string GlyphStop = "\uE71A";
+    private const uint MonitorDefaultToNearest = 2;
 
     private TaskbarIcon? _taskbarIcon;
     private SettingsWindow? _settingsWindow;
@@ -44,6 +45,7 @@ public partial class App : Application
     private RegionIndicatorWindow? _recordingRegionIndicator;
     private DispatcherTimer? _recordingTimer;
     private DateTime _recordingStartedUtc;
+    private TargetSelection? _activeRecordingSelection;
     private CaptureTile? _videoTile;
     private CaptureTile? _gifTile;
     private TrayPopupWindow? _trayPopup;
@@ -356,7 +358,7 @@ public partial class App : Application
                         regionIndicator.Show(ToVirtualDesktopRegion(selection.Target, region));
                     }
 
-                    await CountdownWindow.RunAsync(pick.CountdownDuration);
+                    await CountdownWindow.RunAsync(pick.CountdownDuration, selection.Monitor);
                 }
                 finally
                 {
@@ -384,16 +386,18 @@ public partial class App : Application
 
                 case CaptureType.Video:
                     await Services.GetRequiredService<IVideoRecordingService>().StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes);
+                    _activeRecordingSelection = selection;
                     ShowRecordingRegionIndicator(selection);
                     UpdateRecordingState();
-                    ShowRecordingIndicator(CaptureType.Video);
+                    ShowRecordingIndicator(CaptureType.Video, selection);
                     break;
 
                 case CaptureType.Gif:
                     await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
+                    _activeRecordingSelection = selection;
                     ShowRecordingRegionIndicator(selection);
                     UpdateRecordingState();
-                    ShowRecordingIndicator(CaptureType.Gif);
+                    ShowRecordingIndicator(CaptureType.Gif, selection);
                     break;
             }
         }
@@ -402,6 +406,7 @@ public partial class App : Application
             Debug.WriteLine($"Capture failed: {ex}");
             UpdateRecordingState();
             CloseRecordingRegionIndicator();
+            _activeRecordingSelection = null;
             HideRecordingIndicatorIfNotRecording();
         }
     }
@@ -409,31 +414,56 @@ public partial class App : Application
     private async Task<TargetSelection?> ResolveTargetAsync(CapturePickerMode mode)
     {
         var monitors = Services.GetRequiredService<IMonitorService>();
+        var settings = Services.GetRequiredService<ICaptureSettings>();
 
         switch (mode)
         {
             case CapturePickerMode.Region:
             {
-                var monitor = monitors.GetPrimaryMonitor();
-                if (monitor is null)
+                var all = monitors.GetMonitors();
+                if (all.Count == 0)
                 {
                     return null;
                 }
 
-                var region = await RegionSelectWindow.RunAsync(monitor);
-                return region is { } r
-                    ? new TargetSelection(CaptureTarget.Monitor(monitor.HMonitor), r)
-                    : null;
+                var preferredMonitor = ResolvePreferredMonitor(monitors, settings.MultiMonitorCaptureMode);
+                if (preferredMonitor is { } single)
+                {
+                    var region = await RegionSelectWindow.RunAsync(single);
+                    return region is { } singleRegion
+                        ? new TargetSelection(CaptureTarget.Monitor(single.HMonitor), singleRegion, single)
+                        : null;
+                }
+
+                var result = await RegionSelectController.RunAsync(all);
+                if (result is not { } selection)
+                {
+                    return null;
+                }
+
+                var selectedMonitor = all.FirstOrDefault(m => m.HMonitor == selection.HMonitor)
+                    ?? monitors.GetPrimaryMonitor();
+                return new TargetSelection(CaptureTarget.Monitor(selection.HMonitor), selection.Region, selectedMonitor);
             }
 
             case CapturePickerMode.Screen:
             {
                 var all = monitors.GetMonitors();
-                var chosen = all.Count <= 1
-                    ? all.FirstOrDefault() ?? monitors.GetPrimaryMonitor()
-                    : await ScreenPickerWindow.RunAsync(all);
+                if (all.Count == 0)
+                {
+                    return null;
+                }
+
+                var chosen = ResolvePreferredMonitor(monitors, settings.MultiMonitorCaptureMode);
+                if (chosen is null)
+                {
+                    chosen = all.Count <= 1
+                        ? all.FirstOrDefault() ?? monitors.GetPrimaryMonitor()
+                        : await ScreenPickerWindow.RunAsync(all);
+                }
+
                 return chosen is { } monitor
-                    ? new TargetSelection(CaptureTarget.Monitor(monitor.HMonitor), null)
+                    ? new TargetSelection(CaptureTarget.Monitor(monitor.HMonitor), null, monitor)
                     : null;
             }
 
@@ -441,7 +471,7 @@ public partial class App : Application
             {
                 var hwnd = await WindowPickerWindow.RunAsync();
                 return hwnd is { } h
-                    ? new TargetSelection(CaptureTarget.Window(h), null)
+                    ? new TargetSelection(CaptureTarget.Window(h), null, null)
                     : null;
             }
 
@@ -471,7 +501,46 @@ public partial class App : Application
             : region with { X = monitor.X + region.X, Y = monitor.Y + region.Y };
     }
 
-    private readonly record struct TargetSelection(CaptureTarget Target, PixelRect? Region);
+    private static MonitorInfo? ResolvePreferredMonitor(IMonitorService monitors, MultiMonitorCaptureMode mode) => mode switch
+    {
+        MultiMonitorCaptureMode.UnderCursor => monitors.GetMonitorUnderCursor() ?? monitors.GetPrimaryMonitor(),
+        MultiMonitorCaptureMode.MainDisplay => monitors.GetPrimaryMonitor(),
+        _ => null,
+    };
+
+    private static MonitorInfo? ResolveMonitorForTarget(CaptureTarget target)
+    {
+        var monitorService = Services.GetRequiredService<IMonitorService>();
+
+        if (target.HMonitor != 0)
+        {
+            var monitors = monitorService.GetMonitors();
+            return monitors.FirstOrDefault(m => m.HMonitor == target.HMonitor)
+                ?? monitorService.GetPrimaryMonitor();
+        }
+
+        if (target.Hwnd != 0)
+        {
+            return ResolveMonitorForWindowTarget(target.Hwnd) ?? monitorService.GetPrimaryMonitor();
+        }
+
+        return monitorService.GetPrimaryMonitor();
+    }
+
+    private static MonitorInfo? ResolveMonitorForWindowTarget(nint hwnd)
+    {
+        var monitorService = Services.GetRequiredService<IMonitorService>();
+        var hMonitor = MonitorFromWindow(hwnd, MonitorDefaultToNearest);
+        if (hMonitor == nint.Zero)
+        {
+            return monitorService.GetPrimaryMonitor();
+        }
+
+        var monitors = monitorService.GetMonitors();
+        return monitors.FirstOrDefault(m => m.HMonitor == hMonitor) ?? monitorService.GetPrimaryMonitor();
+    }
+
+    private readonly record struct TargetSelection(CaptureTarget Target, PixelRect? Region, MonitorInfo? Monitor);
 
     private async Task ToggleVideoAsync()
     {
@@ -544,6 +613,7 @@ public partial class App : Application
             HideRecordingIndicator();
             HideProcessingIndicator();
             CloseRecordingRegionIndicator();
+            _activeRecordingSelection = null;
             if (_isExiting)
             {
                 return;
@@ -582,13 +652,13 @@ public partial class App : Application
             if (video.IsRecording)
             {
                 HideRecordingIndicator();
-                ShowProcessingIndicator(CaptureType.Video);
+                ShowProcessingIndicator(CaptureType.Video, _activeRecordingSelection);
                 await video.StopAsync();
             }
             else if (gif.IsRecording)
             {
                 HideRecordingIndicator();
-                ShowProcessingIndicator(CaptureType.Gif);
+                ShowProcessingIndicator(CaptureType.Gif, _activeRecordingSelection);
                 await gif.StopAsync();
             }
         }
@@ -602,6 +672,7 @@ public partial class App : Application
             UpdateRecordingState();
             CloseRecordingRegionIndicatorIfNotRecording();
             HideRecordingIndicatorIfNotRecording();
+            _activeRecordingSelection = null;
         }
     }
 
@@ -643,7 +714,7 @@ public partial class App : Application
         window?.ClosePanel();
     }
 
-    private void ShowRecordingIndicator(CaptureType type)
+    private void ShowRecordingIndicator(CaptureType type, TargetSelection selection)
     {
         HideRecordingIndicator();
 
@@ -671,7 +742,12 @@ public partial class App : Application
 
         _recordingIndicator = window;
         window.UpdateElapsed(TimeSpan.Zero);
-        window.ShowNear();
+
+        var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+        var region = selection.Region is { } selectedRegion
+            ? ToVirtualDesktopRegion(selection.Target, selectedRegion)
+            : null;
+        window.ShowNear(monitor, region);
 
         _recordingTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _recordingTimer.Tick += OnRecordingTimerTick;
@@ -703,7 +779,7 @@ public partial class App : Application
         window?.ClosePanel();
     }
 
-    private void ShowProcessingIndicator(CaptureType type)
+    private void ShowProcessingIndicator(CaptureType type, TargetSelection? selection = null)
     {
         HideProcessingIndicator();
 
@@ -717,7 +793,11 @@ public partial class App : Application
         };
 
         _processingIndicator = window;
-        window.ShowNear();
+        var monitor = selection is { } current ? current.Monitor ?? ResolveMonitorForTarget(current.Target) : null;
+        var region = selection is { Region: { } selectedRegion, Target: { } selectedTarget }
+            ? ToVirtualDesktopRegion(selectedTarget, selectedRegion)
+            : null;
+        window.ShowNear(monitor, region);
     }
 
     private void HideProcessingIndicator()
@@ -1141,6 +1221,9 @@ public partial class App : Application
 
     [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern nint MonitorFromWindow(nint hwnd, uint flags);
 
     private void ApplyTheme()
     {

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -744,9 +744,11 @@ public partial class App : Application
         window.UpdateElapsed(TimeSpan.Zero);
 
         var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
-        var region = selection.Region is { } selectedRegion
-            ? ToVirtualDesktopRegion(selection.Target, selectedRegion)
-            : null;
+        PixelRect? region = null;
+        if (selection.Region is { } selectedRegion)
+        {
+            region = ToVirtualDesktopRegion(selection.Target, selectedRegion);
+        }
         window.ShowNear(monitor, region);
 
         _recordingTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
@@ -794,9 +796,11 @@ public partial class App : Application
 
         _processingIndicator = window;
         var monitor = selection is { } current ? current.Monitor ?? ResolveMonitorForTarget(current.Target) : null;
-        var region = selection is { Region: { } selectedRegion, Target: { } selectedTarget }
-            ? ToVirtualDesktopRegion(selectedTarget, selectedRegion)
-            : null;
+        PixelRect? region = null;
+        if (selection is { Region: { } selectedRegion, Target: { } selectedTarget })
+        {
+            region = ToVirtualDesktopRegion(selectedTarget, selectedRegion);
+        }
         window.ShowNear(monitor, region);
     }
 

--- a/windows/src/TinyClips.App/CountdownWindow.xaml.cs
+++ b/windows/src/TinyClips.App/CountdownWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using TinyClips.Core.Capture;
 using Windows.Graphics;
 using WinRT.Interop;
 
@@ -39,7 +40,7 @@ public sealed partial class CountdownWindow : Window
     }
 
     /// <summary>Shows a countdown overlay and returns when it finishes.</summary>
-    public static Task RunAsync(int seconds)
+    public static Task RunAsync(int seconds, MonitorInfo? monitor = null)
     {
         var window = new CountdownWindow(seconds);
         window.Activate();
@@ -47,7 +48,7 @@ public sealed partial class CountdownWindow : Window
         // Resize/position and clip the window to a rounded square only AFTER it has been
         // shown. Applying SetWindowRgn before the first present leaves the surface blank,
         // which is why the countdown stopped appearing.
-        window.CenterOnPrimaryDisplay();
+        window.CenterOnMonitor(monitor);
         window._timer.Start();
         return window._completed.Task;
     }
@@ -86,9 +87,11 @@ public sealed partial class CountdownWindow : Window
         AppWindow.IsShownInSwitchers = false;
     }
 
-    private void CenterOnPrimaryDisplay()
+    private void CenterOnMonitor(MonitorInfo? monitor)
     {
-        var area = DisplayArea.Primary?.WorkArea;
+        var area = monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 }
+            ? new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight)
+            : DisplayArea.Primary?.WorkArea;
 
         var hwnd = WindowNative.GetWindowHandle(this);
         var scale = GetScale(hwnd);

--- a/windows/src/TinyClips.App/ProcessingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/ProcessingIndicatorWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using TinyClips.Core.Capture;
 using Windows.Graphics;
 using WinRT.Interop;
 using TinyClips.Core.Models;
@@ -37,7 +38,12 @@ public sealed partial class ProcessingIndicatorWindow : Window
 
     public void ShowNear()
     {
-        PositionNearPrimaryWorkArea();
+        ShowNear(null, null);
+    }
+
+    public void ShowNear(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        PositionNearMonitorWorkArea(monitor, regionInVirtualDesktop);
         AppWindow.Show(false);
 
         // Keep the panel out of any concurrent capture.
@@ -70,7 +76,7 @@ public sealed partial class ProcessingIndicatorWindow : Window
         AppWindow.IsShownInSwitchers = false;
     }
 
-    private void PositionNearPrimaryWorkArea()
+    private void PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
     {
         var scale = GetScale();
         var width = (int)Math.Round(WidthDip * scale);
@@ -79,12 +85,31 @@ public sealed partial class ProcessingIndicatorWindow : Window
 
         AppWindow.Resize(new SizeInt32(width, height));
 
-        if (DisplayArea.Primary?.WorkArea is { } work)
+        if (GetWorkArea(monitor) is { } work)
         {
             var x = work.X + Math.Max(0, (work.Width - width) / 2);
             var y = work.Y + topOffset;
+
+            if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
+            {
+                x = region.X + Math.Max(0, (region.Width - width) / 2);
+                y = region.Y + topOffset;
+            }
+
+            x = Math.Clamp(x, work.X, work.X + Math.Max(0, work.Width - width));
+            y = Math.Clamp(y, work.Y, work.Y + Math.Max(0, work.Height - height));
             AppWindow.Move(new PointInt32(x, y));
         }
+    }
+
+    private static RectInt32? GetWorkArea(MonitorInfo? monitor)
+    {
+        if (monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 })
+        {
+            return new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight);
+        }
+
+        return DisplayArea.Primary?.WorkArea;
     }
 
     private double GetScale()

--- a/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
+using TinyClips.Core.Capture;
 using Windows.Foundation;
 using Windows.Graphics;
 using WinRT.Interop;
@@ -68,7 +69,12 @@ public sealed partial class RecordingIndicatorWindow : Window
 
     public void ShowNear()
     {
-        PositionNearPrimaryWorkArea();
+        ShowNear(null, null);
+    }
+
+    public void ShowNear(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        PositionNearMonitorWorkArea(monitor, regionInVirtualDesktop);
         AppWindow.Show(false);
 
         // Exclude the floating panel from screen capture so it never appears in the
@@ -216,7 +222,7 @@ public sealed partial class RecordingIndicatorWindow : Window
         AppWindow.IsShownInSwitchers = false;
     }
 
-    private void PositionNearPrimaryWorkArea()
+    private void PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
     {
         var scale = GetScale();
         var width = (int)Math.Round(WidthDip * scale);
@@ -225,12 +231,31 @@ public sealed partial class RecordingIndicatorWindow : Window
 
         AppWindow.Resize(new SizeInt32(width, height));
 
-        if (DisplayArea.Primary?.WorkArea is { } work)
+        if (GetWorkArea(monitor) is { } work)
         {
             var x = work.X + Math.Max(0, (work.Width - width) / 2);
             var y = work.Y + topOffset;
+
+            if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
+            {
+                x = region.X + Math.Max(0, (region.Width - width) / 2);
+                y = region.Y + topOffset;
+            }
+
+            x = Math.Clamp(x, work.X, work.X + Math.Max(0, work.Width - width));
+            y = Math.Clamp(y, work.Y, work.Y + Math.Max(0, work.Height - height));
             AppWindow.Move(new PointInt32(x, y));
         }
+    }
+
+    private static RectInt32? GetWorkArea(MonitorInfo? monitor)
+    {
+        if (monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 })
+        {
+            return new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight);
+        }
+
+        return DisplayArea.Primary?.WorkArea;
     }
 
     private double GetScale()

--- a/windows/src/TinyClips.App/RegionSelectController.cs
+++ b/windows/src/TinyClips.App/RegionSelectController.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using TinyClips.Core.Capture;
+
+namespace TinyClips.App;
+
+public readonly record struct RegionSelectResult(nint HMonitor, PixelRect Region);
+
+public static class RegionSelectController
+{
+    public static async Task<RegionSelectResult?> RunAsync(IReadOnlyList<MonitorInfo> monitors)
+    {
+        if (monitors.Count == 0)
+        {
+            return null;
+        }
+
+        var capture = App.Services.GetRequiredService<IScreenCaptureService>();
+        var backdropTasks = monitors.Select(async monitor =>
+        {
+            try
+            {
+                return await capture.CaptureMonitorAsync(monitor.HMonitor);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Region backdrop capture failed for {monitor.DeviceName}: {ex}");
+                return null;
+            }
+        }).ToArray();
+
+        var backdrops = await Task.WhenAll(backdropTasks);
+
+        var completion = new TaskCompletionSource<RegionSelectResult?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var windows = new List<RegionSelectWindow>(monitors.Count);
+        var completed = 0;
+
+        void Complete(RegionSelectResult? result)
+        {
+            if (Interlocked.Exchange(ref completed, 1) != 0)
+            {
+                return;
+            }
+
+            completion.TrySetResult(result);
+
+            foreach (var window in windows)
+            {
+                window.CloseFromController();
+            }
+        }
+
+        for (var i = 0; i < monitors.Count; i++)
+        {
+            var window = new RegionSelectWindow(monitors[i], backdrops[i], Complete);
+            windows.Add(window);
+        }
+
+        foreach (var window in windows)
+        {
+            window.Activate();
+        }
+
+        return await completion.Task;
+    }
+}

--- a/windows/src/TinyClips.App/RegionSelectWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RegionSelectWindow.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.Extensions.DependencyInjection;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Graphics;
@@ -14,22 +13,24 @@ using TinyClips.Core.Capture;
 namespace TinyClips.App;
 
 /// <summary>
-/// A full-screen, borderless overlay that lets the user rubber-band a rectangle on the
-/// primary monitor. Returns the selection as a monitor-relative <see cref="PixelRect"/>
-/// in physical pixels, or null if cancelled (Esc / empty selection).
+/// A full-screen, borderless overlay that lets the user rubber-band a rectangle on one
+/// monitor and reports a monitor-relative region in physical pixels.
 /// </summary>
 public sealed partial class RegionSelectWindow : Window
 {
-    private readonly TaskCompletionSource<PixelRect?> _result =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly MonitorInfo _monitor;
     private readonly CapturedFrame? _backdropFrame;
+    private readonly Action<RegionSelectResult?> _onComplete;
     private Point _start;
     private bool _dragging;
     private bool _completed;
+    private bool _closedByController;
 
-    private RegionSelectWindow(MonitorInfo monitor, CapturedFrame? backdropFrame)
+    internal RegionSelectWindow(MonitorInfo monitor, CapturedFrame? backdropFrame, Action<RegionSelectResult?> onComplete)
     {
+        _monitor = monitor;
         _backdropFrame = backdropFrame;
+        _onComplete = onComplete;
 
         InitializeComponent();
 
@@ -45,22 +46,8 @@ public sealed partial class RegionSelectWindow : Window
     /// <summary>Shows the overlay on the given monitor and resolves with the chosen region.</summary>
     public static async Task<PixelRect?> RunAsync(MonitorInfo monitor)
     {
-        // Snapshot the monitor BEFORE the overlay is shown so the dim panels never get baked
-        // into the backdrop image (otherwise we'd capture our own darkening).
-        CapturedFrame? frame = null;
-        try
-        {
-            var capture = App.Services.GetRequiredService<IScreenCaptureService>();
-            frame = await capture.CaptureMonitorAsync(monitor.HMonitor);
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Region backdrop capture failed: {ex}");
-        }
-
-        var window = new RegionSelectWindow(monitor, frame);
-        window.Activate();
-        return await window._result.Task;
+        var result = await RegionSelectController.RunAsync(new[] { monitor });
+        return result?.Region;
     }
 
     private void OnActivated(object sender, WindowActivatedEventArgs args)
@@ -236,26 +223,32 @@ public sealed partial class RegionSelectWindow : Window
         _completed = true;
         _dragging = false;
         RootGrid.ReleasePointerCaptures();
-        Closed -= OnClosed;
-        try
-        {
-            Close();
-        }
-        finally
-        {
-            _result.TrySetResult(region);
-        }
+        _onComplete(region is { } selected
+            ? new RegionSelectResult(_monitor.HMonitor, selected)
+            : null);
+        Close();
     }
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
-        if (_completed)
+        if (_closedByController || _completed)
         {
             return;
         }
 
         _completed = true;
         _dragging = false;
-        _result.TrySetResult(null);
+        _onComplete(null);
+    }
+
+    internal void CloseFromController()
+    {
+        if (_closedByController)
+        {
+            return;
+        }
+
+        _closedByController = true;
+        Close();
     }
 }

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -79,6 +79,9 @@ public sealed partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _reopenPickerAfterCapture;
 
+    [ObservableProperty]
+    private int _multiMonitorCaptureModeIndex;
+
     // Screenshot
     [ObservableProperty]
     private int _screenshotFormatIndex;
@@ -234,6 +237,12 @@ public sealed partial class SettingsViewModel : ObservableObject
             CopyVideoToClipboard = _settings.CopyVideoToClipboard;
             CopyGifToClipboard = _settings.CopyGifToClipboard;
             ReopenPickerAfterCapture = _settings.ReopenPickerAfterCapture;
+            MultiMonitorCaptureModeIndex = _settings.MultiMonitorCaptureMode switch
+            {
+                MultiMonitorCaptureMode.UnderCursor => 1,
+                MultiMonitorCaptureMode.MainDisplay => 2,
+                _ => 0,
+            };
 
             ScreenshotFormatIndex = _settings.ImageFormat == ImageFormat.Png ? 0 : 1;
             ScreenshotScale = _settings.ScreenshotScale;
@@ -327,6 +336,13 @@ public sealed partial class SettingsViewModel : ObservableObject
     partial void OnCopyGifToClipboardChanged(bool value) => Persist(() => _settings.CopyGifToClipboard = value);
 
     partial void OnReopenPickerAfterCaptureChanged(bool value) => Persist(() => _settings.ReopenPickerAfterCapture = value);
+
+    partial void OnMultiMonitorCaptureModeIndexChanged(int value) => Persist(() => _settings.MultiMonitorCaptureMode = value switch
+    {
+        1 => MultiMonitorCaptureMode.UnderCursor,
+        2 => MultiMonitorCaptureMode.MainDisplay,
+        _ => MultiMonitorCaptureMode.Picker,
+    });
 
     partial void OnScreenshotFormatIndexChanged(int value) =>
         Persist(() => _settings.ImageFormat = value == 0 ? ImageFormat.Png : ImageFormat.Jpeg);

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -265,6 +265,33 @@
                                    IsOn="{x:Bind ViewModel.ReopenPickerAfterCapture, Mode=TwoWay}" />
                            </Grid>
                        </Border>
+
+                       <Border Style="{StaticResource SettingCardStyle}">
+                           <Grid ColumnSpacing="16">
+                               <Grid.ColumnDefinitions>
+                                   <ColumnDefinition Width="*" />
+                                   <ColumnDefinition Width="Auto" />
+                               </Grid.ColumnDefinitions>
+                               <StackPanel VerticalAlignment="Center">
+                                   <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Multi-monitor capture mode" />
+                                   <TextBlock
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Text="Choose how Screen and Region decide which display to target." />
+                               </StackPanel>
+                               <ComboBox
+                                   Grid.Column="1"
+                                   Width="240"
+                                   VerticalAlignment="Center"
+                                   AutomationProperties.AutomationId="MultiMonitorCaptureModeComboBox"
+                                   AutomationProperties.Name="Multi-monitor capture mode"
+                                   SelectedIndex="{x:Bind ViewModel.MultiMonitorCaptureModeIndex, Mode=TwoWay}">
+                                   <ComboBoxItem Content="Show picker" />
+                                   <ComboBoxItem Content="Capture monitor under cursor" />
+                                   <ComboBoxItem Content="Always use main display" />
+                               </ComboBox>
+                           </Grid>
+                       </Border>
                    </StackPanel>
 
                    <StackPanel

--- a/windows/src/TinyClips.Core/Capture/IMonitorService.cs
+++ b/windows/src/TinyClips.Core/Capture/IMonitorService.cs
@@ -7,4 +7,7 @@ public interface IMonitorService
 
     /// <summary>Returns the primary monitor, or the first monitor if none is flagged primary.</summary>
     MonitorInfo? GetPrimaryMonitor();
+
+    /// <summary>Returns the monitor containing the current mouse cursor.</summary>
+    MonitorInfo? GetMonitorUnderCursor();
 }

--- a/windows/src/TinyClips.Core/Capture/MonitorInfo.cs
+++ b/windows/src/TinyClips.Core/Capture/MonitorInfo.cs
@@ -21,6 +21,18 @@ public sealed record MonitorInfo
     /// <summary>Height in physical pixels.</summary>
     public required int Height { get; init; }
 
+    /// <summary>Work-area left edge in virtual-desktop physical pixels.</summary>
+    public required int WorkAreaX { get; init; }
+
+    /// <summary>Work-area top edge in virtual-desktop physical pixels.</summary>
+    public required int WorkAreaY { get; init; }
+
+    /// <summary>Work-area width in physical pixels.</summary>
+    public required int WorkAreaWidth { get; init; }
+
+    /// <summary>Work-area height in physical pixels.</summary>
+    public required int WorkAreaHeight { get; init; }
+
     public required int DpiX { get; init; }
 
     public required int DpiY { get; init; }

--- a/windows/src/TinyClips.Core/Capture/MonitorService.cs
+++ b/windows/src/TinyClips.Core/Capture/MonitorService.cs
@@ -11,6 +11,7 @@ public sealed class MonitorService : IMonitorService
 {
     private const int MdtEffectiveDpi = 0;
     private const uint MonitorinfofPrimary = 1;
+    private const uint MonitorDefaultToNearest = 2;
 
     public IReadOnlyList<MonitorInfo> GetMonitors()
     {
@@ -34,6 +35,10 @@ public sealed class MonitorService : IMonitorService
                     Y = info.RcMonitor.Top,
                     Width = info.RcMonitor.Right - info.RcMonitor.Left,
                     Height = info.RcMonitor.Bottom - info.RcMonitor.Top,
+                    WorkAreaX = info.RcWork.Left,
+                    WorkAreaY = info.RcWork.Top,
+                    WorkAreaWidth = info.RcWork.Right - info.RcWork.Left,
+                    WorkAreaHeight = info.RcWork.Bottom - info.RcWork.Top,
                     DpiX = (int)dpiX,
                     DpiY = (int)dpiY,
                     IsPrimary = (info.DwFlags & MonitorinfofPrimary) != 0,
@@ -54,6 +59,23 @@ public sealed class MonitorService : IMonitorService
         return monitors.FirstOrDefault(m => m.IsPrimary) ?? monitors.FirstOrDefault();
     }
 
+    public MonitorInfo? GetMonitorUnderCursor()
+    {
+        if (!GetCursorPos(out var point))
+        {
+            return GetPrimaryMonitor();
+        }
+
+        var hMonitor = MonitorFromPoint(point, MonitorDefaultToNearest);
+        if (hMonitor == nint.Zero)
+        {
+            return GetPrimaryMonitor();
+        }
+
+        var monitors = GetMonitors();
+        return monitors.FirstOrDefault(m => m.HMonitor == hMonitor) ?? GetPrimaryMonitor();
+    }
+
     private delegate bool MonitorEnumProc(nint hMonitor, nint hdc, ref Rect rect, nint data);
 
     [DllImport("user32.dll")]
@@ -65,6 +87,12 @@ public sealed class MonitorService : IMonitorService
     [DllImport("shcore.dll")]
     private static extern int GetDpiForMonitor(nint hMonitor, int dpiType, out uint dpiX, out uint dpiY);
 
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out Point point);
+
+    [DllImport("user32.dll")]
+    private static extern nint MonitorFromPoint(Point point, uint flags);
+
     [StructLayout(LayoutKind.Sequential)]
     private struct Rect
     {
@@ -72,6 +100,13 @@ public sealed class MonitorService : IMonitorService
         public int Top;
         public int Right;
         public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Point
+    {
+        public int X;
+        public int Y;
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/windows/src/TinyClips.Core/Models/MultiMonitorCaptureMode.cs
+++ b/windows/src/TinyClips.Core/Models/MultiMonitorCaptureMode.cs
@@ -1,0 +1,8 @@
+namespace TinyClips.Core.Models;
+
+public enum MultiMonitorCaptureMode
+{
+    Picker = 0,
+    UnderCursor = 1,
+    MainDisplay = 2,
+}

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -311,10 +311,24 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("hasCompletedOnboarding", value);
     }
 
-    public bool AlwaysCaptureMainDisplay
+    public MultiMonitorCaptureMode MultiMonitorCaptureMode
     {
-        get => _settings.Get("alwaysCaptureMainDisplay", false);
-        set => _settings.Set("alwaysCaptureMainDisplay", value);
+        get
+        {
+            var persisted = _settings.Get("multiMonitorCaptureMode", string.Empty);
+            if (string.IsNullOrWhiteSpace(persisted))
+            {
+                // Back-compat with the previous boolean toggle.
+                return _settings.Get("alwaysCaptureMainDisplay", false)
+                    ? Models.MultiMonitorCaptureMode.MainDisplay
+                    : Models.MultiMonitorCaptureMode.Picker;
+            }
+
+            return Enum.TryParse<MultiMonitorCaptureMode>(persisted, ignoreCase: true, out var parsed)
+                ? parsed
+                : Models.MultiMonitorCaptureMode.Picker;
+        }
+        set => _settings.Set("multiMonitorCaptureMode", value.ToString());
     }
 
     public bool ShowRegionIndicator
@@ -487,7 +501,7 @@ public sealed class CaptureSettings : ICaptureSettings
         ScreenshotCountdownEnabled = false;
         ScreenshotCountdownDuration = 3;
         HasCompletedOnboarding = false;
-        AlwaysCaptureMainDisplay = false;
+        MultiMonitorCaptureMode = Models.MultiMonitorCaptureMode.Picker;
         ShowRegionIndicator = true;
         IncludeTinyClipsInCapture = false;
         ShowBrandingOverlay = false;

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -320,13 +320,13 @@ public sealed class CaptureSettings : ICaptureSettings
             {
                 // Back-compat with the previous boolean toggle.
                 return _settings.Get("alwaysCaptureMainDisplay", false)
-                    ? Models.MultiMonitorCaptureMode.MainDisplay
-                    : Models.MultiMonitorCaptureMode.Picker;
+                    ? MultiMonitorCaptureMode.MainDisplay
+                    : MultiMonitorCaptureMode.Picker;
             }
 
             return Enum.TryParse<MultiMonitorCaptureMode>(persisted, ignoreCase: true, out var parsed)
                 ? parsed
-                : Models.MultiMonitorCaptureMode.Picker;
+                : MultiMonitorCaptureMode.Picker;
         }
         set => _settings.Set("multiMonitorCaptureMode", value.ToString());
     }
@@ -501,7 +501,7 @@ public sealed class CaptureSettings : ICaptureSettings
         ScreenshotCountdownEnabled = false;
         ScreenshotCountdownDuration = 3;
         HasCompletedOnboarding = false;
-        MultiMonitorCaptureMode = Models.MultiMonitorCaptureMode.Picker;
+        MultiMonitorCaptureMode = MultiMonitorCaptureMode.Picker;
         ShowRegionIndicator = true;
         IncludeTinyClipsInCapture = false;
         ShowBrandingOverlay = false;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -54,7 +54,7 @@ public interface ICaptureSettings
     bool ScreenshotCountdownEnabled { get; set; }
     int ScreenshotCountdownDuration { get; set; }
     bool HasCompletedOnboarding { get; set; }
-    bool AlwaysCaptureMainDisplay { get; set; }
+    MultiMonitorCaptureMode MultiMonitorCaptureMode { get; set; }
     bool ShowRegionIndicator { get; set; }
     bool IncludeTinyClipsInCapture { get; set; }
     bool ShowBrandingOverlay { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -16,6 +16,7 @@ public sealed class CaptureSettingsTests
         Assert.Equal(100, settings.ScreenshotScale);
         Assert.Equal("TinyClips {date} at {time}", settings.FileNameTemplate);
         Assert.True(settings.ShowTrimmer);
+        Assert.Equal(MultiMonitorCaptureMode.Picker, settings.MultiMonitorCaptureMode);
     }
 
     [Fact]
@@ -27,11 +28,13 @@ public sealed class CaptureSettingsTests
         settings.GifFrameRate = 24.5;
         settings.VideoFrameRate = 60;
         settings.FileNameTemplate = "Custom {date}";
+        settings.MultiMonitorCaptureMode = MultiMonitorCaptureMode.UnderCursor;
 
         Assert.False(settings.CopyScreenshotToClipboard);
         Assert.Equal(24.5, settings.GifFrameRate);
         Assert.Equal(60, settings.VideoFrameRate);
         Assert.Equal("Custom {date}", settings.FileNameTemplate);
+        Assert.Equal(MultiMonitorCaptureMode.UnderCursor, settings.MultiMonitorCaptureMode);
     }
 
     [Fact]

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -38,6 +38,22 @@ public sealed class CaptureSettingsTests
     }
 
     [Fact]
+    public void MultiMonitorCaptureMode_UsesLegacyAlwaysCaptureMainDisplay_WhenModeIsMissing()
+    {
+        var mainDisplaySettingsService = new TestSettingsService();
+        mainDisplaySettingsService.Set("alwaysCaptureMainDisplay", true);
+        var mainDisplaySettings = new CaptureSettings(mainDisplaySettingsService);
+
+        Assert.Equal(MultiMonitorCaptureMode.MainDisplay, mainDisplaySettings.MultiMonitorCaptureMode);
+
+        var pickerSettingsService = new TestSettingsService();
+        pickerSettingsService.Set("alwaysCaptureMainDisplay", false);
+        var pickerSettings = new CaptureSettings(pickerSettingsService);
+
+        Assert.Equal(MultiMonitorCaptureMode.Picker, pickerSettings.MultiMonitorCaptureMode);
+    }
+
+    [Fact]
     public void ImageFormat_RoundTripsThroughScreenshotFormat()
     {
         var settings = CreateSettings();


### PR DESCRIPTION
This brings Windows capture targeting closer to macOS parity for multi-display setups, so Region and Screen capture can target the right monitor instead of defaulting to primary-only behavior.

## What changed
- Added a coordinated multi-monitor region selection flow with `RegionSelectController`, which opens one overlay per monitor and resolves a single shared selection result (`HMONITOR` + monitor-relative region).
- Updated target resolution in `App.xaml.cs` to support multi-monitor capture modes and return monitor-aware selections for region/screen capture.
- Added `MultiMonitorCaptureMode` (`Picker`, `UnderCursor`, `MainDisplay`) in core settings, including persistence and backward compatibility with the old `alwaysCaptureMainDisplay` setting.
- Added `GetMonitorUnderCursor()` and monitor work-area metadata in monitor services/models for monitor-aware placement.
- Updated countdown, recording, and processing indicators to position relative to the captured monitor (and near the selected region when available).
- Added Settings UI and view model binding for choosing multi-monitor capture mode.
- Added tests covering default and round-trip behavior for the new capture mode setting.

## Notes for reviewers
- This change is intentionally focused on capture targeting/indicator positioning and settings plumbing.
- Work-area fields are surfaced from Win32 monitor info so indicator placement avoids taskbar-obscured regions.

Closes #72