### PR TITLE
[Windows] Add privacy policy URL to winget and release docs

### DIFF
--- a/plans/windows-release-checklist.md
+++ b/plans/windows-release-checklist.md
@@ -36,9 +36,9 @@
 - ☐ **App assets audit** — confirm every tile/logo scale referenced in `Package.appxmanifest`
   exists and renders (Square44/150, Wide310x150, SmallTile, LargeTile, SplashScreen, StoreLogo).
   Verify the new macOS-matched icon is exported at all scales.
-- ☐ **Privacy policy URL** — required by the Store, recommended for winget. Publish a page (repo
-  `docs/` or GitHub Pages) covering: screen capture, microphone, system-audio, local file save,
-  no telemetry (state plainly). Capture the URL for both submissions.
+- ☑ **Privacy policy URL** — required by the Store, recommended for winget. Published at
+  `https://tinyclips.app/privacy.html`; use this URL for both Store listing metadata and the winget
+  locale manifest (`PrivacyUrl`).
 - ☐ **Release notes source** — reuse `windows/CHANGELOG.md` `## [Unreleased]` → cut a versioned
   `## [vX.Y.Z]` section per release; feed it to GitHub Release body, Store "what's new", and the
   winget locale `ReleaseNotes`.
@@ -145,7 +145,7 @@ The 3-file manifest lives in `windows/packaging/winget/`. Per release:
   existing `docs/app-store-connect-metadata.md` is **macOS**; a Windows listing pack is needed),
   store logos, category (Photo & video / Productivity), search terms, **copyright © <year>
   Refractored LLC**.
-- ☐ **Privacy policy URL** (required).
+- ☑ **Privacy policy URL** (required): `https://tinyclips.app/privacy.html`.
 - ☐ **Age rating** (IARC questionnaire).
 - ☐ **Capability justifications**: `runFullTrust` requires a "why full trust" justification in Partner
   Center (needed for WGC screen capture + WASAPI audio + arbitrary file save); `microphone` needs a

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -51,6 +51,9 @@ own `CHANGELOG.md` at the repository root.
   selection marquee and hit-testing cover the entire annotation.
 
 ### Changed
+- **Windows privacy policy URL is now set for distribution metadata** — the winget locale manifest
+  now publishes `PrivacyUrl: https://tinyclips.app/privacy.html`, and Windows packaging docs now
+  reference the same URL for Store listing metadata.
 - **Repository renamed to `jamesmontemagno/tiny-clips`** — the GitHub repository link on the
   Settings → About page, the winget manifests, and all documentation now point at the new
   `tiny-clips` repository (the old `tiny-clips-mac` URLs continue to redirect). The winget package

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -49,6 +49,9 @@ release exists:
 4. Submit a PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) (or use
    `wingetcreate submit`). This can be automated in CI on each tagged release.
 
+The locale manifest already includes:
+- `PrivacyUrl: https://tinyclips.app/privacy.html`
+
 > ⚠️ Requires the maintainer's GitHub account; the signed MSIX + hashes can only be produced
 > from a release build with the real signing certificate.
 
@@ -61,6 +64,7 @@ release exists:
    or `winapp` Store submission.
 4. Configure Store add-ons for **Pro** (StoreKit-equivalent) — Store build only.
 5. Complete the listing metadata, privacy, and screen-recording capability declarations.
+   - Privacy policy URL: `https://tinyclips.app/privacy.html`
 
 > ⚠️ Requires a Partner Center account; cannot be completed from the repo alone.
 

--- a/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
@@ -3,6 +3,7 @@ PackageVersion: 1.0.0.0
 PackageLocale: en-US
 Publisher: Refractored
 PublisherUrl: https://github.com/jamesmontemagno
+PrivacyUrl: https://tinyclips.app/privacy.html
 PublisherSupportUrl: https://github.com/jamesmontemagno/tiny-clips/issues
 Author: James Montemagno
 PackageName: Tiny Clips


### PR DESCRIPTION
Windows packaging needed a concrete privacy policy URL for both Microsoft Store listing metadata and winget submission metadata. Without this, issue #78's release checklist item remained incomplete.

This updates the Windows release/distribution metadata to consistently use `https://tinyclips.app/privacy.html`:

- Adds `PrivacyUrl` to `windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml`.
- Updates `windows/packaging/README.md` to document the same URL for winget and Store submission steps.
- Marks the privacy policy checklist items complete in `plans/windows-release-checklist.md` with the published URL.
- Records the change in `windows/CHANGELOG.md` under Unreleased.