### PR TITLE
Add prefilled issue/feature link in Windows About

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -51,6 +51,9 @@ own `CHANGELOG.md` at the repository root.
   selection marquee and hit-testing cover the entire annotation.
 
 ### Changed
+- **About page now links directly to issue/feature requests with prefilled details** — Settings →
+  About now includes an **Open an issue or feature request** link that deep-links to the GitHub
+  repo issue form and pre-fills app version + Windows runtime details (similar to the macOS flow).
 - **Windows privacy policy URL is now set for distribution metadata** — the winget locale manifest
   now publishes `PrivacyUrl: https://tinyclips.app/privacy.html`, and Windows packaging docs now
   reference the same URL for Store listing metadata.

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -1255,15 +1255,24 @@
                             <TextBlock
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="View the project, report issues, and contribute on GitHub." />
+                                Text="View the project, open an issue or feature request, and contribute on GitHub." />
                         </StackPanel>
-                        <HyperlinkButton
+                        <StackPanel
                             Grid.Column="1"
                             VerticalAlignment="Center"
-                            AutomationProperties.AutomationId="AboutRepoLink"
-                            AutomationProperties.Name="Open the Tiny Clips GitHub repository"
-                            Content="GitHub repository"
-                            NavigateUri="https://github.com/jamesmontemagno/tiny-clips" />
+                            HorizontalAlignment="Right"
+                            Spacing="4">
+                            <HyperlinkButton
+                                AutomationProperties.AutomationId="AboutRepoLink"
+                                AutomationProperties.Name="Open the Tiny Clips GitHub repository"
+                                Content="GitHub repository"
+                                NavigateUri="https://github.com/jamesmontemagno/tiny-clips" />
+                            <HyperlinkButton
+                                x:Name="AboutIssueLink"
+                                AutomationProperties.AutomationId="AboutIssueLink"
+                                AutomationProperties.Name="Open an issue or feature request on GitHub"
+                                Content="Open an issue or feature request" />
+                        </StackPanel>
                     </Grid>
                 </Border>
 

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI;
@@ -276,7 +277,25 @@ public sealed partial class SettingsWindow : Window
         }
 
         AboutVersionText.Text = $"Version {version}";
+        AboutIssueLink.NavigateUri = BuildIssueRequestUri(version);
         AboutCopyrightText.Text = $"© {DateTime.Now.Year} Refractored LLC";
+    }
+
+    private static Uri BuildIssueRequestUri(string version)
+    {
+        const string repositoryIssuesNewUrl = "https://github.com/jamesmontemagno/tiny-clips/issues/new";
+        var runtime = RuntimeInformation.OSDescription;
+        var body =
+            "### Details" + "\n" +
+            $"- App: Tiny Clips for Windows" + "\n" +
+            $"- Version: {version}" + "\n" +
+            $"- OS: {runtime}" + "\n\n" +
+            "### Describe your issue or feature request" + "\n" +
+            "<!-- Tell us what happened or what you'd like to see -->";
+
+        var title = "[Issue/Feature]: ";
+        var query = $"title={Uri.EscapeDataString(title)}&body={Uri.EscapeDataString(body)}";
+        return new Uri($"{repositoryIssuesNewUrl}?{query}");
     }
 
     private void ShowSettingsSection(string sectionTag)


### PR DESCRIPTION
## Why
The About page already links to the repository, but it did not provide a direct issue/feature-request entry point with useful context prefilled. This makes reporting slower and less consistent than the macOS flow.

## What changed
- Added a new **Open an issue or feature request** link in **Settings -> About**.
- Kept the existing repository link and updated the supporting About copy to mention issue/feature requests.
- Added URL construction in `SettingsWindow.xaml.cs` that deep-links to `issues/new` and pre-fills:
  - app name
  - app version
  - Windows runtime/OS description
  - starter prompt text for issue/feature details
- Updated `windows/CHANGELOG.md` under **Unreleased** to document this behavior change.

## Notes for reviewers
This uses GitHub URL query parameters (`title` + `body`) for prefill so it remains lightweight and does not require template coupling.