### PR TITLE
Windows: remove Pro split and add Store build flavor flag

### DIFF
--- a/plans/windows-release-checklist.md
+++ b/plans/windows-release-checklist.md
@@ -6,6 +6,10 @@
 > how-to lives in `windows/packaging/README.md`.
 >
 > Legend: ☐ = to do · ⚠️ = needs an account/secret only the maintainer can provide · 🤖 = automatable in CI.
+>
+> **2026 scope update:** Windows no longer has a Pro/IAP tier. Direct and Store builds ship the
+> same feature set; the Store build only differs in distribution behavior (for example, no
+> direct/winget self-update surfaces), toggled via `-p:TinyClipsStoreBuild=true`.
 
 ---
 
@@ -20,7 +24,7 @@
 | winget manifest | **Templates exist** in `windows/packaging/winget/` (installer/locale/version) with `<FILL-IN>` placeholders. |
 | CI | `windows-build.yml` builds x64+ARM64 Release + runs Core tests on PR. **No release/packaging/signing CI.** `release.yml` is **macOS-only**. |
 | Signing | **Not set up.** Azure Trusted Signing to be provisioned (Phase 4 prereq). |
-| Store/Direct split | **Not implemented yet** — no `IEntitlementService` Free vs Store builds, no Store config, no add-ons. |
+| Store/Direct split | Feature set is unified (no Pro/IAP on Windows). Store vs Direct now only controls distribution UI/behavior via a build flag. |
 | WACK | Not run. |
 
 ---
@@ -48,11 +52,9 @@
 - ☐ **Clean-machine smoke test** — install the **signed** MSIX on a machine without the dev cert and
   without VS; verify tray launch, screenshot/video/GIF capture, save to `Pictures\TinyClips`, toast,
   microphone/system-audio recording, and "launch at login" (StartupTask) all work under identity.
-- ☐ **Decide Direct vs Store feature split now** (blocks the Store build): introduce
-  `IEntitlementService` with `FreeEntitlementService` (Direct = all features free) and
-  `StoreEntitlementService` (Store add-ons). The **Store build must ship no reachable self-update /
-  `.appinstaller` / winget / external-purchase UI** (Store-cert requirement). Direct build has no
-  Store APIs. Gate via build configuration / compilation symbol.
+- ☐ **Keep Store-vs-Direct behavior split at distribution level only**: no feature gating/IAP on
+  Windows, but the **Store build must ship no reachable self-update / `.appinstaller` / winget /
+  external-purchase UI** (Store-cert requirement). Gate via build configuration / compilation symbol.
 
 ---
 
@@ -129,16 +131,12 @@ The 3-file manifest lives in `windows/packaging/winget/`. Per release:
   the Store values (Visual Studio "Associate App with the Store", or `winapp` pull, or a separate
   Store manifest/config). Do **not** ship the Direct `CN=Refractored` identity to the Store.
 - ☐ Build the Store upload package: **`.msixupload`** bundling **x64 + ARM64** (Store re-signs).
-- ☐ Ensure the **Store build flavor** uses `StoreEntitlementService` and hides all self-update /
-  winget / `.appinstaller` / external-purchase UI (Store-cert requirement, §1).
+- ☐ Ensure the **Store build flavor** hides all self-update / winget / `.appinstaller` /
+  external-purchase UI (Store-cert requirement, §1).
 
-### 3.3 Pro / in-app purchases (Store-only)
-- ☐ Create **durable add-ons** (Pro: monthly / yearly / lifetime — mirror the macOS `ProPlan`) with
-  **stable product IDs** in Partner Center.
-- ☐ Wire `StoreContext` purchase + license check behind `IEntitlementService`; add an **offline
-  entitlement cache** so Pro survives offline launches.
-- ☐ Sandbox test **purchase + restore** for each product; verify no-op Pro gates when not purchased.
-- ☐ Confirm **Direct build has no IAP/license code paths** (fully free).
+### 3.3 Pricing / entitlement model
+- ☐ Confirm there are **no Store add-ons / IAP entitlements** for Windows builds.
+- ☐ Confirm both Direct and Store builds expose the same feature set (no Pro gates).
 
 ### 3.4 Listing + compliance
 - ☐ Store listing metadata: description, **screenshots** (capture from the running Windows app — the

--- a/plans/windows-winui3-port-plan.md
+++ b/plans/windows-winui3-port-plan.md
@@ -14,6 +14,10 @@
 > entirely through **winget** (see [§4 Phase 4](#phase-4--distribution--monetization)); the Store
 > build uses Store auto-update. Sections below that describe the Clips Manager, upload, or SQLite
 > catalog are retained for history but are **not being built**.
+>
+> **2026 scope update:** Windows no longer has a Pro/IAP tier. Direct and Store builds ship the
+> same features; the Store flavor only changes distribution behavior (for example, no direct/winget
+> self-update surfaces), via `-p:TinyClipsStoreBuild=true`.
 
 ---
 
@@ -30,7 +34,7 @@
 | MVVM | CommunityToolkit.Mvvm + `Microsoft.Extensions.DependencyInjection` | Mirrors mac `ObservableObject`/`@Published` |
 | Tooling | **Windows App Development CLI (`winapp`)** for SDK restore, identity, manifest, certs, signing, MSIX pack | Single toolchain across CI/local |
 | Updater | **No Velopack.** Store build = Store updates; **Direct build = winget** (`winget upgrade`, publishing each release's signed MSIX to winget-pkgs) | MSIX already has identity/update semantics; winget is the single Direct channel |
-| Pro / IAP | **Store build = `StoreContext` add-ons. Direct build is fully FREE** (all features unlocked, no purchase) | Store IAP only works in Store; avoids a separate license system entirely |
+| Pro / IAP | **No Pro/IAP on Windows** (Direct and Store features match) | Keeps Windows simple; monetization remains macOS-only |
 | Signing | **Azure Trusted Signing** for direct MSIX (account **not yet set up — Phase 4 prerequisite**); stable publisher identity forever | Avoids cert-trust install friction; self-signed cert only for internal test until then |
 | Accounts | Microsoft **Partner Center: available**. Azure Trusted Signing: **to be provisioned** before Direct GA | Partner Center owns Store identity + name reservation |
 | ~~Upload provider~~ | **Removed from scope** — no in-app upload/sharing | Browse captures in File Explorer instead |
@@ -52,7 +56,7 @@
 | System audio loopback | **WASAPI loopback** (separate pipeline — WGC is video-only) | Audio clock can be master |
 | Carbon `RegisterEventHotKey` | Win32 `RegisterHotKey` with conflict detection | Registration service w/ failure UI |
 | Sparkle | Store auto-update (Store) / **winget** (Direct) | No Velopack |
-| StoreKit 2 IAP | Microsoft Store add-ons via `StoreContext` (Store build only) | Direct build is fully free — no IAP/license |
+| StoreKit 2 IAP | Not used on Windows | No Windows Store add-ons / license system |
 | `@AppStorage` (UserDefaults) | `ApplicationData.LocalSettings` (prefs) | No SQLite catalog (Clips Manager removed) |
 | `UserNotifications` | `AppNotificationManager` toasts | Requires identity (have it) |
 | Launch at login | Packaged **`StartupTask`** (no registry for Store) | User-visible state + OS-denied fallback |
@@ -136,12 +140,11 @@ Design rules baked in from the review:
 - **CaptureCoordinator is thin** — orchestration only; no god object (logic lives in the stages above).
 
 ### 4.2 Build configurations
-Two MSBuild configs gate channel behavior via `DIRECT` / `STORE` constants (parallel to the mac `APPSTORE`):
-- **Direct:** **winget** update path (`winget upgrade`); **all Pro features unlocked for free** (`FreeEntitlementService`); no Store APIs, no purchase/license UI.
-- **Store:** Store auto-update, `StoreEntitlementService` add-ons, **no reachable self-update / appinstaller / winget / external-purchase UI** (Store-cert requirement).
-- **Development:** `DevelopmentEntitlementService` (all features on, for local/dev).
+Two MSBuild flavors gate distribution behavior via `TinyClipsStoreBuild` / `TINYCLIPS_STORE_BUILD`:
+- **Direct (default):** **winget** update path (`winget upgrade`); no in-app self-updater.
+- **Store (`-p:TinyClipsStoreBuild=true`):** Store auto-update and **no reachable direct/winget/appinstaller/external-purchase UI** (Store-cert requirement).
 
-All three implement a single channel-neutral **`IEntitlementService`** (identical feature flags, cache semantics, failure states) so feature-gating never leaks channel-specific APIs into ViewModels. The Direct build's `FreeEntitlementService` simply reports every feature as entitled.
+Feature set is the same in both flavors (no Windows Pro/IAP gating).
 
 ---
 

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -51,6 +51,10 @@ own `CHANGELOG.md` at the repository root.
   selection marquee and hit-testing cover the entire annotation.
 
 ### Changed
+- **Store-vs-Direct behavior now uses a build flag** — Windows keeps one feature set (no Pro tier),
+  and store-specific distribution behavior is now controlled by
+  `-p:TinyClipsStoreBuild=true` / `TINYCLIPS_STORE_BUILD` (for example, hiding direct/winget update
+  surfaces in Store builds).
 - **Repository renamed to `jamesmontemagno/tiny-clips`** — the GitHub repository link on the
   Settings → About page, the winget manifests, and all documentation now point at the new
   `tiny-clips` repository (the old `tiny-clips-mac` URLs continue to redirect). The winget package

--- a/windows/README.md
+++ b/windows/README.md
@@ -78,6 +78,12 @@ dotnet run --project windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:
 dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Debug
 ```
 
+To build the **Microsoft Store** flavor (same feature set, Store distribution behavior), set:
+
+```powershell
+dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64 -p:TinyClipsStoreBuild=true
+```
+
 The app launches **tray-only** (no window). Left- or right-click the tray icon for the Fluent
 menu: **Screenshot**, **Capture Region**, **Record Video**, **Record GIF**, **Settings**,
 **Guide**, **Exit**. Capture items first show the **Region / Screen / Window** picker.
@@ -96,6 +102,6 @@ For coordinate/DPI behaviour across mixed-DPI monitors, see
 
 - **Direct:** signed MSIX distributed via **winget**; updates ship through `winget upgrade`
   (no separate in-app updater). Fully free.
-- **Microsoft Store:** Store auto-update + Pro add-ons (Pro is Store-only).
+- **Microsoft Store:** Store auto-update. Feature set matches Direct; no Windows Pro tier.
 
 See the plan for the full phased roadmap, packaging, and signing details.

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -59,7 +59,9 @@ release exists:
    `Package.appxmanifest` `Identity`).
 3. Build the Store-configuration MSIX (Store handles signing) and upload via Partner Center
    or `winapp` Store submission.
-4. Configure Store add-ons for **Pro** (StoreKit-equivalent) — Store build only.
+4. Build with the Store flavor flag so Store-only distribution behavior is enabled:
+   `dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:TinyClipsStoreBuild=true`
+   (repeat for ARM64 as needed).
 5. Complete the listing metadata, privacy, and screen-recording capability declarations.
 
 > ⚠️ Requires a Partner Center account; cannot be completed from the repo alone.

--- a/windows/src/TinyClips.App/BuildFlavor.cs
+++ b/windows/src/TinyClips.App/BuildFlavor.cs
@@ -1,0 +1,12 @@
+namespace TinyClips.App;
+
+internal static class BuildFlavor
+{
+#if TINYCLIPS_STORE_BUILD
+    public const bool IsStoreBuild = true;
+#else
+    public const bool IsStoreBuild = false;
+#endif
+
+    public const bool IsDirectBuild = !IsStoreBuild;
+}

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -1244,6 +1244,32 @@
                     </StackPanel>
                 </Border>
 
+                <Border
+                    x:Name="DirectBuildUpdatesCard"
+                    Visibility="Collapsed"
+                    Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="4">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Updates (Direct build)" />
+                        <TextBlock
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="This build updates through winget (`winget upgrade Refractored.TinyClips`). Tiny Clips does not include an in-app updater." />
+                    </StackPanel>
+                </Border>
+
+                <Border
+                    x:Name="StoreBuildUpdatesCard"
+                    Visibility="Collapsed"
+                    Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="4">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Updates (Microsoft Store build)" />
+                        <TextBlock
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="This build is updated by Microsoft Store auto-update; direct/winget update UI is intentionally hidden." />
+                    </StackPanel>
+                </Border>
+
                 <Border Style="{StaticResource SettingCardStyle}">
                     <Grid ColumnSpacing="16">
                         <Grid.ColumnDefinitions>

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -23,6 +23,8 @@ namespace TinyClips.App;
 public sealed partial class SettingsWindow : Window
 {
     public SettingsViewModel ViewModel { get; }
+    public bool IsStoreBuild => BuildFlavor.IsStoreBuild;
+    public bool IsDirectBuild => BuildFlavor.IsDirectBuild;
 
     public SettingsWindow()
     {
@@ -34,6 +36,7 @@ public sealed partial class SettingsWindow : Window
             App.Services.GetRequiredService<IClipStorageService>());
 
         InitializeComponent();
+        ApplyBuildFlavorVisibility();
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
@@ -289,6 +292,12 @@ public sealed partial class SettingsWindow : Window
         BrandingSection.Visibility = sectionTag == "Branding" ? Visibility.Visible : Visibility.Collapsed;
         HotkeysSection.Visibility = sectionTag == "Hotkeys" ? Visibility.Visible : Visibility.Collapsed;
         AboutSection.Visibility = sectionTag == "About" ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void ApplyBuildFlavorVisibility()
+    {
+        DirectBuildUpdatesCard.Visibility = IsDirectBuild ? Visibility.Visible : Visibility.Collapsed;
+        StoreBuildUpdatesCard.Visibility = IsStoreBuild ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private async void OnBrowseSaveDirectory(object sender, RoutedEventArgs e)

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -25,6 +25,19 @@
     <NoWarn>$(NoWarn);MVVMTK0045</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Build flavor switch:
+      - false (default): Direct/winget distribution
+      - true: Microsoft Store distribution
+    -->
+    <TinyClipsStoreBuild Condition="'$(TinyClipsStoreBuild)' == ''">false</TinyClipsStoreBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TinyClipsStoreBuild)' == 'true'">
+    <DefineConstants>$(DefineConstants);TINYCLIPS_STORE_BUILD</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />


### PR DESCRIPTION
Windows no longer needs a Pro entitlement split. This change aligns the Windows app to a single feature set across distribution channels, while still preserving Store certification behavior differences.

The implementation introduces a build-flavor switch (`TinyClipsStoreBuild` -> `TINYCLIPS_STORE_BUILD`) and a small `BuildFlavor` helper in the app layer. Settings -> About now shows channel-specific update messaging so Store builds explicitly avoid direct/winget update surfaces, while Direct builds point to winget updates.

Documentation and planning docs were updated to match the new direction: no Windows Pro/IAP tier, and Store vs Direct differences are limited to distribution behavior.

## Notes for reviewers
- This is intentionally a behavior/config split, not a feature split.
- Store flavor is enabled with `-p:TinyClipsStoreBuild=true`.
- Existing Windows features remain available in both build flavors.