### PR TITLE
Prepare Windows winget release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ Packages/
 # Visual Studio workspace/local state
 .vs/
 
+# Windows local SDK/release artifacts
+.winapp/
+artifacts/
+
 # Python (tooling/scripts)
 __pycache__/
 *.py[cod]

--- a/plans/windows-release-checklist.md
+++ b/plans/windows-release-checklist.md
@@ -17,7 +17,7 @@
 
 | Thing | State |
 | --- | --- |
-| App packaging | Single-project **MSIX with identity** (`EnableMsixTooling`), `Refractored.TinyClips`, `Publisher=CN=Refractored`, version `1.0.0.0`. |
+| App packaging | Single-project **MSIX with identity** (`EnableMsixTooling`), `Refractored.TinyClips`, `Publisher=CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US`, version `1.0.0.0`. |
 | Architectures | **x64 + ARM64** (`<Platforms>x64;ARM64</Platforms>`). |
 | Min OS | `10.0.22621.0` (Win 11 22H2). |
 | Capabilities | `runFullTrust` + `microphone` declared in `Package.appxmanifest`. |
@@ -33,7 +33,7 @@
 
 - ☐ **Freeze the identity matrix** (see §5). Confirm final **package family name (PFN)**, publisher,
   display name. Note: the **Store will assign its own Identity/Publisher** — the Direct build keeps
-  `CN=Refractored` (or the Trusted Signing subject); the two channels are **different identities**.
+  `CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US` (the Trusted Signing subject); the two channels are **different identities**.
 - ☐ **Version strategy** — map release tag `vMAJOR.MINOR.PATCH` → `Package.appxmanifest`
   `Version="MAJOR.MINOR.PATCH.0"` (4-part, revision `0`). Bump on every submission (Store/winget
   reject duplicate versions). 🤖 stamp this in CI from the tag.
@@ -67,7 +67,7 @@
   submission (untrusted signature).*
 - ☐ Make sure `Package.appxmanifest` `Publisher` **exactly matches** the signing cert subject, or
   packaging will fail signature validation.
-- ☐ (Interim, internal test only) self-signed: `winapp cert generate --publisher "CN=Refractored"`
+- ☐ (Interim, internal test only) self-signed: `winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"`
   + `winapp cert install`. Never publish a self-signed build to winget.
 
 ### 2.2 Build + sign the MSIX
@@ -104,7 +104,7 @@ The 3-file manifest lives in `windows/packaging/winget/`. Per release:
     `<publisher-id-hash>` placeholder).
   - `MinimumOSVersion` → `10.0.22621.0` (matches manifest).
 - ☐ Locale manifest (`...locale.en-US.yaml`) is **already populated** (PackageName, Publisher,
-  PublisherUrl/SupportUrl, Author, License MIT, Description, Moniker `tinyclips`, Tags). Optional
+  PublisherUrl/SupportUrl, Author, License MIT, Description, Tags). Optional
   adds per release: `Copyright` ("© <year> Refractored LLC") and `ReleaseNotes`/`ReleaseNotesUrl`.
   The version manifest (`...yaml`) is complete. **Only the installer manifest needs per-release
   edits** (URLs, hashes, real PFN).
@@ -129,7 +129,7 @@ The 3-file manifest lives in `windows/packaging/winget/`. Per release:
 ### 3.2 Store-configured package
 - ☐ Produce a **Store build** whose `Package.appxmanifest` `Identity`/`Publisher` are overridden with
   the Store values (Visual Studio "Associate App with the Store", or `winapp` pull, or a separate
-  Store manifest/config). Do **not** ship the Direct `CN=Refractored` identity to the Store.
+  Store manifest/config). Do **not** ship the Direct `CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US` identity to the Store.
 - ☐ Build the Store upload package: **`.msixupload`** bundling **x64 + ARM64** (Store re-signs).
 - ☐ Ensure the **Store build flavor** hides all self-update / winget / `.appinstaller` /
   external-purchase UI (Store-cert requirement, §1).
@@ -180,8 +180,8 @@ The 3-file manifest lives in `windows/packaging/winget/`. Per release:
 | Field | Direct (winget/MSIX) | Store |
 | --- | --- | --- |
 | Package Name | `Refractored.TinyClips` | **Store-assigned** |
-| Publisher | `CN=Refractored` (or Trusted Signing subject) | **Store-assigned** (`CN=<GUID>`) |
-| PublisherDisplayName | `Refractored` | Partner Center display name |
+| Publisher | `CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US` | **Store-assigned** (`CN=<GUID>`) |
+| PublisherDisplayName | `Refractored LLC` | Partner Center display name |
 | Version | from tag → `X.Y.Z.0` | from tag → `X.Y.Z.0` |
 | Signing | Azure Trusted Signing | Store re-signs |
 | Updates | `.appinstaller` + winget | Store |

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,8 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.0.0-windows] - 2026-06-15
+
 ### Added
 - **Branding overlay** — when enabled in Settings, captures get a subtle "Captured on Tiny Clips"
   badge (a rounded black pill with white text) in the bottom-right corner, matching the macOS app.

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -20,7 +20,7 @@ cd windows
 winapp restore
 
 # (Dev only) create + trust a local signing cert
-winapp cert generate --publisher "CN=Refractored"
+winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
 winapp cert install
 
 # Produce the MSIX (x64 and arm64)

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -10,15 +10,15 @@ Scope: user
 InstallModes:
   - silent
   - silentWithProgress
-PackageFamilyName: Refractored.TinyClips_<publisher-id-hash>
+PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0/TinyClips-1.0.0-x64.msix
-    InstallerSha256: <FILL-IN-SHA256>
-    SignatureSha256: <FILL-IN-SIGNATURE-SHA256>
+    InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix
+    InstallerSha256: 973592963c3ae32e6ce629040df310ae93892612e239e7235916f657425bad9f
+    SignatureSha256: 6afd1d40ab6757e1671fb5a4d8e2e07c1caf8ec5d243e062f612dec75216083f
   - Architecture: arm64
-    InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0/TinyClips-1.0.0-arm64.msix
-    InstallerSha256: <FILL-IN-SHA256>
-    SignatureSha256: <FILL-IN-SIGNATURE-SHA256>
+    InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-arm64.msix
+    InstallerSha256: 6bf6095538425f490015d251348d3e8dc90834115fc9c3f48c160cbfd4ab1a14
+    SignatureSha256: ac98863338bc6058c7dfac3f19e6159f53d3d045e666df7e2075a64bf7d4e1c8
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
@@ -1,7 +1,7 @@
 PackageIdentifier: Refractored.TinyClips
 PackageVersion: 1.0.0.0
 PackageLocale: en-US
-Publisher: Refractored
+Publisher: Refractored LLC
 PublisherUrl: https://github.com/jamesmontemagno
 PrivacyUrl: https://tinyclips.app/privacy.html
 PublisherSupportUrl: https://github.com/jamesmontemagno/tiny-clips/issues
@@ -15,7 +15,6 @@ Description: |-
   Tiny Clips is a lightweight system-tray app for quickly capturing screenshots,
   screen recordings (MP4), and animated GIFs. Pick a region or the full screen,
   use global hotkeys, and save straight to your Pictures/Videos folders.
-Moniker: tinyclips
 Tags:
   - screenshot
   - screen-recorder

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -9,14 +9,14 @@
 
   <Identity
     Name="Refractored.TinyClips"
-    Publisher="CN=Refractored"
+    Publisher="CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="D90CE0D4-542A-47D3-89A4-CF82BF4E244B" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
     <DisplayName>Tiny Clips</DisplayName>
-    <PublisherDisplayName>Refractored</PublisherDisplayName>
+    <PublisherDisplayName>Refractored LLC</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -97,8 +97,7 @@
 
   <!-- Publish Properties -->
   <PropertyGroup>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(PublishReadyToRun)' == ''">False</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug' and ('$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true')">True</PublishTrimmed>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">False</PublishTrimmed>


### PR DESCRIPTION
## Summary
- Updates the Windows package identity to match the Azure Trusted Signing certificate subject
- Disables ReadyToRun for smaller Windows MSIX release packages
- Finalizes the winget manifest for `v1.0.0-windows`
- Removes the conflicting `tinyclips` winget moniker and ignores generated Windows release artifacts

## Validation
- `winget validate --manifest windows\packaging\winget`
- Signed x64 and ARM64 MSIX packages with Azure Artifact Signing
- Verified signatures with SignTool
- WACK overall PASS for x64 and ARM64 packages