### PR TITLE
Fix Windows release WinApp CLI install

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Windows App CLI
         shell: pwsh
         run: |
-          winget install -e --id Microsoft.winappcli --accept-source-agreements --accept-package-agreements --silent
+          winget install -e --id Microsoft.winappcli --source winget --accept-source-agreements --accept-package-agreements --silent
           "$env:LOCALAPPDATA\Microsoft\WindowsApps" >> $env:GITHUB_PATH
 
       - name: Publish x64


### PR DESCRIPTION
## Summary
- force Windows Release workflow to install Microsoft.winappcli from the winget source
- fixes the v1.0.1-windows release run failing at the WinApp CLI install step because the runner defaulted to msstore

## Validation
- Parsed .github/workflows/windows-release.yml with PyYAML
- git diff --check