### PR TITLE
Fix Windows release WinApp CLI package ID

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Windows App CLI
         shell: pwsh
         run: |
-          winget install -e --id Microsoft.winappcli --source winget --accept-source-agreements --accept-package-agreements --silent
+          winget install -e --id Microsoft.WinAppCli --source winget --accept-source-agreements --accept-package-agreements --silent
           "$env:LOCALAPPDATA\Microsoft\WindowsApps" >> $env:GITHUB_PATH
 
       - name: Publish x64


### PR DESCRIPTION
## Summary
- use the correct winget package identifier, Microsoft.WinAppCli, in the Windows Release workflow
- fixes release runs failing at the WinApp CLI install step

## Validation
- Parsed .github/workflows/windows-release.yml with PyYAML
- git diff --check