### PR TITLE
Fix Windows release manifest stamping

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           $manifestPath = "windows/src/TinyClips.App/Package.appxmanifest"
           $content = Get-Content $manifestPath -Raw
-          $content = $content -replace 'Version="[^"]+"', "Version=""$env:PACKAGE_VERSION"""
+          $content = $content -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$env:PACKAGE_VERSION`${2}"
           Set-Content -Path $manifestPath -Value $content -Encoding UTF8
 
       - name: Install Windows App CLI


### PR DESCRIPTION
## Summary
- stamp only the Package.appxmanifest Identity Version attribute
- avoids corrupting the XML declaration before WinApp CLI packaging

## Validation
- Simulated stamp parses as XML and updates Identity.Version to 1.0.1.0
- Parsed .github/workflows/windows-release.yml with PyYAML
- git diff --check