### PR TITLE
Use Windows release environment for Azure OIDC

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -24,6 +24,7 @@ jobs:
   build-sign-release:
     name: Build, sign, and release MSIX
     runs-on: windows-latest
+    environment: windows-release
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- bind the Windows Release job to the windows-release GitHub environment
- matches the Azure federated credential subject for OIDC login

## Validation
- Added Azure federated credential subject repo:jamesmontemagno/tiny-clips:environment:windows-release
- Parsed .github/workflows/windows-release.yml with PyYAML
- git diff --check