### PR TITLE
Fix Windows MSIX startup crash (revert to framework-dependent packaging)

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -66,31 +66,48 @@ jobs:
           $content = $content -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$env:PACKAGE_VERSION`${2}"
           Set-Content -Path $manifestPath -Value $content -Encoding UTF8
 
-      - name: Install Windows App CLI
-        shell: pwsh
-        run: |
-          winget install -e --id Microsoft.WinAppCli --source winget --accept-source-agreements --accept-package-agreements --silent
-          "$env:LOCALAPPDATA\Microsoft\WindowsApps" >> $env:GITHUB_PATH
-
-      - name: Publish x64
-        shell: pwsh
-        run: dotnet publish $env:APP_PROJECT -c Release -p:Platform=x64 -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false -p:EnableMsixTooling=false -o artifacts/windows/layout/x64 -v:minimal
-
-      - name: Publish ARM64
-        shell: pwsh
-        run: dotnet publish $env:APP_PROJECT -c Release -p:Platform=ARM64 -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false -p:EnableMsixTooling=false -o artifacts/windows/layout/arm64 -v:minimal
-
-      - name: Package MSIX
+      - name: Build and package MSIX
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/windows | Out-Null
 
-          $manifestPath = "windows/src/TinyClips.App/Package.appxmanifest"
-          $x64Layout = "artifacts/windows/layout/x64"
-          $arm64Layout = "artifacts/windows/layout/arm64"
+          # Framework-dependent MSIX built with the supported MSBuild MSIX tooling.
+          # This produces an AppxManifest with the WinRT ActivatableClass registrations
+          # required for the installed package to launch on clean machines (matches the
+          # working v1.0.0 release). Self-contained packaging omits those registrations
+          # and crashes on startup with REGDB_E_CLASSNOTREG. The WindowsAppSDK runtime
+          # is declared as a framework PackageDependency and acquired by winget/Store.
+          $platforms = @(
+            @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
+            @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
+          )
 
-          winapp package $x64Layout --manifest $manifestPath --executable TinyClips.App.exe --output "artifacts/windows/TinyClips-$env:ASSET_VERSION-x64.msix"
-          winapp package $arm64Layout --manifest $manifestPath --executable TinyClips.App.exe --output "artifacts/windows/TinyClips-$env:ASSET_VERSION-arm64.msix"
+          foreach ($p in $platforms) {
+            $packageDir = "artifacts/windows/package/$($p.Asset)"
+            New-Item -ItemType Directory -Force -Path $packageDir | Out-Null
+            $packageDirFull = (Resolve-Path $packageDir).Path + [IO.Path]::DirectorySeparatorChar
+
+            dotnet build $env:APP_PROJECT `
+              -c Release `
+              -p:Platform=$($p.Platform) `
+              -p:RuntimeIdentifier=$($p.Rid) `
+              -p:WindowsAppSDKSelfContained=false `
+              -p:EnableMsixTooling=true `
+              -p:GenerateAppxPackageOnBuild=true `
+              -p:AppxPackageDir=$packageDirFull `
+              -p:AppxBundle=Never `
+              -p:UapAppxPackageBuildMode=SideloadOnly `
+              -p:AppxPackageSigningEnabled=false `
+              -v:minimal
+            if ($LASTEXITCODE -ne 0) { throw "MSIX build failed for $($p.Platform)." }
+
+            $produced = Get-ChildItem $packageDir -Recurse -Filter *.msix |
+              Where-Object { $_.Name -notmatch 'symbols' } |
+              Select-Object -First 1
+            if (-not $produced) { throw "No MSIX produced for $($p.Platform)." }
+
+            Copy-Item $produced.FullName "artifacts/windows/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix" -Force
+          }
 
       - name: Azure login
         uses: azure/login@v2

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,18 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Installed MSIX no longer crashes on startup** — the winget/MSIX build was switched to
+  self-contained packaging to clear winget validation, but the resulting package shipped an
+  AppxManifest with **no** WinRT activation registrations. On a clean machine (without the
+  Windows App Runtime installed) the app crashed immediately at `Application.Start` with
+  `REGDB_E_CLASSNOTREG` (`0xc000027b`), because the installed package resolves WinRT activation
+  from the manifest, not from the executable's embedded reg-free manifest. The release workflow
+  now packages a **framework-dependent** MSIX with the supported MSBuild MSIX tooling, which
+  emits the full set of `ActivatableClass` registrations and declares the Windows App Runtime as
+  a framework dependency (the same configuration as the original, working v1.0.0 release). The
+  runtime is acquired automatically by winget/Store at install time.
+
 ## [v1.0.0-windows] - 2026-06-15
 
 ### Added


### PR DESCRIPTION
## Problem

The `v1.0.1-windows` MSIX (installed via winget or directly) crashed immediately on startup on clean machines:

```
0xc000027b / REGDB_E_CLASSNOTREG (0x80040154) at Microsoft.UI.Xaml.Application.Start
```

The working `v1.0.0-windows` release was **framework-dependent**. To pass winget sandbox validation, `v1.0.1` switched packaging to **self-contained** (`dotnet publish -p:WindowsAppSDKSelfContained=true -p:EnableMsixTooling=false` + `winapp package`).

## Root cause

An installed/packaged MSIX resolves WinRT activation from the **AppxManifest** `<Extensions>` `ActivatableClass` registrations (written to the registry at install time), **not** from the executable's embedded reg-free (SxS) manifest.

- v1.0.0 (framework-dependent): AppxManifest had **69** `ActivatableClass` registrations (WebView2 + Win2D) and a `Microsoft.WindowsAppRuntime.2` framework `PackageDependency`; the WinUI classes came from the installed runtime → launches.
- v1.0.1 (self-contained): the `winapp package` AppxManifest had **0** `ActivatableClass` registrations and no framework dependency. The MSIX tooling does not harvest the WinAppSDK winmds into manifest registrations for self-contained builds, so on a clean machine nothing was registered → crash.

The crash is **not** caused by ReadyToRun, trimming, or the build machine — it reproduces from the packaging mode alone. (Note: a dev box with the Windows App Runtime already installed masks the failure, since activation falls back to the installed framework.)

## Fix

Package the MSIX with the supported **MSBuild MSIX tooling** (`-p:GenerateAppxPackageOnBuild=true -p:EnableMsixTooling=true`) as **framework-dependent** (`-p:WindowsAppSDKSelfContained=false`). This emits the full `ActivatableClass` registration set and declares the Windows App Runtime as a framework dependency — the same configuration as the field-proven v1.0.0 release. The runtime is acquired automatically by winget/Store at install time.

Verified locally: the produced x64 AppxManifest contains 69 `ActivatableClass` entries and the `Microsoft.WindowsAppRuntime.2` dependency, matching v1.0.0.

## Changes
- `.github/workflows/windows-release.yml`: replace the self-contained `dotnet publish` + `winapp package` steps (and the `Microsoft.WinAppCli` install) with a single MSBuild framework-dependent MSIX build/package step for x64 and ARM64. Downstream signing, WACK, hashing, and winget-manifest steps are unchanged (same output filenames).
- `windows/CHANGELOG.md`: add a Fixed entry under `[Unreleased]`.

## Notes / follow-up
- **winget validation:** framework-dependent end users get the runtime auto-acquired by winget/Store (how v1.0.0 worked). The winget-pkgs automated sandbox may lack the runtime and could require manual validation.
- After this merges and a signed `v1.0.2-windows` is released, update winget-pkgs PR #388237 to `1.0.2.0` with the new installer URLs/hashes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>