### PR TITLE
Widen Windows onboarding welcome layout

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,8 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Fixed
+- **Onboarding wizard now defaults to a wider layout** — increased the first-run welcome window
+  width and relaxed step content max-widths so introductory copy is less likely to wrap on first launch.
 - **Installed MSIX no longer crashes on startup** — the winget/MSIX build was switched to
   self-contained packaging to clear winget validation, but the resulting package shipped an
   AppxManifest with **no** WinRT activation registrations. On a clean machine (without the

--- a/windows/src/TinyClips.App/OnboardingWindow.xaml
+++ b/windows/src/TinyClips.App/OnboardingWindow.xaml
@@ -67,7 +67,7 @@
                     Style="{StaticResource TitleLargeTextBlockStyle}"
                     Text="Welcome to Tiny Clips" />
                 <TextBlock
-                    MaxWidth="440"
+                    MaxWidth="540"
                     HorizontalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource BodyTextBlockStyle}"
@@ -79,7 +79,7 @@
             <!--  Step 1: How it works  -->
             <StackPanel
                 x:Name="Step1"
-                MaxWidth="480"
+                MaxWidth="560"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Spacing="16"
@@ -105,7 +105,7 @@
             <!--  Step 2: All set  -->
             <StackPanel
                 x:Name="Step2"
-                MaxWidth="480"
+                MaxWidth="560"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Spacing="16"

--- a/windows/src/TinyClips.App/OnboardingWindow.xaml.cs
+++ b/windows/src/TinyClips.App/OnboardingWindow.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class OnboardingWindow : Window
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
-        AppWindow.Resize(new SizeInt32(640, 640));
+        AppWindow.Resize(new SizeInt32(720, 640));
 
         RootGrid.RequestedTheme = _settings.Theme switch
         {


### PR DESCRIPTION
## Summary
The Windows first-run onboarding window was too narrow, so welcome and step content wrapped aggressively by default. This makes the initial experience feel cramped and harder to scan.

This updates the onboarding layout to give copy and guide rows more horizontal room while keeping the existing flow and step structure unchanged.

## What changed
- Increased `OnboardingWindow` default size from `640x640` to `720x640`
- Increased welcome body text max width from `440` to `540`
- Increased step content max width for Steps 1 and 2 from `480` to `560`
- Added an Unreleased changelog entry in `windows/CHANGELOG.md`

## Notes for reviewers
- This is intentionally a layout-only change (no onboarding behavior or navigation logic changes).
- Windows direct distribution remains winget-updated; this PR does not change update mechanics.