### PR TITLE
Fix winget validation: declare Windows App SDK runtime dependency

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -76,7 +76,10 @@ jobs:
           # required for the installed package to launch on clean machines (matches the
           # working v1.0.0 release). Self-contained packaging omits those registrations
           # and crashes on startup with REGDB_E_CLASSNOTREG. The WindowsAppSDK runtime
-          # is declared as a framework PackageDependency and acquired by winget/Store.
+          # is declared as a framework PackageDependency in the AppxManifest; the winget
+          # installer manifest declares the matching Microsoft.WindowsAppRuntime.1.8
+          # package dependency so winget installs the runtime first (required on the
+          # clean, network-isolated VMs used by winget Installation Validation).
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -246,6 +249,9 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
+          Dependencies:
+            PackageDependencies:
+              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,12 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Fixed
+- **winget Installation Validation now passes** — the framework-dependent MSIX declares the
+  Windows App SDK runtime (`Microsoft.WindowsAppRuntime.1.8`) as a package dependency in its
+  AppxManifest. That runtime is missing on winget's clean, network-isolated validation VMs, so
+  installation failed there (it succeeded locally only because the runtime was already present).
+  The winget installer manifest now declares `Microsoft.WindowsAppRuntime.1.8` under
+  `Dependencies.PackageDependencies`, so winget installs the runtime first on any clean machine.
 - **Installed MSIX no longer crashes on startup** — the winget/MSIX build was switched to
   self-contained packaging to clear winget validation, but the resulting package shipped an
   AppxManifest with **no** WinRT activation registrations. On a clean machine (without the

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,8 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.0.4-windows] - 2026-06-16
+
 ### Fixed
 - **winget Installation Validation now passes** — the framework-dependent MSIX declares the
   Windows App SDK runtime (`Microsoft.WindowsAppRuntime.1.8`) as a package dependency in its

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -11,6 +11,12 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
+# TinyClips is framework-dependent on the Windows App SDK runtime. Declaring it as a
+# winget dependency ensures the runtime is installed first, including on the clean,
+# network-isolated VMs used by winget Installation Validation.
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix


### PR DESCRIPTION
## Problem

winget Installation Validation for `Refractored.TinyClips` 1.0.3 fails ([build 343747](https://dev.azure.com/shine-oss/winget-pkgs/_build/results?buildId=343747)) even though the MSIX installs and runs fine locally.

Root cause: TinyClips is a **Windows App SDK** app whose `AppxManifest.xml` declares an external framework dependency:

```xml
<PackageDependency Name="Microsoft.WindowsAppRuntime.1.8" MinVersion="8000.879.2017.0" .../>
```

It installs locally because the Windows App Runtime 1.8 is already present. winget's Installation Validation runs in a **clean, network-isolated VM** (note the `🔒 Start Network Isolation` step), so the runtime is absent and can't be auto-acquired from the Store → `winget install` fails with a missing-dependency error (`0x80073CF3`) for both x64 and arm64. Signing and WACK all pass; this is purely the unsatisfied runtime dependency.

## Fix

`Microsoft.WindowsAppRuntime.1.8` is itself a winget package, so we declare it as a dependency. winget then installs the runtime first, including on the isolated validation VMs.

- `windows/packaging/winget/Refractored.TinyClips.installer.yaml` — add `Dependencies.PackageDependencies`.
- `.github/workflows/windows-release.yml` — emit the same block in the generated installer manifest, and refresh the stale comment.
- `windows/CHANGELOG.md` — document the fix.

```yaml
Dependencies:
  PackageDependencies:
    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
```

To unblock the **already-open** winget PR #388237 without cutting a new release, the same `Dependencies` block can be added to that PR's installer manifest and re-validated with `@wingetbot run`.