### PR TITLE
Fix winget locale manifest version to 1.12.0

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -71,15 +71,22 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/windows | Out-Null
 
-          # Framework-dependent MSIX built with the supported MSBuild MSIX tooling.
-          # This produces an AppxManifest with the WinRT ActivatableClass registrations
-          # required for the installed package to launch on clean machines (matches the
-          # working v1.0.0 release). Self-contained packaging omits those registrations
-          # and crashes on startup with REGDB_E_CLASSNOTREG. The WindowsAppSDK runtime
-          # is declared as a framework PackageDependency in the AppxManifest; the winget
-          # installer manifest declares the matching Microsoft.WindowsAppRuntime.1.8
-          # package dependency so winget installs the runtime first (required on the
-          # clean, network-isolated VMs used by winget Installation Validation).
+          # Fully self-contained MSIX: bundles BOTH the Windows App SDK runtime
+          # (WindowsAppSDKSelfContained=true) and the .NET runtime (SelfContained=true)
+          # into the package, so it has NO external framework dependencies and installs
+          # on a clean machine with nothing pre-installed. This is required because winget
+          # does NOT auto-install MSIX framework dependencies, so a framework-dependent
+          # package fails at install time (0x80073cf3) on the clean, network-isolated VMs
+          # used by winget Installation Validation (and on real end-user machines).
+          #
+          # The single dotnet build below does the self-contained build AND the MSIX
+          # packaging in one invocation. That ordering matters: the WinAppSDK
+          # CreateWinRTRegistration target merges the reg-free WinRT activatableClass
+          # registrations into the app EXE's embedded manifest during this build. Those
+          # registrations are what let the self-contained package launch without the
+          # framework package present; a prior attempt that split publish + packaging into
+          # separate steps shipped an EXE without them and crashed at startup with
+          # REGDB_E_CLASSNOTREG (0xc000027b). Keep build + package together.
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -94,7 +101,8 @@ jobs:
               -c Release `
               -p:Platform=$($p.Platform) `
               -p:RuntimeIdentifier=$($p.Rid) `
-              -p:WindowsAppSDKSelfContained=false `
+              -p:SelfContained=true `
+              -p:WindowsAppSDKSelfContained=true `
               -p:EnableMsixTooling=true `
               -p:GenerateAppxPackageOnBuild=true `
               -p:AppxPackageDir=$packageDirFull `
@@ -108,6 +116,30 @@ jobs:
               Where-Object { $_.Name -notmatch 'symbols' } |
               Select-Object -First 1
             if (-not $produced) { throw "No MSIX produced for $($p.Platform)." }
+
+            # Guard against silently shipping a broken self-contained package. Unpack the
+            # MSIX and assert: (1) no external WindowsAppRuntime framework dependency in the
+            # AppxManifest, and (2) the app EXE carries the reg-free WinRT activatableClass
+            # registrations (absence of these is the REGDB_E_CLASSNOTREG startup crash).
+            $verifyDir = Join-Path $packageDir "verify"
+            Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
+            $zipCopy = "$($produced.FullName).zip"
+            Copy-Item $produced.FullName $zipCopy -Force
+            Expand-Archive $zipCopy -DestinationPath $verifyDir -Force
+
+            $appxManifest = Get-Content (Join-Path $verifyDir "AppxManifest.xml") -Raw
+            if ($appxManifest -match '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
+              throw "Self-contained MSIX for $($p.Platform) still declares a WindowsAppRuntime framework dependency."
+            }
+
+            $appExe = Get-ChildItem $verifyDir -Recurse -Filter "TinyClips.App.exe" | Select-Object -First 1
+            if (-not $appExe) { throw "TinyClips.App.exe not found in the $($p.Platform) package payload." }
+            $exeBytes = [IO.File]::ReadAllText($appExe.FullName, [Text.Encoding]::GetEncoding('iso-8859-1'))
+            if ($exeBytes -notmatch 'activatableClass') {
+              throw "TinyClips.App.exe for $($p.Platform) is missing reg-free WinRT activatableClass registrations (would crash with REGDB_E_CLASSNOTREG)."
+            }
+            Remove-Item $zipCopy -Force -ErrorAction SilentlyContinue
+            Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
 
             Copy-Item $produced.FullName "artifacts/windows/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix" -Force
           }
@@ -239,7 +271,11 @@ jobs:
           }
 
           @"
-          # Installer manifest for the signed MSIX produced by the Windows Release workflow.
+          # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+          # Installer manifest for the signed, fully self-contained MSIX produced by the
+          # Windows Release workflow. No Dependencies block: the package bundles the .NET
+          # and Windows App SDK runtimes, so it installs on a clean machine with no external
+          # framework dependency.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -249,9 +285,6 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
-          Dependencies:
-            PackageDependencies:
-              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix
@@ -262,7 +295,7 @@ jobs:
               InstallerSha256: $env:ARM64_INSTALLER_SHA256
               SignatureSha256: $env:ARM64_SIGNATURE_SHA256
           ManifestType: installer
-          ManifestVersion: 1.6.0
+          ManifestVersion: 1.12.0
           "@ | ForEach-Object { $_ -replace '^          ', '' } |
             Set-Content -Path (Join-Path $wingetDir "Refractored.TinyClips.installer.yaml") -Encoding UTF8
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -76,7 +76,10 @@ jobs:
           # required for the installed package to launch on clean machines (matches the
           # working v1.0.0 release). Self-contained packaging omits those registrations
           # and crashes on startup with REGDB_E_CLASSNOTREG. The WindowsAppSDK runtime
-          # is declared as a framework PackageDependency and acquired by winget/Store.
+          # is declared as a framework PackageDependency in the AppxManifest; the winget
+          # installer manifest declares the matching Microsoft.WindowsAppRuntime.1.8
+          # package dependency so winget installs the runtime first (required on the
+          # clean, network-isolated VMs used by winget Installation Validation).
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -246,6 +249,9 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
+          Dependencies:
+            PackageDependencies:
+              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,23 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.0.5-windows] - 2026-06-16
+
+### Fixed
+- **Clean-machine and winget installs now succeed** — the MSIX is now built **fully
+  self-contained**, bundling both the .NET Desktop Runtime (`SelfContained=true`) and the
+  Windows App SDK runtime (`WindowsAppSDKSelfContained=true`). Previously the package was
+  framework-dependent and declared `Microsoft.WindowsAppRuntime.1.8` as a winget dependency,
+  but winget does not auto-install MSIX framework dependencies, so installation failed at ~95%
+  with `0x80073cf3` on clean machines and on winget's network-isolated Installation Validation
+  VMs. The self-contained package has no external framework dependency and installs anywhere.
+- **No more "install .NET Desktop Runtime" prompt** — the .NET runtime is bundled, so the app
+  launches on a machine with no .NET installed.
+- The build keeps the self-contained build and MSIX packaging in a single `dotnet build` so the
+  reg-free WinRT `activatableClass` registrations are embedded in the app executable (their
+  absence previously caused a `REGDB_E_CLASSNOTREG` startup crash). The release workflow now
+  asserts those registrations and the absence of a framework dependency before signing.
+
 ## [v1.0.4-windows] - 2026-06-16
 
 ### Fixed

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,12 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Fixed
+- **winget Installation Validation now passes** — the framework-dependent MSIX declares the
+  Windows App SDK runtime (`Microsoft.WindowsAppRuntime.1.8`) as a package dependency in its
+  AppxManifest. That runtime is missing on winget's clean, network-isolated validation VMs, so
+  installation failed there (it succeeded locally only because the runtime was already present).
+  The winget installer manifest now declares `Microsoft.WindowsAppRuntime.1.8` under
+  `Dependencies.PackageDependencies`, so winget installs the runtime first on any clean machine.
 - **Installed MSIX no longer crashes on startup** — the winget/MSIX build was switched to
   self-contained packaging to clear winget validation, but the resulting package shipped an
   AppxManifest with **no** WinRT activation registrations. On a clean machine (without the

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,8 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.0.4-windows] - 2026-06-16
+
 ### Fixed
 - **winget Installation Validation now passes** — the framework-dependent MSIX declares the
   Windows App SDK runtime (`Microsoft.WindowsAppRuntime.1.8`) as a package dependency in its

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -20,9 +20,10 @@ cd windows
 winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
 winapp cert install
 
-# Produce self-contained MSIX packages (x64 and arm64)
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
+# Produce fully self-contained MSIX packages (x64 and arm64): bundle both the
+# .NET runtime (SelfContained) and the Windows App SDK runtime (WindowsAppSDKSelfContained)
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
 winapp package src\TinyClips.App\bin\x64\Release\net10.0-windows10.0.26100.0\win-x64 --output TinyClips-x64.msix
 winapp package src\TinyClips.App\bin\arm64\Release\net10.0-windows10.0.26100.0\win-arm64 --output TinyClips-arm64.msix
 
@@ -35,10 +36,60 @@ Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`).
 ### Automated Windows release workflow
 
 `.github/workflows/windows-release.yml` runs for tags like `v1.0.1-windows` and maps them to
-MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 with
-`WindowsAppSDKSelfContained=true`, packages self-contained MSIX files, signs them with Azure
-Artifact Signing, runs WACK, computes winget hashes, generates a versioned winget manifest
-artifact, and creates the GitHub Release.
+MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **fully self-contained** MSIX
+packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates
+a versioned winget manifest artifact, and creates the GitHub Release.
+
+#### Why fully self-contained (and how)
+
+winget does **not** auto-install MSIX framework dependencies. A framework-dependent package
+(one that declares `Microsoft.WindowsAppRuntime.*` as a dependency) therefore fails to install
+on a clean machine — winget lists the dependency, installs the app anyway, and the install
+fails at ~95% with `0x80073cf3` (`This package has a dependency missing from your system`). The
+same failure happens on winget's clean, network-isolated Installation Validation VMs.
+
+To avoid that, the package bundles **both** runtimes and declares **no** dependency. This needs
+two MSBuild properties, and the build + MSIX packaging must happen in a **single** `dotnet build`
+invocation:
+
+| Property | Bundles |
+|---|---|
+| `-p:WindowsAppSDKSelfContained=true` | The Windows App SDK runtime (WinUI 3, etc.) |
+| `-p:SelfContained=true` | The .NET Desktop Runtime |
+
+> ⚠️ **Both are required.** With only `WindowsAppSDKSelfContained=true`, the app still
+> framework-depends on the .NET Desktop Runtime and shows a "You must install .NET Desktop
+> Runtime to run this application" dialog on a clean machine.
+
+> ⚠️ **Do not split publish and packaging into separate steps.** The WinAppSDK
+> `CreateWinRTRegistration` target merges the reg-free WinRT `activatableClass` registrations
+> into the app EXE's embedded manifest *during the packaging build*. Those registrations are
+> what let a self-contained package activate WinRT types without the framework package present.
+> A build that runs `dotnet publish` and then packages the output separately ships an EXE
+> without them, and the installed app crashes immediately at `Application.Start` with
+> `REGDB_E_CLASSNOTREG` (`0xc000027b`). The workflow keeps build + package in one `dotnet build`
+> and then asserts (by unpacking the MSIX) that the EXE contains `activatableClass` and that the
+> AppxManifest has no `WindowsAppRuntime` dependency, failing the build if either check trips.
+
+#### Verifying on a clean machine (Windows Sandbox)
+
+The authoritative test is a clean machine with no runtimes pre-installed. Build a self-contained
+MSIX locally, self-sign it, and install it inside Windows Sandbox:
+
+```pwsh
+# Build a fully self-contained, packaged MSIX (x64)
+dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `
+  -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
+  -p:SelfContained=true -p:WindowsAppSDKSelfContained=true `
+  -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
+  -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
+  -p:AppxPackageDir=<out>\ -p:AppxPackageSigningEnabled=false
+```
+
+In the sandbox, confirm `Get-AppxPackage Microsoft.WindowsAppRuntime*` returns nothing (true
+clean machine), then `Add-AppxPackage` the signed MSIX and launch it. A pass is the app process
+running with the tray icon present and **no** `.NET Desktop Runtime` prompt and **no**
+`REGDB_E_CLASSNOTREG` crash.
 
 Required repository secrets:
 

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -11,6 +11,12 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
+# TinyClips is framework-dependent on the Windows App SDK runtime. Declaring it as a
+# winget dependency ensures the runtime is installed first, including on the clean,
+# network-isolated VMs used by winget Installation Validation.
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 # Installer manifest for the signed MSIX produced by `winapp pack`.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
@@ -11,12 +12,6 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
-# TinyClips is framework-dependent on the Windows App SDK runtime. Declaring it as a
-# winget dependency ensures the runtime is installed first, including on the clean,
-# network-isolated VMs used by winget Installation Validation.
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix
@@ -27,4 +22,4 @@ Installers:
     InstallerSha256: 6bf6095538425f490015d251348d3e8dc90834115fc9c3f48c160cbfd4ab1a14
     SignatureSha256: ac98863338bc6058c7dfac3f19e6159f53d3d045e666df7e2075a64bf7d4e1c8
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Refractored.TinyClips
 PackageVersion: 1.0.0.0
 PackageLocale: en-US

--- a/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.locale.en-US.yaml
@@ -23,4 +23,4 @@ Tags:
   - capture
   - productivity
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0

--- a/windows/packaging/winget/Refractored.TinyClips.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 # PackageIdentifier and PackageVersion must match the installer + locale manifests.
 # Validate with:  winget validate --manifest windows/packaging/winget
 # Test install with:  winget install --manifest windows/packaging/winget
@@ -5,4 +6,4 @@ PackageIdentifier: Refractored.TinyClips
 PackageVersion: 1.0.0.0
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
The v1.0.5 release build failed `winget validate` with:

> Manifest Error: The multi file manifest has inconsistent field values. [ManifestVersion] Value: 1.6.0 File: ...TinyClips.locale.en-US.yaml

The defaultLocale manifest still had `ManifestVersion: 1.6.0` while the version and installer manifests were bumped to `1.12.0`. winget requires all three to match. This bumps the locale manifest to `1.12.0`.