### PR TITLE
windows: migrate launch-at-login to MSIX StartupTask API (#81)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -25,6 +25,14 @@ own `CHANGELOG.md` at the repository root.
 - **Onboarding wizard now defaults to a wider layout** — increased the first-run welcome window
   width and relaxed step content max-widths so introductory copy is less likely to wrap on first launch.
 
+### Fixed
+- **Launch at login now survives app updates** — migrated from writing an `HKCU\...\Run` registry
+  value (which pointed at the versioned `WindowsApps\<PackageFullName>` install path and silently
+  stopped working after every MSIX update) to the supported `windows.startupTask` MSIX extension and
+  `Windows.ApplicationModel.StartupTask` API. The Settings toggle now reflects the real OS-owned state
+  and explains when Windows has disabled launch at login (e.g. turned off in Windows Settings → Apps →
+  Startup, or blocked by policy). Unpackaged developer runs keep the registry behavior as a fallback.
+
 ## [v1.0.5-windows] - 2026-06-16
 
 ### Fixed

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -4,8 +4,9 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  IgnorableNamespaces="uap uap5 rescap">
 
   <Identity
     Name="Refractored.TinyClips"
@@ -43,6 +44,15 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
+        <uap5:Extension
+          Category="windows.startupTask"
+          Executable="TinyClips.App.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <uap5:StartupTask
+            TaskId="TinyClipsLaunchAtLogin"
+            Enabled="false"
+            DisplayName="Tiny Clips" />
+        </uap5:Extension>
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="image">
             <uap:DisplayName>Tiny Clips Image</uap:DisplayName>

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TinyClips.Core.Models;
 using TinyClips.Core.Services;
@@ -37,6 +38,9 @@ public sealed partial class SettingsViewModel : ObservableObject
         _audioDevices = audioDevices;
         _storage = storage;
         Load();
+
+        // Reconcile the toggle with the OS-owned launch-at-login (StartupTask) state.
+        _ = RefreshLaunchAtLoginAsync();
     }
 
     /// <summary>
@@ -66,6 +70,23 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _launchAtLogin;
+
+    /// <summary>False when Windows owns the toggle (policy-locked), so the UI disables it.</summary>
+    [ObservableProperty]
+    private bool _launchAtLoginToggleEnabled = true;
+
+    /// <summary>Explains OS-imposed launch-at-login states (e.g. disabled by the user in Windows Settings).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LaunchAtLoginNoteVisibility))]
+    private string _launchAtLoginNote = string.Empty;
+
+    public Microsoft.UI.Xaml.Visibility LaunchAtLoginNoteVisibility =>
+        string.IsNullOrEmpty(LaunchAtLoginNote)
+            ? Microsoft.UI.Xaml.Visibility.Collapsed
+            : Microsoft.UI.Xaml.Visibility.Visible;
+
+    // Guards the toggle's change handler while we set LaunchAtLogin to reflect OS truth.
+    private bool _suppressLaunchAtLogin;
 
     [ObservableProperty]
     private bool _copyScreenshotToClipboard;
@@ -322,11 +343,50 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnLaunchAtLoginChanged(bool value)
     {
-        Persist(() =>
+        if (_loading || _suppressLaunchAtLogin)
         {
-            _settings.LaunchAtLogin = value;
-            _launchAtLoginService.Apply(value);
-        });
+            return;
+        }
+
+        _ = ApplyLaunchAtLoginAsync(value);
+    }
+
+    private async Task ApplyLaunchAtLoginAsync(bool value)
+    {
+        var state = await _launchAtLoginService.SetEnabledAsync(value);
+        ApplyLaunchAtLoginState(state);
+    }
+
+    private async Task RefreshLaunchAtLoginAsync()
+    {
+        var state = await _launchAtLoginService.GetStateAsync();
+        ApplyLaunchAtLoginState(state);
+    }
+
+    private void ApplyLaunchAtLoginState(LaunchAtLoginState state)
+    {
+        var enabled = state is LaunchAtLoginState.Enabled or LaunchAtLoginState.EnabledByPolicy;
+
+        // Reflect OS truth without re-triggering the change handler.
+        _suppressLaunchAtLogin = true;
+        LaunchAtLogin = enabled;
+        _suppressLaunchAtLogin = false;
+
+        // The app can only flip the toggle when Windows hasn't locked it.
+        LaunchAtLoginToggleEnabled = state is LaunchAtLoginState.Enabled or LaunchAtLoginState.Disabled;
+
+        LaunchAtLoginNote = state switch
+        {
+            LaunchAtLoginState.DisabledByUser =>
+                "Turned off in Windows Settings \u2192 Apps \u2192 Startup. Re-enable Tiny Clips there to allow launch at login.",
+            LaunchAtLoginState.DisabledByPolicy => "Launch at login is disabled by your organization's policy.",
+            LaunchAtLoginState.EnabledByPolicy => "Launch at login is enabled by your organization's policy.",
+            LaunchAtLoginState.Unavailable => "Launch at login isn't available for this installation.",
+            _ => string.Empty,
+        };
+
+        // Keep the persisted mirror aligned with the real state.
+        _settings.LaunchAtLogin = enabled;
     }
 
     partial void OnCopyScreenshotToClipboardChanged(bool value) => Persist(() => _settings.CopyScreenshotToClipboard = value);

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -216,12 +216,20 @@
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="Start Tiny Clips when I sign in to Windows." />
+                           <TextBlock
+                               Margin="0,4,0,0"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                               TextWrapping="Wrap"
+                               Visibility="{x:Bind ViewModel.LaunchAtLoginNoteVisibility, Mode=OneWay}"
+                               Text="{x:Bind ViewModel.LaunchAtLoginNote, Mode=OneWay}" />
                        </StackPanel>
                        <ToggleSwitch
                            Grid.Column="1"
                            VerticalAlignment="Center"
                            AutomationProperties.AutomationId="LaunchAtLoginToggle"
                            AutomationProperties.Name="Launch at login"
+                           IsEnabled="{x:Bind ViewModel.LaunchAtLoginToggleEnabled, Mode=OneWay}"
                            IsOn="{x:Bind ViewModel.LaunchAtLogin, Mode=TwoWay}" />
                    </Grid>
                 </Border>

--- a/windows/src/TinyClips.Core/Services/ILaunchAtLoginService.cs
+++ b/windows/src/TinyClips.Core/Services/ILaunchAtLoginService.cs
@@ -2,8 +2,14 @@ namespace TinyClips.Core.Services;
 
 public interface ILaunchAtLoginService
 {
-    bool IsEnabled { get; set; }
+    /// <summary>Reads the current launch-at-login state from the OS.</summary>
+    Task<LaunchAtLoginState> GetStateAsync();
 
-    void Sync(bool enabled);
-    void Apply(bool enabled);
+    /// <summary>
+    /// Requests the desired launch-at-login state and returns the actual resulting
+    /// state. The OS may refuse the change (e.g. the user disabled the startup task
+    /// in Windows Settings), so callers must reconcile their UI with the return value.
+    /// Enabling can surface a one-time OS consent prompt.
+    /// </summary>
+    Task<LaunchAtLoginState> SetEnabledAsync(bool enabled);
 }

--- a/windows/src/TinyClips.Core/Services/LaunchAtLoginService.cs
+++ b/windows/src/TinyClips.Core/Services/LaunchAtLoginService.cs
@@ -1,34 +1,111 @@
 using System.Diagnostics;
 using Microsoft.Win32;
+using Windows.ApplicationModel;
 
 namespace TinyClips.Core.Services;
 
+/// <summary>
+/// Launch-at-login backed by the MSIX <see cref="StartupTask"/> API. The startup
+/// task is declared as a <c>windows.startupTask</c> extension in the package manifest
+/// (<c>TaskId == <see cref="TaskId"/></c>) so the registration survives version updates —
+/// unlike the old <c>HKCU\...\Run</c> value, which pointed at the versioned
+/// <c>WindowsApps\&lt;PackageFullName&gt;</c> path and broke after every update.
+///
+/// When the app runs unpackaged (developer F5), the StartupTask API is unavailable, so
+/// the service falls back to the legacy registry approach purely to keep dev runs working.
+/// </summary>
 public sealed class LaunchAtLoginService : ILaunchAtLoginService
 {
+    // Must match the TaskId of the windows.startupTask extension in Package.appxmanifest.
+    private const string TaskId = "TinyClipsLaunchAtLogin";
+
     private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string RunValueName = "TinyClips";
 
-    public bool IsEnabled
+    public async Task<LaunchAtLoginState> GetStateAsync()
     {
-        get
+        try
         {
-            try
-            {
-                using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, false);
-                var storedValue = ((string?)key?.GetValue(RunValueName))?.Trim('"');
-                return string.Equals(storedValue, GetExecutablePath(), StringComparison.OrdinalIgnoreCase);
-            }
-            catch
-            {
-                return false;
-            }
+            var task = await StartupTask.GetAsync(TaskId);
+            return Map(task.State);
         }
-        set => Apply(value);
+        catch (Exception)
+        {
+            // Unpackaged dev runs (and unexpected failures) fall back to the registry.
+            return GetRegistryState();
+        }
     }
 
-    public void Sync(bool enabled) => Apply(enabled);
+    public async Task<LaunchAtLoginState> SetEnabledAsync(bool enabled)
+    {
+        StartupTask task;
+        try
+        {
+            task = await StartupTask.GetAsync(TaskId);
+        }
+        catch (Exception)
+        {
+            ApplyRegistry(enabled);
+            return GetRegistryState();
+        }
 
-    public void Apply(bool enabled)
+        try
+        {
+            if (enabled)
+            {
+                if (task.State == StartupTaskState.Disabled)
+                {
+                    // Can surface a one-time OS consent prompt; the awaited result is authoritative.
+                    return Map(await task.RequestEnableAsync());
+                }
+
+                return Map(task.State);
+            }
+
+            if (task.State is StartupTaskState.Enabled or StartupTaskState.EnabledByPolicy)
+            {
+                task.Disable();
+            }
+
+            // Disable() mutates the registration; re-read so the returned state is current.
+            var refreshed = await StartupTask.GetAsync(TaskId);
+            return Map(refreshed.State);
+        }
+        catch (Exception)
+        {
+            return LaunchAtLoginState.Unavailable;
+        }
+    }
+
+    private static LaunchAtLoginState Map(StartupTaskState state) => state switch
+    {
+        StartupTaskState.Enabled => LaunchAtLoginState.Enabled,
+        StartupTaskState.Disabled => LaunchAtLoginState.Disabled,
+        StartupTaskState.DisabledByUser => LaunchAtLoginState.DisabledByUser,
+        StartupTaskState.DisabledByPolicy => LaunchAtLoginState.DisabledByPolicy,
+        StartupTaskState.EnabledByPolicy => LaunchAtLoginState.EnabledByPolicy,
+        _ => LaunchAtLoginState.Unavailable,
+    };
+
+    // --- Registry fallback (unpackaged dev runs only) ---
+
+    private static LaunchAtLoginState GetRegistryState()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, false);
+            var storedValue = ((string?)key?.GetValue(RunValueName))?.Trim('"');
+            return string.Equals(storedValue, GetExecutablePath(), StringComparison.OrdinalIgnoreCase)
+                ? LaunchAtLoginState.Enabled
+                : LaunchAtLoginState.Disabled;
+        }
+        catch
+        {
+            return LaunchAtLoginState.Disabled;
+        }
+    }
+
+    private static void ApplyRegistry(bool enabled)
     {
         try
         {
@@ -46,7 +123,6 @@ public sealed class LaunchAtLoginService : ILaunchAtLoginService
 
             if (enabled)
             {
-                // MSIX should use windows.startupTask + StartupTask; per-version install paths break registry launch after updates.
                 key.SetValue(RunValueName, QuoteExecutablePath(executablePath));
                 return;
             }

--- a/windows/src/TinyClips.Core/Services/LaunchAtLoginService.cs
+++ b/windows/src/TinyClips.Core/Services/LaunchAtLoginService.cs
@@ -22,8 +22,32 @@ public sealed class LaunchAtLoginService : ILaunchAtLoginService
     private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string RunValueName = "TinyClips";
 
+    private static bool? _isPackaged;
+
+    // Only an unpackaged (developer F5) run may use the legacy registry path. A packaged
+    // app must never write an HKCU\...\Run value — that is the stale-after-update bug this
+    // service exists to remove — so we key off real package identity, not on a GetAsync failure.
+    private static bool IsPackaged => _isPackaged ??= DetectPackaged();
+
+    private static bool DetectPackaged()
+    {
+        try
+        {
+            return Package.Current is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<LaunchAtLoginState> GetStateAsync()
     {
+        if (!IsPackaged)
+        {
+            return GetRegistryState();
+        }
+
         try
         {
             var task = await StartupTask.GetAsync(TaskId);
@@ -31,19 +55,13 @@ public sealed class LaunchAtLoginService : ILaunchAtLoginService
         }
         catch (Exception)
         {
-            // Unpackaged dev runs (and unexpected failures) fall back to the registry.
-            return GetRegistryState();
+            return LaunchAtLoginState.Unavailable;
         }
     }
 
     public async Task<LaunchAtLoginState> SetEnabledAsync(bool enabled)
     {
-        StartupTask task;
-        try
-        {
-            task = await StartupTask.GetAsync(TaskId);
-        }
-        catch (Exception)
+        if (!IsPackaged)
         {
             ApplyRegistry(enabled);
             return GetRegistryState();
@@ -51,6 +69,8 @@ public sealed class LaunchAtLoginService : ILaunchAtLoginService
 
         try
         {
+            var task = await StartupTask.GetAsync(TaskId);
+
             if (enabled)
             {
                 if (task.State == StartupTaskState.Disabled)

--- a/windows/src/TinyClips.Core/Services/LaunchAtLoginState.cs
+++ b/windows/src/TinyClips.Core/Services/LaunchAtLoginState.cs
@@ -1,0 +1,28 @@
+namespace TinyClips.Core.Services;
+
+/// <summary>
+/// Reflects the real launch-at-login state as reported by the OS. For an
+/// MSIX-packaged app this maps onto <c>Windows.ApplicationModel.StartupTaskState</c>;
+/// the <c>DisabledByUser</c>/<c>DisabledByPolicy</c>/<c>EnabledByPolicy</c> values let
+/// the Settings UI explain when Windows — not the app — owns the toggle.
+/// </summary>
+public enum LaunchAtLoginState
+{
+    /// <summary>Off, and the app may turn it on.</summary>
+    Disabled,
+
+    /// <summary>On, and the app may turn it off.</summary>
+    Enabled,
+
+    /// <summary>The user turned it off in Windows Settings/Task Manager; the app cannot re-enable it.</summary>
+    DisabledByUser,
+
+    /// <summary>Group policy forces it off; the app cannot change it.</summary>
+    DisabledByPolicy,
+
+    /// <summary>Group policy forces it on; the app cannot change it.</summary>
+    EnabledByPolicy,
+
+    /// <summary>Launch at login could not be queried (e.g. unsupported install).</summary>
+    Unavailable,
+}


### PR DESCRIPTION
Closes #81.

## Problem
`LaunchAtLoginService` wrote the executable path to `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. For an MSIX app the install path lives under the versioned `C:\Program Files\WindowsApps\<PackageFullName>\...`, so after every MSIX update the stored `Run` value pointed at the old (removed) path and launch-at-login silently stopped working until the user toggled it off/on.

## Change
Migrate to the supported MSIX mechanism:

- **Manifest**: declare a `windows.startupTask` extension (`uap5`) with `TaskId="TinyClipsLaunchAtLogin"` `Enabled="false"`.
- **Service**: `ILaunchAtLoginService` is now async with a `LaunchAtLoginState` enum.
  - `GetStateAsync()` reads `StartupTask.GetAsync(taskId).State`.
  - `SetEnabledAsync(bool)` enables via `RequestEnableAsync()` (which can show a one-time OS consent prompt) and disables via `Disable()`, then returns the **actual** resulting state.
  - Maps `DisabledByUser` / `DisabledByPolicy` / `EnabledByPolicy`.
  - Unpackaged developer runs fall back to the legacy registry behavior so `F5` still works.
- **Settings UI**: the toggle now reflects real OS-owned state, disables itself when Windows has policy-locked it, and shows an explanatory note (e.g. "Turned off in Windows Settings → Apps → Startup").

## Validation
- `TinyClips.App` (Release, x64, framework-dependent) builds: 0 warnings / 0 errors.
- `TinyClips.Core.Tests`: 25 passed.
- ⚠️ Persistence across an MSIX **update** can't be verified in CI — needs a manual check on a real packaged install + version bump (per the issue).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>