### PR TITLE
Fix onboarding Skip button placement

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,11 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Onboarding "Skip" button is now reliably clickable** — moved it out of the custom title bar
+  (where it overlapped the window's minimize/maximize/close caption buttons) into the wizard footer
+  next to **Back**, and hid it on the final step where **Get started** already completes onboarding.
+
 ## [v1.0.6-windows] - 2026-06-16
 
 ### Changed

--- a/windows/src/TinyClips.App/OnboardingWindow.xaml
+++ b/windows/src/TinyClips.App/OnboardingWindow.xaml
@@ -23,23 +23,11 @@
             x:Name="AppTitleBar"
             Grid.Row="0"
             Height="48"
-            Padding="16,0"
-            ColumnSpacing="8">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
+            Padding="16,0">
             <TextBlock
                 VerticalAlignment="Center"
                 Style="{StaticResource CaptionTextBlockStyle}"
                 Text="Welcome" />
-            <Button
-                Grid.Column="1"
-                AutomationProperties.AutomationId="OnboardingSkipButton"
-                Background="Transparent"
-                BorderThickness="0"
-                Click="OnSkipClicked"
-                Content="Skip" />
         </Grid>
 
         <!--  Steps  -->
@@ -184,12 +172,24 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Button
-                x:Name="BackButton"
-                AutomationProperties.AutomationId="OnboardingBackButton"
-                Click="OnBackClicked"
-                Content="Back"
-                Visibility="Collapsed" />
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    x:Name="SkipButton"
+                    AutomationProperties.AutomationId="OnboardingSkipButton"
+                    AutomationProperties.HelpText="Close the welcome guide and start using Tiny Clips"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Click="OnSkipClicked"
+                    Content="Skip" />
+                <Button
+                    x:Name="BackButton"
+                    AutomationProperties.AutomationId="OnboardingBackButton"
+                    Click="OnBackClicked"
+                    Content="Back"
+                    Visibility="Collapsed" />
+            </StackPanel>
 
             <StackPanel
                 Grid.Column="1"

--- a/windows/src/TinyClips.App/OnboardingWindow.xaml.cs
+++ b/windows/src/TinyClips.App/OnboardingWindow.xaml.cs
@@ -81,6 +81,7 @@ public sealed partial class OnboardingWindow : Window
         Step2.Visibility = _step == 2 ? Visibility.Visible : Visibility.Collapsed;
 
         BackButton.Visibility = _step > 0 ? Visibility.Visible : Visibility.Collapsed;
+        SkipButton.Visibility = _step >= LastStep ? Visibility.Collapsed : Visibility.Visible;
         NextButton.Content = _step >= LastStep ? "Get started" : "Next";
 
         var active = (SolidColorBrush)Application.Current.Resources["AccentFillColorDefaultBrush"];


### PR DESCRIPTION
## Problem

On the first-run welcome guide, the **Skip** button was placed inside the custom title bar (`SetTitleBar(AppTitleBar)`), right-aligned at the top — the same region Windows reserves for the minimize/maximize/close caption buttons. As a result Skip overlapped/sat under the caption buttons and was crowded and unreliable to click.

## Fix

- Moved **Skip** out of the title bar into the wizard footer, grouped at the bottom-left next to **Back** (a normal, fully clickable region — not a drag region).
- Hid **Skip** on the final step, where the accent **Get started** button already completes onboarding (avoids a redundant duplicate action).
- Removed the now-unused title-bar `Grid` columns; the title bar just shows the "Welcome" caption.
- Added an accessibility `HelpText` on the Skip button.

## Testing

- `dotnet build windows/src/TinyClips.App` (Release, x64, framework-dependent) — succeeds, 0 warnings / 0 errors.

Behavior unchanged: Skip still marks onboarding complete and closes the window.