### PR TITLE
Fix Settings fields loading blank and not persisting

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,14 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Settings now load and persist correctly in the installed (packaged) app** — fixed a
+  first-load race where WinUI TwoWay bindings (theme, save location, file name template,
+  screenshot/video options, microphone) wrote their controls' empty initial values back over
+  the loaded settings, which showed blank fields and silently reset choices on every reopen.
+  Persistence is now suppressed until the window's first layout completes, then the view model
+  re-syncs from storage. An already-empty file name template also heals back to the default.
+
 ## [v1.0.7-windows] - 2026-06-16
 
 ### Fixed

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -27,6 +27,14 @@ public sealed partial class SettingsViewModel : ObservableObject
     private readonly IClipStorageService _storage;
     private bool _loading;
 
+    // Persistence stays suppressed until the Settings window has finished its first
+    // layout/binding pass. WinUI TwoWay x:Bind targets (ComboBox.SelectedIndex,
+    // TextBox.Text, ToggleSwitch.IsOn) push their transient initial values back into the
+    // source while the controls are realized — which happens *after* the constructor's
+    // Load() resets _loading. Without this gate those write-backs overwrite the loaded
+    // values (blanking ComboBoxes to -1, emptying text boxes) and persist the garbage.
+    private bool _ready;
+
     /// <summary>Raised when the selected theme changes so the window can re-apply it live.</summary>
     public event Action? ThemeChanged;
 
@@ -238,6 +246,23 @@ public sealed partial class SettingsViewModel : ObservableObject
         OnPropertyChanged(nameof(GifHotKeyDisplay));
     }
 
+    /// <summary>
+    /// Called by the window once its visual tree has loaded and the controls' initial
+    /// TwoWay binding write-backs have settled. Re-reads the (still-intact) persisted
+    /// values into the bound properties so the UI shows real data, then unlocks
+    /// persistence so genuine user edits are saved.
+    /// </summary>
+    public void CompleteInitialization()
+    {
+        if (_ready)
+        {
+            return;
+        }
+
+        Load();
+        _ready = true;
+    }
+
     private void Load()
     {
         _loading = true;
@@ -250,7 +275,9 @@ public sealed partial class SettingsViewModel : ObservableObject
                 _ => 0,
             };
             SaveDirectory = _settings.SaveDirectory;
-            FileNameTemplate = _settings.FileNameTemplate;
+            FileNameTemplate = string.IsNullOrWhiteSpace(_settings.FileNameTemplate)
+                ? "TinyClips {date} at {time}"
+                : _settings.FileNameTemplate;
             ShowInExplorer = _settings.ShowInExplorer;
             ShowSaveNotifications = _settings.ShowSaveNotifications;
             LaunchAtLogin = _settings.LaunchAtLogin;
@@ -315,7 +342,7 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnThemeIndexChanged(int value)
     {
-        if (_loading)
+        if (_loading || !_ready)
         {
             return;
         }
@@ -343,7 +370,7 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnLaunchAtLoginChanged(bool value)
     {
-        if (_loading || _suppressLaunchAtLogin)
+        if (_loading || !_ready || _suppressLaunchAtLogin)
         {
             return;
         }
@@ -482,7 +509,7 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     private void Persist(Action apply)
     {
-        if (_loading)
+        if (_loading || !_ready)
         {
             return;
         }

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -53,13 +53,27 @@ public sealed partial class SettingsWindow : Window
         UpdateAboutInfo();
         ViewModel.ThemeChanged += ApplyTheme;
         ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        RootGrid.Loaded += OnRootGridLoaded;
         Closed += OnClosed;
+    }
+
+    // Runs after the first layout pass, once the controls' initial TwoWay binding
+    // write-backs have settled. Re-syncs the view model from persisted storage so the
+    // fields show real values, then re-applies anything that depends on them.
+    private void OnRootGridLoaded(object sender, RoutedEventArgs e)
+    {
+        RootGrid.Loaded -= OnRootGridLoaded;
+        ViewModel.CompleteInitialization();
+        ApplyTheme();
+        UpdateMouseClickPreview();
+        UpdateGifMouseClickPreview();
     }
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
         ViewModel.ThemeChanged -= ApplyTheme;
         ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        RootGrid.Loaded -= OnRootGridLoaded;
         Closed -= OnClosed;
     }
 


### PR DESCRIPTION
## Problem

In the installed (packaged) app, opening **Settings** showed **blank fields** (Appearance/theme, Save location, File name template, screenshot and some video options, microphone) and choices **silently reset** on every reopen — e.g. set a theme, close Settings, reopen, and it's wrong/empty.

## Root cause

The `SettingsViewModel` only suppressed persistence during the constructor's `Load()` (the `_loading` flag), which finishes **before** `InitializeComponent()` wires up the XAML. As the WinUI controls were realized, their **TwoWay `x:Bind` targets pushed their transient initial values back into the source** — `ComboBox.SelectedIndex` → `-1` (blank), empty `TextBox.Text`, default `ToggleSwitch.IsOn` — and the change handlers happily **persisted that garbage** over the just-loaded settings. So the store got corrupted on open and the UI showed blanks.

(The Hotkeys fields were unaffected because they're computed read-only display strings, which is why those kept showing.)

## Fix

- Added a `_ready` gate. `Persist(...)` and the manual `OnThemeIndexChanged` / `OnLaunchAtLoginChanged` handlers now no-op until the window signals it's ready, so the controls' initial binding write-backs can't corrupt or persist anything.
- The window calls `ViewModel.CompleteInitialization()` from `RootGrid.Loaded` (after the first layout/binding pass), which re-syncs the view model from the still-intact persisted values and then unlocks persistence. Theme + mouse-click previews are re-applied at the same point.
- `Load()` now heals an already-empty file name template back to the default (`TinyClips {date} at {time}`) so users whose template was blanked by the old behavior recover automatically.

## Testing

- `dotnet build windows/src/TinyClips.App` (Release, x64, framework-dependent) — 0 warnings / 0 errors.
- `dotnet test windows/tests/TinyClips.Core.Tests` — **25 passed**.
- Manual: open Settings → all fields show real values; change theme/template/toggles → close → reopen → values persist correctly.