### PR TITLE
Improve Windows video/GIF recording indicator timing

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,12 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Recording overlays now appear immediately after countdown for video/GIF** — the red capture border and stop controls are shown before the recorder start call, so recording UI no longer appears late after capture has already begun.
+- **"Show in Explorer after save" is now respected in all finalize paths** — post-trim and direct video/GIF finalization only reveal files in Explorer when the setting is enabled.
+- **Stop panel is now visible during countdown but safely disabled** — for video/GIF captures with countdown enabled, the recording panel appears immediately with Stop disabled, then enables once recording actually starts.
+- **Recording panel now prefers positioning above the selected region** — when there is space, the stop panel appears above the red region box; it falls back below or clamped in-view placement when needed.
+
 ## [v1.0.7-windows] - 2026-06-16
 
 ### Fixed

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -347,6 +347,14 @@ public partial class App : Application
                 return;
             }
 
+            var showDisabledStopDuringCountdown = type is CaptureType.Video or CaptureType.Gif
+                && pick.CountdownEnabled
+                && pick.CountdownDuration > 0;
+            if (showDisabledStopDuringCountdown)
+            {
+                ShowRecordingIndicator(type, selection, stopEnabled: false, startTimer: false);
+            }
+
             RegionIndicatorWindow? regionIndicator = null;
             if (pick.CountdownEnabled && pick.CountdownDuration > 0)
             {
@@ -385,19 +393,27 @@ public partial class App : Application
                     break;
 
                 case CaptureType.Video:
-                    await Services.GetRequiredService<IVideoRecordingService>().StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes);
                     _activeRecordingSelection = selection;
                     ShowRecordingRegionIndicator(selection);
+                    if (!showDisabledStopDuringCountdown)
+                    {
+                        ShowRecordingIndicator(CaptureType.Video, selection);
+                    }
+                    await Services.GetRequiredService<IVideoRecordingService>().StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes);
+                    ActivateRecordingIndicatorForStartedCapture();
                     UpdateRecordingState();
-                    ShowRecordingIndicator(CaptureType.Video, selection);
                     break;
 
                 case CaptureType.Gif:
-                    await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
                     _activeRecordingSelection = selection;
                     ShowRecordingRegionIndicator(selection);
+                    if (!showDisabledStopDuringCountdown)
+                    {
+                        ShowRecordingIndicator(CaptureType.Gif, selection);
+                    }
+                    await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
+                    ActivateRecordingIndicatorForStartedCapture();
                     UpdateRecordingState();
-                    ShowRecordingIndicator(CaptureType.Gif, selection);
                     break;
             }
         }
@@ -714,11 +730,9 @@ public partial class App : Application
         window?.ClosePanel();
     }
 
-    private void ShowRecordingIndicator(CaptureType type, TargetSelection selection)
+    private void ShowRecordingIndicator(CaptureType type, TargetSelection selection, bool stopEnabled = true, bool startTimer = true)
     {
         HideRecordingIndicator();
-
-        _recordingStartedUtc = DateTime.UtcNow;
 
         var hotKeys = Services.GetRequiredService<IHotKeyService>();
         var settings = Services.GetRequiredService<ICaptureSettings>();
@@ -742,6 +756,7 @@ public partial class App : Application
 
         _recordingIndicator = window;
         window.UpdateElapsed(TimeSpan.Zero);
+        window.SetStopEnabled(stopEnabled);
 
         var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
         PixelRect? region = null;
@@ -751,6 +766,23 @@ public partial class App : Application
         }
         window.ShowNear(monitor, region);
 
+        if (startTimer)
+        {
+            _recordingStartedUtc = DateTime.UtcNow;
+            StartRecordingTimer();
+        }
+    }
+
+    private void ActivateRecordingIndicatorForStartedCapture()
+    {
+        _recordingStartedUtc = DateTime.UtcNow;
+        _recordingIndicator?.SetStopEnabled(true);
+        StartRecordingTimer();
+    }
+
+    private void StartRecordingTimer()
+    {
+        StopRecordingTimer();
         _recordingTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _recordingTimer.Tick += OnRecordingTimerTick;
         _recordingTimer.Start();
@@ -826,7 +858,11 @@ public partial class App : Application
     private async Task FinalizeClipAsync(string path, CaptureType type)
     {
         await CopyToClipboardAsync(path, type);
-        RevealInExplorer(path);
+        var settings = Services.GetRequiredService<ICaptureSettings>();
+        if (settings.ShowInExplorer)
+        {
+            RevealInExplorer(path);
+        }
         ShowSaveToast(path);
     }
 

--- a/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class RecordingIndicatorWindow : Window
     private const int WidthDip = 320;
     private const int HeightDip = 64;
     private const int TopOffsetDip = 24;
+    private const int RegionOutsideOffsetDip = 12;
 
     private const uint WdaExcludeFromCapture = 0x11;
 
@@ -92,6 +93,11 @@ public sealed partial class RecordingIndicatorWindow : Window
 
         var totalMinutes = (int)Math.Min(99, elapsed.TotalMinutes);
         ElapsedText.Text = $"{totalMinutes:00}:{elapsed.Seconds:00}";
+    }
+
+    public void SetStopEnabled(bool enabled)
+    {
+        StopButton.IsEnabled = enabled && !_stopRequested;
     }
 
     public void ClosePanel()
@@ -228,6 +234,7 @@ public sealed partial class RecordingIndicatorWindow : Window
         var width = (int)Math.Round(WidthDip * scale);
         var height = (int)Math.Round(HeightDip * scale);
         var topOffset = (int)Math.Round(TopOffsetDip * scale);
+        var regionOutsideOffset = (int)Math.Round(RegionOutsideOffsetDip * scale);
 
         AppWindow.Resize(new SizeInt32(width, height));
 
@@ -239,7 +246,20 @@ public sealed partial class RecordingIndicatorWindow : Window
             if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
             {
                 x = region.X + Math.Max(0, (region.Width - width) / 2);
-                y = region.Y + topOffset;
+                var preferredAbove = region.Y - height - regionOutsideOffset;
+                var preferredBelow = region.Y + region.Height + regionOutsideOffset;
+                if (preferredAbove >= work.Y)
+                {
+                    y = preferredAbove;
+                }
+                else if (preferredBelow <= work.Y + Math.Max(0, work.Height - height))
+                {
+                    y = preferredBelow;
+                }
+                else
+                {
+                    y = region.Y + topOffset;
+                }
             }
 
             x = Math.Clamp(x, work.X, work.X + Math.Max(0, work.Width - width));


### PR DESCRIPTION
This improves the Windows recording flow so the UI matches user expectations during countdown and region capture.

For video and GIF captures with countdown enabled, the recording indicator now appears immediately in a disabled state, then enables Stop and starts elapsed timing only after recording actually starts. This keeps the user informed during countdown without allowing premature stop actions.

It also refines recording panel placement for region captures by preferring a position above the selected region box when space allows, with safe fallbacks below or clamped in-view when needed.

Additionally, Explorer reveal behavior remains governed by settings from the prior update, and the Windows changelog was updated to document these recording UX improvements.