### PR TITLE
Restore WinGet user scope

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -266,12 +266,12 @@ jobs:
           # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
           # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
           # they are declared below as winget package dependencies so winget installs them before
-          # the app (and the Windows App SDK runtime is also auto-acquired by the OS Store).
+          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
+          # scope, and forcing user scope makes winget reject them during validation.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
           InstallerType: msix
-          Scope: user
           InstallModes:
             - silent
             - silentWithProgress

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -91,12 +91,12 @@ jobs:
           # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
           # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
           # they are declared below as winget package dependencies so winget installs them before
-          # the app (and the Windows App SDK runtime is also auto-acquired by the OS Store).
+          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
+          # scope, and forcing user scope makes winget reject them during validation.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
           InstallerType: msix
-          Scope: user
           InstallModes:
             - silent
             - silentWithProgress

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,10 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Fixed
+- **winget dependency installation no longer forces user scope** — removed `Scope: user` from the
+  installer manifest generated for winget submissions. The app MSIX still installs per-user, but
+  the .NET Desktop Runtime and Windows App Runtime dependency packages use machine/unknown-scope
+  installers; forcing user scope made winget validation reject them with "No suitable installer found."
 - **Recording overlays now appear immediately after countdown for video/GIF** — the red capture border and stop controls are shown before the recorder start call, so recording UI no longer appears late after capture has already begun.
 - **"Show in Explorer after save" is now respected in all finalize paths** — post-trim and direct video/GIF finalization only reveal files in Explorer when the setting is enabled.
 - **Stop panel is now visible during countdown but safely disabled** — for video/GIF captures with countdown enabled, the recording panel appears immediately with Stop disabled, then enables once recording actually starts.
@@ -77,8 +81,7 @@ own `CHANGELOG.md` at the repository root.
   AppxManifest. That runtime is missing on winget's clean, network-isolated validation VMs, so
   installation failed there (it succeeded locally only because the runtime was already present).
   The winget installer manifest now declares `Microsoft.WindowsAppRuntime.1.8` under
-  `Dependencies.PackageDependencies`, so winget installs the runtime first on any clean machine.
->>>>>>> origin/main
+  `  Dependencies.PackageDependencies`, so winget installs the runtime first on any clean machine.
 - **Installed MSIX no longer crashes on startup** — the winget/MSIX build was switched to
   self-contained packaging to clear winget validation, but the resulting package shipped an
   AppxManifest with **no** WinRT activation registrations. On a clean machine (without the

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -75,6 +75,10 @@ On a normal Windows machine (with the Store/App Installer) that does not yet hav
 `Microsoft.WindowsAppRuntime.1.8` first, then the app. A pass is the app process running with the
 tray icon present and no `.NET Desktop Runtime` prompt.
 
+Do not add `Scope: user` to the installer manifest. The TinyClips MSIX installs per-user by
+default, but the runtime dependency installers are machine-scope/unknown-scope packages; forcing
+user scope causes winget validation to reject those dependencies with "No suitable installer found."
+
 ```pwsh
 # Build a framework-dependent, packaged MSIX (x64)
 dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 # Installer manifest for the signed, framework-dependent MSIX produced by `winapp pack`.
 # The package does not bundle the .NET or Windows App SDK runtimes; they are declared below
-# as winget package dependencies so winget installs them before the app.
+# as winget package dependencies so winget installs them before the app. Do not set Scope:
+# the dependency installers are machine-scope/unknown scope, and forcing user scope makes
+# winget reject them during validation.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
 #   winget hash --msix <path-to-msix>
@@ -9,7 +11,6 @@ PackageIdentifier: Refractored.TinyClips
 PackageVersion: 1.0.0.0
 MinimumOSVersion: 10.0.22000.0
 InstallerType: msix
-Scope: user
 InstallModes:
   - silent
   - silentWithProgress


### PR DESCRIPTION
WinGet package consistency checks compare new submissions against the already-published TinyClips manifest, and version 1.0.5.0 includes `Scope: user`. Removing it from the generated 1.0.7.0 manifest caused a `Missing property Scope` inconsistency, so this restores the user scope in the WinGet generation paths and packaging template.

The earlier dependency installer failure was confirmed to be on the WinGet validation side, so we should keep the manifest scope aligned with the published package history.

Validation:
- `winget validate --manifest windows\packaging\winget`
- `git diff --check`