### PR TITLE
Restore WinGet user scope

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -266,12 +266,12 @@ jobs:
           # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
           # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
           # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # the app (and the Windows App SDK runtime is also auto-acquired by the OS Store).
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
           InstallerType: msix
+          Scope: user
           InstallModes:
             - silent
             - silentWithProgress

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -91,12 +91,12 @@ jobs:
           # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
           # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
           # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # the app (and the Windows App SDK runtime is also auto-acquired by the OS Store).
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
           InstallerType: msix
+          Scope: user
           InstallModes:
             - silent
             - silentWithProgress

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,10 +6,6 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Fixed
-- **winget dependency installation no longer forces user scope** — removed `Scope: user` from the
-  installer manifest generated for winget submissions. The app MSIX still installs per-user, but
-  the .NET Desktop Runtime and Windows App Runtime dependency packages use machine/unknown-scope
-  installers; forcing user scope made winget validation reject them with "No suitable installer found."
 - **Recording overlays now appear immediately after countdown for video/GIF** — the red capture border and stop controls are shown before the recorder start call, so recording UI no longer appears late after capture has already begun.
 - **"Show in Explorer after save" is now respected in all finalize paths** — post-trim and direct video/GIF finalization only reveal files in Explorer when the setting is enabled.
 - **Stop panel is now visible during countdown but safely disabled** — for video/GIF captures with countdown enabled, the recording panel appears immediately with Stop disabled, then enables once recording actually starts.

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -75,10 +75,6 @@ On a normal Windows machine (with the Store/App Installer) that does not yet hav
 `Microsoft.WindowsAppRuntime.1.8` first, then the app. A pass is the app process running with the
 tray icon present and no `.NET Desktop Runtime` prompt.
 
-Do not add `Scope: user` to the installer manifest. The TinyClips MSIX installs per-user by
-default, but the runtime dependency installers are machine-scope/unknown-scope packages; forcing
-user scope causes winget validation to reject those dependencies with "No suitable installer found."
-
 ```pwsh
 # Build a framework-dependent, packaged MSIX (x64)
 dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 # Installer manifest for the signed, framework-dependent MSIX produced by `winapp pack`.
 # The package does not bundle the .NET or Windows App SDK runtimes; they are declared below
-# as winget package dependencies so winget installs them before the app. Do not set Scope:
-# the dependency installers are machine-scope/unknown scope, and forcing user scope makes
-# winget reject them during validation.
+# as winget package dependencies so winget installs them before the app.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
 #   winget hash --msix <path-to-msix>
@@ -11,6 +9,7 @@ PackageIdentifier: Refractored.TinyClips
 PackageVersion: 1.0.0.0
 MinimumOSVersion: 10.0.22000.0
 InstallerType: msix
+Scope: user
 InstallModes:
   - silent
   - silentWithProgress


### PR DESCRIPTION
WinGet package consistency checks compare new submissions against the already-published TinyClips manifest, and version 1.0.5.0 includes `Scope: user`. The prior PR was merged after removing the property, which leaves future generated manifests vulnerable to the `Missing property Scope` inconsistency.

This restores `Scope: user` in both WinGet manifest generation paths and the packaging template, and removes the now-incorrect documentation/changelog note about omitting the scope. The WinGet validation dependency failure was confirmed to be on the service side, so the manifest should stay aligned with the published package history.

Validation:
- `winget validate --manifest windows\packaging\winget`
- `git diff --check`