### PR TITLE
Clarify Homebrew tap trust setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ video (MP4), and animated GIFs of a selected screen region — on **macOS** and 
 **Homebrew**
 
 ```bash
-brew tap jamesmontemagno/tiny-clips
+brew tap jamesmontemagno/tiny-clips https://github.com/jamesmontemagno/tiny-clips
+brew trust jamesmontemagno/tiny-clips 2>/dev/null || true
 brew install --cask tiny-clips
 ```
+
+The `brew trust` line is only needed on Homebrew versions that require trust for non-official taps; it safely no-ops elsewhere.
 
 **Download**
 


### PR DESCRIPTION
Adds explicit repo URL usage for the repo-local Homebrew tap and documents the optional `brew trust` step required by newer Homebrew trust settings for non-official taps.

This mirrors the install guidance we added for ResizeMe so users can copy/paste a command sequence that works across Homebrew versions.