### PR TITLE
Fix mac Sparkle appcast metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,11 @@ jobs:
             TAG="${{ github.ref_name }}"
           fi
 
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){2,3}$ ]]; then
+            echo "macOS release tags must look like v1.2.3 or v1.2.3.4. Got '$TAG'."
+            exit 1
+          fi
+
           VERSION="${TAG#v}"
           BUILD_NUMBER="${{ github.run_number }}"
 
@@ -214,7 +219,7 @@ jobs:
       - name: Generate Changelog
         run: |
           git fetch --tags --force
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | grep -vx "${{ env.RELEASE_TAG }}" | head -n 1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+(\.[0-9]+){2,3}$' | grep -vx "${{ env.RELEASE_TAG }}" | head -n 1)
           export PREVIOUS_TAG
           echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
 

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -11,24 +11,24 @@
         <item>
             
             
-            <title>1.0.0-windows</title>
+            <title>1.4.0.3</title>
             
             
-            <pubDate>Mon, 15 Jun 2026 20:22:15 +0000</pubDate>
+            <pubDate>Wed, 27 May 2026 21:16:33 +0000</pubDate>
             
             
-            <sparkle:version>36</sparkle:version>
+            <sparkle:version>35</sparkle:version>
             
             
-            <sparkle:shortVersionString>1.0.0-windows</sparkle:shortVersionString>
+            <sparkle:shortVersionString>1.4.0.3</sparkle:shortVersionString>
             
             
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             
             
-            <description><![CDATA[<h3>What's Changed</h3><ul><li>Prepare Windows winget release</li></ul><p><a href="https://github.com/jamesmontemagno/tiny-clips/compare/v1.4.0.3...v1.0.0-windows">Full Changelog</a></p>]]></description>
-            <sparkle:releaseNotesLink>https://github.com/jamesmontemagno/tiny-clips/releases/tag/v1.0.0-windows</sparkle:releaseNotesLink>
-            <enclosure url="https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-v1.0.0-windows.zip" length="3296567" type="application/octet-stream" sparkle:edSignature="SOOBifbUTJKIstzbkVf/kPBVN8LlOtRSh3GcbSb+bhllzEKP+HLwwoRx6ziGyNnu1u0LTBJrx5lUbAHU8YQzAg=="/>
+            <description><![CDATA[<h3>What's Changed</h3><ul><li>chore: update CHANGELOG for v1.4.0.3 release</li></ul><p><a href="https://github.com/jamesmontemagno/tiny-clips/compare/v1.4.0.2...v1.4.0.3">Full Changelog</a></p>]]></description>
+            <sparkle:releaseNotesLink>https://github.com/jamesmontemagno/tiny-clips/releases/tag/v1.4.0.3</sparkle:releaseNotesLink>
+            <enclosure url="https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.4.0.3/TinyClips-v1.4.0.3.zip" length="3151026" type="application/octet-stream" sparkle:edSignature="Jwt6HMMjj0If94hOmbGqWS7xu5Zfe+nLD31VzgcEYwDoCC2ezMMPY/9jh5RAUYVasWkGBS4zw/QWqSbnZUcLAg=="/>
             
         
         </item>


### PR DESCRIPTION
## Summary
Fixes the mac Sparkle appcast after a Windows release tag was published as the latest mac update.

## Issue
Mac users could hit Sparkle's generic update error while checking for updates. The feed itself was wrong: `docs/appcast.xml` advertised `1.0.0-windows` as the latest mac release.

That happened because the mac release workflow accepted a tag like `v1.0.0-windows`, generated release metadata from it, and committed that metadata back to the appcast.

![Sparkle Update Error](https://gist.githubusercontent.com/ericchernuka/55c058cbf38d7173b16d7dcd074b813e/raw/tinyclips-update-error.svg)

## Fix
- Restores `docs/appcast.xml` to the latest valid mac release: `1.4.0.3` / Sparkle build `35`.
- Rejects non-mac release tags before the mac workflow writes version metadata.
- Filters changelog lookup to mac release tags so Windows tags do not become the previous mac release.

## Validation
- Parsed `.github/workflows/release.yml` as YAML.
- Parsed `docs/appcast.xml` and confirmed it points to `1.4.0.3`, Sparkle build `35`, and the `v1.4.0.3` zip.
- Checked the tag regex accepts `v1.2.3` and `v1.2.3.4`, and rejects `v1.0.0-windows`.
- Ran `git diff --check`.
