### PR TITLE
Align Windows recording setup flow

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,12 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Improved
+- **Video/GIF recording now matches the macOS target-first setup flow** — after choosing Region,
+  Screen, or Window, Windows now shows a pre-record panel before countdown. Video captures can pick
+  system audio, microphone on/off, the microphone device defaulting to Settings, mouse-click visuals,
+  and the recording time limit; GIF captures keep the no-audio setup with mouse-click visuals.
+
 ### Fixed
 - **Settings now opens immediately while microphones load in the background** — microphone device enumeration is now asynchronous, and the microphone picker shows a loading spinner until devices are ready instead of blocking the settings window during startup.
 - **Picker overlays now match the tray popup shell style** — capture, screen, window, and countdown picker windows now use the same context-menu presenter behavior, 8px rounded window clipping, and filled popup surface treatment as the tray popup, making corners/backgrounds visually consistent.

--- a/windows/README.md
+++ b/windows/README.md
@@ -15,10 +15,11 @@ A native **WinUI 3 / Windows App SDK** port of Tiny Clips — a tray-based scree
 ## Features
 
 - **Capture picker** — choose **Region**, **Screen**, or **Window** (R / S / W) before any capture,
-  mirroring the macOS picker, with an inline pre-capture countdown.
+  mirroring the macOS picker. Video/GIF captures then show a pre-record setup panel before countdown.
 - **Screenshot** (PNG/JPEG, scale, quality) — full screen, a specific window, or a drag-selected **region**.
   The region selector shows a live snapshot of the screen and dims only outside the selection.
-- **Video recording** → hardware-accelerated **H.264 MP4** (configurable frame rate, time limit).
+- **Video recording** → hardware-accelerated **H.264 MP4** (configurable frame rate, audio sources,
+  microphone device, mouse-click visuals, and time limit before each recording).
 - **GIF recording** → animated GIF (frame rate, max-width downscale, infinite loop).
 - **Recording indicator** — a floating always-on-top panel shows the elapsed time and a Stop button
   (with the stop hotkey) while recording.
@@ -87,8 +88,9 @@ dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform
 The app launches **tray-only** (no window). Left- or right-click the tray icon for the Fluent
 menu: **Screenshot**, **Capture Region**, **Record Video**, **Record GIF**, **Settings**,
 **Guide**, **Exit**. Capture items first show the **Region / Screen / Window** picker.
-Recording items toggle to **Stop Recording** (also `Ctrl+Shift+S`) while active, and a floating
-recording indicator shows the elapsed time. Global hotkeys work app-wide.
+Video/GIF captures then show a setup panel before countdown and recording. Recording items toggle
+to **Stop Recording** (also `Ctrl+Shift+S`) while active, and a floating recording indicator shows
+the elapsed time. Global hotkeys work app-wide.
 
 For coordinate/DPI behaviour across mixed-DPI monitors, see
 [`docs/dpi-and-coordinates.md`](docs/dpi-and-coordinates.md).

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -345,6 +345,19 @@ public partial class App : Application
                 return;
             }
 
+            RecordingSetupResult? recordingSetup = null;
+            if (type is CaptureType.Video or CaptureType.Gif)
+            {
+                recordingSetup = await ShowRecordingSetupAsync(type, selection, settings);
+                if (recordingSetup is null)
+                {
+                    CloseRecordingRegionIndicator();
+                    return;
+                }
+
+                ApplyRecordingSetup(type, recordingSetup, settings);
+            }
+
             var showDisabledStopDuringCountdown = type is CaptureType.Video or CaptureType.Gif
                 && pick.CountdownEnabled
                 && pick.CountdownDuration > 0;
@@ -358,7 +371,9 @@ public partial class App : Application
             {
                 try
                 {
-                    if (selection.Region is { } region)
+                    var recordingRegionAlreadyShown = type is CaptureType.Video or CaptureType.Gif
+                        && _recordingRegionIndicator is not null;
+                    if (selection.Region is { } region && !recordingRegionAlreadyShown)
                     {
                         regionIndicator = new RegionIndicatorWindow();
                         regionIndicator.Show(ToVirtualDesktopRegion(selection.Target, region));
@@ -397,7 +412,7 @@ public partial class App : Application
                     {
                         ShowRecordingIndicator(CaptureType.Video, selection);
                     }
-                    await Services.GetRequiredService<IVideoRecordingService>().StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes);
+                    await Services.GetRequiredService<IVideoRecordingService>().StartAsync(selection.Target, selection.Region, recordingSetup?.VideoTimeLimitMinutes);
                     ActivateRecordingIndicatorForStartedCapture();
                     UpdateRecordingState();
                     break;
@@ -415,6 +430,7 @@ public partial class App : Application
                     break;
             }
         }
+
         catch (Exception ex)
         {
             Debug.WriteLine($"Capture failed: {ex}");
@@ -423,6 +439,44 @@ public partial class App : Application
             _activeRecordingSelection = null;
             HideRecordingIndicatorIfNotRecording();
         }
+    }
+
+    private async Task<RecordingSetupResult?> ShowRecordingSetupAsync(CaptureType type, TargetSelection selection, ICaptureSettings settings)
+    {
+        PixelRect? region = null;
+        if (selection.Region is { } selectedRegion)
+        {
+            region = ToVirtualDesktopRegion(selection.Target, selectedRegion);
+            if (settings.ShowRegionIndicator)
+            {
+                ShowRecordingRegionIndicator(selection);
+            }
+        }
+
+        var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+        var audioDevices = Services.GetRequiredService<IAudioDeviceService>();
+        var result = await RecordingSetupWindow.RunAsync(type, settings, audioDevices, monitor, region);
+        if (result is null)
+        {
+            CloseRecordingRegionIndicator();
+        }
+
+        return result;
+    }
+
+    private static void ApplyRecordingSetup(CaptureType type, RecordingSetupResult setup, ICaptureSettings settings)
+    {
+        settings.SetShowMouseClickVisuals(setup.ShowMouseClicks, type);
+
+        if (type != CaptureType.Video)
+        {
+            return;
+        }
+
+        settings.RecordAudio = setup.RecordSystemAudio;
+        settings.RecordMicrophone = setup.RecordMicrophone;
+        settings.SelectedMicrophoneId = setup.SelectedMicrophoneId;
+        settings.VideoRecordingTimeLimitMinutes = setup.VideoTimeLimitMinutes;
     }
 
     private async Task<TargetSelection?> ResolveTargetAsync(CapturePickerMode mode)
@@ -734,15 +788,8 @@ public partial class App : Application
 
         var hotKeys = Services.GetRequiredService<IHotKeyService>();
         var settings = Services.GetRequiredService<ICaptureSettings>();
-        var showAudioControls = type == CaptureType.Video;
-        var window = new RecordingIndicatorWindow(
-            hotKeys.StopRecordingDisplayString,
-            showAudioControls,
-            settings.RecordMicrophone,
-            settings.RecordAudio);
+        var window = new RecordingIndicatorWindow(hotKeys.StopRecordingDisplayString);
         window.StopRequested = () => _ = StopActiveRecordingAsync();
-        window.MicrophoneToggled = on => settings.RecordMicrophone = on;
-        window.SystemAudioToggled = on => settings.RecordAudio = on;
         window.Closed += (_, _) =>
         {
             if (ReferenceEquals(_recordingIndicator, window))

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -447,21 +447,27 @@ public partial class App : Application
         if (selection.Region is { } selectedRegion)
         {
             region = ToVirtualDesktopRegion(selection.Target, selectedRegion);
-            if (settings.ShowRegionIndicator)
+            RegionIndicatorWindow? setupRegionIndicator = null;
+            try
             {
-                ShowRecordingRegionIndicator(selection);
+                if (settings.ShowRegionIndicator)
+                {
+                    setupRegionIndicator = ShowRegionIndicator(selection);
+                }
+
+                var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+                var audioDevices = Services.GetRequiredService<IAudioDeviceService>();
+                return await RecordingSetupWindow.RunAsync(type, settings, audioDevices, monitor, region);
+            }
+            finally
+            {
+                setupRegionIndicator?.ClosePanel();
             }
         }
 
-        var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
-        var audioDevices = Services.GetRequiredService<IAudioDeviceService>();
-        var result = await RecordingSetupWindow.RunAsync(type, settings, audioDevices, monitor, region);
-        if (result is null)
-        {
-            CloseRecordingRegionIndicator();
-        }
-
-        return result;
+        var setupMonitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+        var setupAudioDevices = Services.GetRequiredService<IAudioDeviceService>();
+        return await RecordingSetupWindow.RunAsync(type, settings, setupAudioDevices, setupMonitor, region);
     }
 
     private static void ApplyRecordingSetup(CaptureType type, RecordingSetupResult setup, ICaptureSettings settings)
@@ -746,13 +752,13 @@ public partial class App : Application
 
     private void ShowRecordingRegionIndicator(TargetSelection selection)
     {
-        if (selection.Region is not { } region)
+        if (selection.Region is null)
         {
             return;
         }
 
         CloseRecordingRegionIndicator();
-        var indicator = new RegionIndicatorWindow();
+        var indicator = ShowRegionIndicator(selection)!;
         _recordingRegionIndicator = indicator;
         indicator.Closed += (_, _) =>
         {
@@ -761,7 +767,18 @@ public partial class App : Application
                 _recordingRegionIndicator = null;
             }
         };
+    }
+
+    private RegionIndicatorWindow? ShowRegionIndicator(TargetSelection selection)
+    {
+        if (selection.Region is not { } region)
+        {
+            return null;
+        }
+
+        var indicator = new RegionIndicatorWindow();
         indicator.Show(ToVirtualDesktopRegion(selection.Target, region));
+        return indicator;
     }
 
     private void CloseRecordingRegionIndicatorIfNotRecording()

--- a/windows/src/TinyClips.App/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/CapturePickerWindow.xaml.cs
@@ -66,13 +66,7 @@ public sealed partial class CapturePickerWindow : Window
         BuildTimerFlyout();
         UpdateTimerLabel();
 
-        // Only video supports an auto-stop time limit.
-        if (captureType == CaptureType.Video)
-        {
-            LimitButton.Visibility = Visibility.Visible;
-            BuildLimitFlyout();
-            UpdateLimitLabel();
-        }
+        LimitButton.Visibility = Visibility.Collapsed;
 
         ConfigurePresenter();
 

--- a/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml
+++ b/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml
@@ -53,49 +53,15 @@
                         Text="Stop from tray" />
                 </StackPanel>
 
-                <StackPanel
+                <Button
+                    x:Name="StopButton"
                     Grid.Column="2"
-                    Orientation="Horizontal"
-                    VerticalAlignment="Center"
-                    Spacing="6">
-
-                    <ToggleButton
-                        x:Name="MicToggle"
-                        Width="32"
-                        Height="32"
-                        MinWidth="0"
-                        Padding="0"
-                        AutomationProperties.AutomationId="ToggleMicrophoneButton"
-                        AutomationProperties.Name="Microphone"
-                        Checked="OnMicToggled"
-                        Unchecked="OnMicToggled"
-                        ToolTipService.ToolTip="Microphone (for the next recording)">
-                        <FontIcon x:Name="MicIcon" FontSize="14" Glyph="&#xE720;" />
-                    </ToggleButton>
-
-                    <ToggleButton
-                        x:Name="SystemAudioToggle"
-                        Width="32"
-                        Height="32"
-                        MinWidth="0"
-                        Padding="0"
-                        AutomationProperties.AutomationId="ToggleSystemAudioButton"
-                        AutomationProperties.Name="System audio"
-                        Checked="OnSystemAudioToggled"
-                        Unchecked="OnSystemAudioToggled"
-                        ToolTipService.ToolTip="System audio (for the next recording)">
-                        <FontIcon x:Name="SystemAudioIcon" FontSize="14" Glyph="&#xE767;" />
-                    </ToggleButton>
-
-                    <Button
-                        x:Name="StopButton"
-                        AutomationProperties.AutomationId="StopRecordingButton"
-                        AutomationProperties.Name="Stop recording"
-                        Click="OnStopClick"
-                        Content="Stop"
-                        Style="{StaticResource AccentButtonStyle}"
-                        ToolTipService.ToolTip="Stop recording" />
-                </StackPanel>
+                    AutomationProperties.AutomationId="StopRecordingButton"
+                    AutomationProperties.Name="Stop recording"
+                    Click="OnStopClick"
+                    Content="Stop"
+                    Style="{StaticResource AccentButtonStyle}"
+                    ToolTipService.ToolTip="Stop recording" />
             </Grid>
         </Border>
     </Grid>

--- a/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RecordingIndicatorWindow.xaml.cs
@@ -14,26 +14,21 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class RecordingIndicatorWindow : Window
 {
-    private const int WidthDip = 320;
+    private const int WidthDip = 260;
     private const int HeightDip = 64;
     private const int TopOffsetDip = 24;
     private const int RegionOutsideOffsetDip = 12;
 
     private const uint WdaExcludeFromCapture = 0x11;
 
-    private const string MicGlyph = "\uE720";
-    private const string SystemAudioOnGlyph = "\uE767";
-    private const string SystemAudioOffGlyph = "\uE74F";
-
     private bool _stopRequested;
     private bool _closed;
-    private bool _suppressAudioEvents;
 
     private bool _dragging;
     private POINT _dragCursorStart;
     private PointInt32 _dragWindowStart;
 
-    public RecordingIndicatorWindow(string stopHint, bool showAudioControls, bool micOn, bool systemAudioOn)
+    public RecordingIndicatorWindow(string stopHint)
     {
         InitializeComponent();
 
@@ -41,32 +36,11 @@ public sealed partial class RecordingIndicatorWindow : Window
             ? "Stop from tray"
             : $"Stop: {stopHint}";
 
-        if (showAudioControls)
-        {
-            _suppressAudioEvents = true;
-            MicToggle.IsChecked = micOn;
-            SystemAudioToggle.IsChecked = systemAudioOn;
-            _suppressAudioEvents = false;
-            UpdateMicVisual(micOn);
-            UpdateSystemAudioVisual(systemAudioOn);
-        }
-        else
-        {
-            MicToggle.Visibility = Visibility.Collapsed;
-            SystemAudioToggle.Visibility = Visibility.Collapsed;
-        }
-
         ConfigurePresenter();
         Closed += OnClosed;
     }
 
     public Action? StopRequested { get; set; }
-
-    /// <summary>Raised when the microphone toggle changes; persists the default for the next recording.</summary>
-    public Action<bool>? MicrophoneToggled { get; set; }
-
-    /// <summary>Raised when the system-audio toggle changes; persists the default for the next recording.</summary>
-    public Action<bool>? SystemAudioToggled { get; set; }
 
     public void ShowNear()
     {
@@ -125,48 +99,6 @@ public sealed partial class RecordingIndicatorWindow : Window
         var callback = StopRequested;
         StopRequested = null;
         callback?.Invoke();
-    }
-
-    private void OnMicToggled(object sender, RoutedEventArgs e)
-    {
-        var on = MicToggle.IsChecked == true;
-        UpdateMicVisual(on);
-
-        if (_suppressAudioEvents)
-        {
-            return;
-        }
-
-        MicrophoneToggled?.Invoke(on);
-    }
-
-    private void OnSystemAudioToggled(object sender, RoutedEventArgs e)
-    {
-        var on = SystemAudioToggle.IsChecked == true;
-        UpdateSystemAudioVisual(on);
-
-        if (_suppressAudioEvents)
-        {
-            return;
-        }
-
-        SystemAudioToggled?.Invoke(on);
-    }
-
-    private void UpdateMicVisual(bool on)
-    {
-        MicIcon.Glyph = MicGlyph;
-        var state = on ? "On" : "Off";
-        Microsoft.UI.Xaml.Controls.ToolTipService.SetToolTip(MicToggle, $"Microphone: {state} (for the next recording)");
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(MicToggle, $"Microphone {state}");
-    }
-
-    private void UpdateSystemAudioVisual(bool on)
-    {
-        SystemAudioIcon.Glyph = on ? SystemAudioOnGlyph : SystemAudioOffGlyph;
-        var state = on ? "On" : "Off";
-        Microsoft.UI.Xaml.Controls.ToolTipService.SetToolTip(SystemAudioToggle, $"System audio: {state} (for the next recording)");
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(SystemAudioToggle, $"System audio {state}");
     }
 
     // Drag-anywhere support: pressing the Stop button is handled by the Button itself

--- a/windows/src/TinyClips.App/RecordingSetupWindow.xaml
+++ b/windows/src/TinyClips.App/RecordingSetupWindow.xaml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="TinyClips.App.RecordingSetupWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid
+        x:Name="RootGrid"
+        Background="Transparent"
+        KeyDown="OnKeyDown"
+        PointerMoved="OnPointerMoved"
+        PointerPressed="OnPointerPressed"
+        PointerReleased="OnPointerReleased">
+        <Border
+            Padding="12,8"
+            Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Border.Shadow>
+                <ThemeShadow />
+            </Border.Shadow>
+
+            <StackPanel
+                Orientation="Horizontal"
+                Spacing="8"
+                VerticalAlignment="Center">
+                <ToggleButton
+                    x:Name="SystemAudioToggle"
+                    Width="34"
+                    Height="34"
+                    MinWidth="0"
+                    Padding="0"
+                    AutomationProperties.AutomationId="SetupSystemAudioButton"
+                    AutomationProperties.Name="System audio"
+                    Checked="OnSystemAudioToggled"
+                    Unchecked="OnSystemAudioToggled"
+                    ToolTipService.ToolTip="System audio">
+                    <FontIcon x:Name="SystemAudioIcon" FontSize="14" Glyph="&#xE767;" />
+                </ToggleButton>
+
+                <ToggleButton
+                    x:Name="MicrophoneToggle"
+                    Width="34"
+                    Height="34"
+                    MinWidth="0"
+                    Padding="0"
+                    AutomationProperties.AutomationId="SetupMicrophoneButton"
+                    AutomationProperties.Name="Microphone"
+                    Checked="OnMicrophoneToggled"
+                    Unchecked="OnMicrophoneToggled"
+                    ToolTipService.ToolTip="Microphone">
+                    <Grid Width="18" Height="18">
+                        <FontIcon
+                            x:Name="MicrophoneIcon"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            FontSize="14"
+                            Glyph="&#xE720;" />
+                        <Line
+                            x:Name="MicrophoneSlash"
+                            X1="3"
+                            X2="15"
+                            Y1="15"
+                            Y2="3"
+                            Stroke="{ThemeResource TextFillColorPrimaryBrush}"
+                            StrokeEndLineCap="Round"
+                            StrokeThickness="2"
+                            Visibility="Collapsed" />
+                    </Grid>
+                </ToggleButton>
+
+                <Grid x:Name="MicrophonePickerHost" MinWidth="210">
+                    <ComboBox
+                        x:Name="MicrophoneCombo"
+                        MinWidth="210"
+                        AutomationProperties.AutomationId="SetupMicrophoneDeviceCombo"
+                        AutomationProperties.Name="Microphone device"
+                        DisplayMemberPath="Name"
+                        SelectionChanged="OnMicrophoneSelectionChanged" />
+                    <StackPanel
+                        x:Name="MicrophoneLoadingPanel"
+                        Orientation="Horizontal"
+                        Spacing="8"
+                        Visibility="Collapsed">
+                        <ProgressRing
+                            Width="20"
+                            Height="20"
+                            IsActive="True" />
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="Loading..." />
+                    </StackPanel>
+                </Grid>
+
+                <ToggleButton
+                    x:Name="MouseClicksToggle"
+                    Width="34"
+                    Height="34"
+                    MinWidth="0"
+                    Padding="0"
+                    AutomationProperties.AutomationId="SetupMouseClicksButton"
+                    AutomationProperties.Name="Mouse click visuals"
+                    Checked="OnMouseClicksToggled"
+                    Unchecked="OnMouseClicksToggled"
+                    ToolTipService.ToolTip="Mouse click visuals">
+                    <FontIcon
+                        FontFamily="Segoe Fluent Icons"
+                        FontSize="16"
+                        Glyph="&#xE962;" />
+                </ToggleButton>
+
+                <DropDownButton
+                    x:Name="LimitButton"
+                    AutomationProperties.AutomationId="SetupTimeLimitButton"
+                    AutomationProperties.Name="Recording time limit"
+                    ToolTipService.ToolTip="Recording time limit">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="13" Glyph="&#xE823;" />
+                        <TextBlock x:Name="LimitLabel" Text="No limit" />
+                    </StackPanel>
+                    <DropDownButton.Flyout>
+                        <MenuFlyout x:Name="LimitFlyout" />
+                    </DropDownButton.Flyout>
+                </DropDownButton>
+
+                <Rectangle
+                    Width="1"
+                    Height="24"
+                    Margin="2,0"
+                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                <Button
+                    x:Name="StartButton"
+                    AutomationProperties.AutomationId="StartRecordingButton"
+                    AutomationProperties.Name="Start recording"
+                    Click="OnStart"
+                    Style="{StaticResource AccentButtonStyle}"
+                    ToolTipService.ToolTip="Start recording (Enter)">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <Ellipse
+                            Width="10"
+                            Height="10"
+                            Fill="{ThemeResource SystemFillColorCriticalBrush}" />
+                        <TextBlock Text="Record" />
+                    </StackPanel>
+                </Button>
+
+                <Button
+                    x:Name="CancelButton"
+                    Width="34"
+                    Height="34"
+                    MinWidth="0"
+                    Padding="0"
+                    AutomationProperties.AutomationId="CancelRecordingSetupButton"
+                    AutomationProperties.Name="Cancel recording setup"
+                    Click="OnCancel"
+                    ToolTipService.ToolTip="Cancel (Esc)">
+                    <FontIcon FontFamily="Segoe Fluent Icons" FontSize="12" Glyph="&#xE711;" />
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/windows/src/TinyClips.App/RecordingSetupWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RecordingSetupWindow.xaml.cs
@@ -1,0 +1,499 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using TinyClips.Core.Capture;
+using TinyClips.Core.Models;
+using TinyClips.Core.Services;
+using Windows.Graphics;
+using Windows.System;
+using WinRT.Interop;
+
+namespace TinyClips.App;
+
+public sealed record RecordingSetupResult(
+    bool RecordSystemAudio,
+    bool RecordMicrophone,
+    string SelectedMicrophoneId,
+    bool ShowMouseClicks,
+    int VideoTimeLimitMinutes);
+
+/// <summary>
+/// Pre-recording setup panel shown after target selection and before countdown.
+/// </summary>
+public sealed partial class RecordingSetupWindow : Window
+{
+    private static readonly int[] LimitOptions = { 0, 1, 3, 5, 10, 15, 30, 45, 60 };
+
+    private const int TopOffsetDip = 24;
+    private const int RegionOutsideOffsetDip = 12;
+    private const uint WdaExcludeFromCapture = 0x11;
+
+    private const string MicGlyph = "\uE720";
+    private const string SystemAudioOnGlyph = "\uE767";
+    private const string SystemAudioOffGlyph = "\uE74F";
+
+    private readonly TaskCompletionSource<RecordingSetupResult?> _result = new();
+    private readonly CaptureType _captureType;
+    private readonly IAudioDeviceService _audioDevices;
+    private readonly ObservableCollection<AudioInputDevice> _microphones = new();
+
+    private bool _completed;
+    private bool _closed;
+    private bool _suppressEvents;
+    private bool _recordSystemAudio;
+    private bool _recordMicrophone;
+    private string _selectedMicrophoneId;
+    private bool _showMouseClicks;
+    private int _videoTimeLimitMinutes;
+
+    private bool _dragging;
+    private POINT _dragCursorStart;
+    private PointInt32 _dragWindowStart;
+
+    private RecordingSetupWindow(CaptureType captureType, ICaptureSettings settings, IAudioDeviceService audioDevices)
+    {
+        InitializeComponent();
+
+        _captureType = captureType;
+        _audioDevices = audioDevices;
+        _recordSystemAudio = settings.RecordAudio;
+        _recordMicrophone = settings.RecordMicrophone;
+        _selectedMicrophoneId = settings.SelectedMicrophoneId ?? string.Empty;
+        _showMouseClicks = settings.ShouldShowMouseClickVisuals(captureType);
+        _videoTimeLimitMinutes = Math.Max(0, settings.VideoRecordingTimeLimitMinutes);
+
+        MicrophoneCombo.ItemsSource = _microphones;
+        _microphones.Add(new AudioInputDevice(string.Empty, "System default"));
+        MicrophoneCombo.SelectedItem = _microphones[0];
+
+        ConfigurePresenter();
+        ConfigureForCaptureType();
+        BuildLimitFlyout();
+        UpdateVisuals();
+
+        Closed += OnClosed;
+    }
+
+    public static Task<RecordingSetupResult?> RunAsync(
+        CaptureType captureType,
+        ICaptureSettings settings,
+        IAudioDeviceService audioDevices,
+        MonitorInfo? monitor,
+        PixelRect? regionInVirtualDesktop)
+    {
+        var window = new RecordingSetupWindow(captureType, settings, audioDevices);
+        window.ShowNear(monitor, regionInVirtualDesktop);
+        if (captureType == CaptureType.Video)
+        {
+            _ = window.LoadMicrophonesAsync();
+        }
+
+        return window._result.Task;
+    }
+
+    private void ConfigureForCaptureType()
+    {
+        if (_captureType == CaptureType.Gif)
+        {
+            SystemAudioToggle.Visibility = Visibility.Collapsed;
+            MicrophoneToggle.Visibility = Visibility.Collapsed;
+            MicrophonePickerHost.Visibility = Visibility.Collapsed;
+            LimitButton.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private async Task LoadMicrophonesAsync()
+    {
+        SetMicrophoneLoading(true);
+        try
+        {
+            var microphones = await Task.Run(() => _audioDevices.GetMicrophones());
+            if (_closed)
+            {
+                return;
+            }
+
+            ApplyMicrophones(microphones);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Microphone enumeration failed: {ex}");
+            if (_closed)
+            {
+                return;
+            }
+
+            ApplyMicrophones(Array.Empty<AudioInputDevice>());
+        }
+        finally
+        {
+            SetMicrophoneLoading(false);
+        }
+    }
+
+    private void ApplyMicrophones(IReadOnlyList<AudioInputDevice> microphones)
+    {
+        _suppressEvents = true;
+        try
+        {
+            _microphones.Clear();
+            if (microphones.Count == 0)
+            {
+                _microphones.Add(new AudioInputDevice(string.Empty, "System default"));
+            }
+            else
+            {
+                foreach (var microphone in microphones)
+                {
+                    _microphones.Add(microphone);
+                }
+            }
+
+            var selected = _microphones.FirstOrDefault(m => m.Id == _selectedMicrophoneId) ?? _microphones[0];
+            _selectedMicrophoneId = selected.Id;
+            MicrophoneCombo.SelectedItem = selected;
+        }
+        finally
+        {
+            _suppressEvents = false;
+            UpdateMicrophonePickerEnabled();
+        }
+    }
+
+    private void SetMicrophoneLoading(bool loading)
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        MicrophoneLoadingPanel.Visibility = loading ? Visibility.Visible : Visibility.Collapsed;
+        MicrophoneCombo.Visibility = loading ? Visibility.Collapsed : Visibility.Visible;
+        UpdateMicrophonePickerEnabled();
+    }
+
+    private void BuildLimitFlyout()
+    {
+        foreach (var minutes in LimitOptions)
+        {
+            var item = new MenuFlyoutItem { Text = minutes == 0 ? "No limit" : $"{minutes} min" };
+            item.Click += (_, _) =>
+            {
+                _videoTimeLimitMinutes = minutes;
+                UpdateLimitLabel();
+            };
+            LimitFlyout.Items.Add(item);
+        }
+    }
+
+    private void ShowNear(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        PositionNearMonitorWorkArea(monitor, regionInVirtualDesktop);
+        Activate();
+        RootGrid.Focus(FocusState.Programmatic);
+
+        var hwnd = WindowNative.GetWindowHandle(this);
+        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+    }
+
+    private void PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        var scale = GetScale();
+        RootGrid.UpdateLayout();
+        RootGrid.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
+
+        var width = (int)Math.Ceiling(RootGrid.DesiredSize.Width * scale);
+        var height = (int)Math.Ceiling(RootGrid.DesiredSize.Height * scale);
+        var topOffset = (int)Math.Round(TopOffsetDip * scale);
+        var regionOutsideOffset = (int)Math.Round(RegionOutsideOffsetDip * scale);
+
+        AppWindow.Resize(new SizeInt32(width + 2, height + 2));
+
+        if (GetWorkArea(monitor) is not { } work)
+        {
+            return;
+        }
+
+        var x = work.X + Math.Max(0, (work.Width - width) / 2);
+        var y = work.Y + topOffset;
+
+        if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
+        {
+            x = region.X + Math.Max(0, (region.Width - width) / 2);
+            var preferredAbove = region.Y - height - regionOutsideOffset;
+            var preferredBelow = region.Y + region.Height + regionOutsideOffset;
+            if (preferredAbove >= work.Y)
+            {
+                y = preferredAbove;
+            }
+            else if (preferredBelow <= work.Y + Math.Max(0, work.Height - height))
+            {
+                y = preferredBelow;
+            }
+            else
+            {
+                y = region.Y + topOffset;
+            }
+        }
+
+        x = Math.Clamp(x, work.X, work.X + Math.Max(0, work.Width - width));
+        y = Math.Clamp(y, work.Y, work.Y + Math.Max(0, work.Height - height));
+        AppWindow.Move(new PointInt32(x, y));
+    }
+
+    private static RectInt32? GetWorkArea(MonitorInfo? monitor)
+    {
+        if (monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 })
+        {
+            return new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight);
+        }
+
+        return DisplayArea.Primary?.WorkArea;
+    }
+
+    private double GetScale()
+    {
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var dpi = GetDpiForWindow(hwnd);
+        return dpi <= 0 ? 1.0 : dpi / 96.0;
+    }
+
+    private void ConfigurePresenter()
+    {
+        var presenter = OverlappedPresenter.CreateForContextMenu();
+        presenter.IsAlwaysOnTop = true;
+        AppWindow.SetPresenter(presenter);
+        AppWindow.IsShownInSwitchers = false;
+    }
+
+    private void OnSystemAudioToggled(object sender, RoutedEventArgs e)
+    {
+        if (_suppressEvents)
+        {
+            return;
+        }
+
+        _recordSystemAudio = SystemAudioToggle.IsChecked == true;
+        UpdateSystemAudioVisual();
+    }
+
+    private void OnMicrophoneToggled(object sender, RoutedEventArgs e)
+    {
+        if (_suppressEvents)
+        {
+            return;
+        }
+
+        _recordMicrophone = MicrophoneToggle.IsChecked == true;
+        UpdateMicrophoneVisual();
+        UpdateMicrophonePickerEnabled();
+    }
+
+    private void OnMouseClicksToggled(object sender, RoutedEventArgs e)
+    {
+        if (_suppressEvents)
+        {
+            return;
+        }
+
+        _showMouseClicks = MouseClicksToggle.IsChecked == true;
+        UpdateMouseClicksVisual();
+    }
+
+    private void OnMicrophoneSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressEvents)
+        {
+            return;
+        }
+
+        if (MicrophoneCombo.SelectedItem is AudioInputDevice microphone)
+        {
+            _selectedMicrophoneId = microphone.Id;
+        }
+    }
+
+    private void OnStart(object sender, RoutedEventArgs e)
+    {
+        var selectedMicrophoneId = MicrophoneCombo.SelectedItem is AudioInputDevice microphone
+            ? microphone.Id
+            : _selectedMicrophoneId;
+        Complete(new RecordingSetupResult(
+            _captureType == CaptureType.Video && _recordSystemAudio,
+            _captureType == CaptureType.Video && _recordMicrophone,
+            selectedMicrophoneId,
+            _showMouseClicks,
+            _videoTimeLimitMinutes));
+    }
+
+    private void OnCancel(object sender, RoutedEventArgs e) => Complete(null);
+
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case VirtualKey.Enter:
+                OnStart(sender, e);
+                e.Handled = true;
+                break;
+            case VirtualKey.Escape:
+                Complete(null);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void Complete(RecordingSetupResult? result)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        _result.TrySetResult(result);
+        ClosePanel();
+    }
+
+    private void ClosePanel()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        _closed = true;
+        Close();
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        _closed = true;
+        if (!_completed)
+        {
+            _completed = true;
+            _result.TrySetResult(null);
+        }
+    }
+
+    private void UpdateVisuals()
+    {
+        _suppressEvents = true;
+        try
+        {
+            SystemAudioToggle.IsChecked = _recordSystemAudio;
+            MicrophoneToggle.IsChecked = _recordMicrophone;
+            MouseClicksToggle.IsChecked = _showMouseClicks;
+        }
+        finally
+        {
+            _suppressEvents = false;
+        }
+
+        UpdateSystemAudioVisual();
+        UpdateMicrophoneVisual();
+        UpdateMouseClicksVisual();
+        UpdateMicrophonePickerEnabled();
+        UpdateLimitLabel();
+    }
+
+    private void UpdateSystemAudioVisual()
+    {
+        SystemAudioIcon.Glyph = _recordSystemAudio ? SystemAudioOnGlyph : SystemAudioOffGlyph;
+        var state = _recordSystemAudio ? "On" : "Off";
+        ToolTipService.SetToolTip(SystemAudioToggle, $"System audio: {state}");
+        AutomationProperties.SetName(SystemAudioToggle, $"System audio {state}");
+    }
+
+    private void UpdateMicrophoneVisual()
+    {
+        MicrophoneIcon.Glyph = MicGlyph;
+        MicrophoneSlash.Visibility = _recordMicrophone ? Visibility.Collapsed : Visibility.Visible;
+        var state = _recordMicrophone ? "On" : "Off";
+        ToolTipService.SetToolTip(MicrophoneToggle, $"Microphone: {state}");
+        AutomationProperties.SetName(MicrophoneToggle, $"Microphone {state}");
+    }
+
+    private void UpdateMouseClicksVisual()
+    {
+        var state = _showMouseClicks ? "On" : "Off";
+        ToolTipService.SetToolTip(MouseClicksToggle, $"Mouse click visuals: {state}");
+        AutomationProperties.SetName(MouseClicksToggle, $"Mouse click visuals {state}");
+    }
+
+    private void UpdateMicrophonePickerEnabled()
+    {
+        MicrophoneCombo.IsEnabled = _recordMicrophone && MicrophoneLoadingPanel.Visibility != Visibility.Visible;
+    }
+
+    private void UpdateLimitLabel()
+    {
+        LimitLabel.Text = _videoTimeLimitMinutes <= 0 ? "No limit" : $"{_videoTimeLimitMinutes} min";
+        AutomationProperties.SetName(
+            LimitButton,
+            $"Recording time limit, {(_videoTimeLimitMinutes <= 0 ? "no limit" : _videoTimeLimitMinutes + " minutes")}");
+    }
+
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        GetCursorPos(out _dragCursorStart);
+        _dragWindowStart = AppWindow.Position;
+        _dragging = element.CapturePointer(e.Pointer);
+    }
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_dragging)
+        {
+            return;
+        }
+
+        GetCursorPos(out var current);
+        var dx = current.X - _dragCursorStart.X;
+        var dy = current.Y - _dragCursorStart.Y;
+        if (dx == 0 && dy == 0)
+        {
+            return;
+        }
+
+        AppWindow.Move(new PointInt32(_dragWindowStart.X + dx, _dragWindowStart.Y + dy));
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        _dragging = false;
+        element.ReleasePointerCapture(e.Pointer);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out POINT lpPoint);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(nint hwnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
+}

--- a/windows/src/TinyClips.App/RecordingSetupWindow.xaml.cs
+++ b/windows/src/TinyClips.App/RecordingSetupWindow.xaml.cs
@@ -27,7 +27,7 @@ public sealed record RecordingSetupResult(
 /// </summary>
 public sealed partial class RecordingSetupWindow : Window
 {
-    private static readonly int[] LimitOptions = { 0, 1, 3, 5, 10, 15, 30, 45, 60 };
+    private static readonly int[] LimitOptions = { 0, 1, 2, 3, 5, 10, 15, 30, 45, 60 };
 
     private const int TopOffsetDip = 24;
     private const int RegionOutsideOffsetDip = 12;
@@ -69,7 +69,15 @@ public sealed partial class RecordingSetupWindow : Window
 
         MicrophoneCombo.ItemsSource = _microphones;
         _microphones.Add(new AudioInputDevice(string.Empty, "System default"));
-        MicrophoneCombo.SelectedItem = _microphones[0];
+        _suppressEvents = true;
+        try
+        {
+            MicrophoneCombo.SelectedItem = _microphones[0];
+        }
+        finally
+        {
+            _suppressEvents = false;
+        }
 
         ConfigurePresenter();
         ConfigureForCaptureType();
@@ -207,12 +215,12 @@ public sealed partial class RecordingSetupWindow : Window
         RootGrid.UpdateLayout();
         RootGrid.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
 
-        var width = (int)Math.Ceiling(RootGrid.DesiredSize.Width * scale);
-        var height = (int)Math.Ceiling(RootGrid.DesiredSize.Height * scale);
+        var width = (int)Math.Ceiling(RootGrid.DesiredSize.Width * scale) + 2;
+        var height = (int)Math.Ceiling(RootGrid.DesiredSize.Height * scale) + 2;
         var topOffset = (int)Math.Round(TopOffsetDip * scale);
         var regionOutsideOffset = (int)Math.Round(RegionOutsideOffsetDip * scale);
 
-        AppWindow.Resize(new SizeInt32(width + 2, height + 2));
+        AppWindow.Resize(new SizeInt32(width, height));
 
         if (GetWorkArea(monitor) is not { } work)
         {


### PR DESCRIPTION
Windows video and GIF capture now follows the macOS-style target-first flow: choose Region, Screen, or Window first, configure recording options, then start countdown and recording.

## Summary
- Added a pre-record setup panel for Windows video/GIF captures.
- Moved video audio choices into setup, including system audio, microphone on/off, and a microphone device dropdown defaulting to Settings.
- Kept GIF setup audio-free while still supporting mouse-click visuals.
- Simplified the active recording indicator so it focuses on elapsed time and Stop.
- Updated Windows README and changelog for the new flow.

## Validation
- `dotnet build windows\src\TinyClips.App\TinyClips.App.csproj -c Debug -p:Platform=x64 --no-restore`
- `dotnet test windows\tests\TinyClips.Core.Tests\TinyClips.Core.Tests.csproj -c Debug --no-restore`