### PR TITLE
Add preset color swatches with Custom picker to editor color controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Improved
 - Added SF Symbol icons to each action in the macOS menu bar menu so capture and app commands are easier to scan at a glance.
 - macOS screenshot editor image-corner and shadow controls now apply to the actual screenshot content instead of the padded export background, matching the editor preview and saved output.
+- macOS screenshot editor color controls (stroke, fill, text, number badge, and background) now show common preset color swatches first with a **Custom…** option that opens the full native color picker, so picking a common color is a single click while full precision stays available.
 
 ## v1.5.1-mac - 2026-07-03
 

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -317,10 +317,10 @@ private func annotationColorsEqual(_ lhs: Color, _ rhs: Color) -> Bool {
     left.getRed(&lr, green: &lg, blue: &lb, alpha: &la)
     right.getRed(&rr, green: &rg, blue: &rb, alpha: &ra)
 
-    return abs(lr - rr) < 0.01 &&
-        abs(lg - rg) < 0.01 &&
-        abs(lb - rb) < 0.01 &&
-        abs(la - ra) < 0.01
+    return abs(lr - rr) < 0.0001 &&
+        abs(lg - rg) < 0.0001 &&
+        abs(lb - rb) < 0.0001 &&
+        abs(la - ra) < 0.0001
 }
 
 private func redactionBrightness(for row: Int, column: Int, preset: RedactionBlurPreset) -> Double {

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -283,6 +283,46 @@ private enum EditorPopover: String, Identifiable {
     var id: Self { self }
 }
 
+private struct AnnotationColorPreset: Identifiable {
+    let id: String
+    let name: String
+    let color: Color
+}
+
+/// Common preset colors offered before the native "Custom…" picker across the
+/// editor's annotation color surfaces (stroke, fill, text, badge, background).
+private let annotationColorPresets: [AnnotationColorPreset] = [
+    AnnotationColorPreset(id: "black", name: "Black", color: .black),
+    AnnotationColorPreset(id: "white", name: "White", color: .white),
+    AnnotationColorPreset(id: "gray", name: "Gray", color: Color(red: 0.55, green: 0.55, blue: 0.57)),
+    AnnotationColorPreset(id: "red", name: "Red", color: Color(red: 0.90, green: 0.20, blue: 0.18)),
+    AnnotationColorPreset(id: "orange", name: "Orange", color: Color(red: 1.00, green: 0.58, blue: 0.16)),
+    AnnotationColorPreset(id: "yellow", name: "Yellow", color: Color(red: 1.00, green: 0.84, blue: 0.20)),
+    AnnotationColorPreset(id: "green", name: "Green", color: Color(red: 0.24, green: 0.70, blue: 0.34)),
+    AnnotationColorPreset(id: "teal", name: "Teal", color: Color(red: 0.00, green: 0.72, blue: 0.72)),
+    AnnotationColorPreset(id: "blue", name: "Blue", color: Color(red: 0.20, green: 0.52, blue: 0.96)),
+    AnnotationColorPreset(id: "purple", name: "Purple", color: Color(red: 0.55, green: 0.35, blue: 0.90)),
+    AnnotationColorPreset(id: "pink", name: "Pink", color: Color(red: 1.00, green: 0.36, blue: 0.66)),
+    AnnotationColorPreset(id: "brown", name: "Brown", color: Color(red: 0.60, green: 0.40, blue: 0.24)),
+]
+
+private func annotationColorsEqual(_ lhs: Color, _ rhs: Color) -> Bool {
+    guard let left = NSColor(lhs).usingColorSpace(.deviceRGB),
+          let right = NSColor(rhs).usingColorSpace(.deviceRGB) else {
+        return false
+    }
+
+    var lr: CGFloat = 0, lg: CGFloat = 0, lb: CGFloat = 0, la: CGFloat = 0
+    var rr: CGFloat = 0, rg: CGFloat = 0, rb: CGFloat = 0, ra: CGFloat = 0
+    left.getRed(&lr, green: &lg, blue: &lb, alpha: &la)
+    right.getRed(&rr, green: &rg, blue: &rb, alpha: &ra)
+
+    return abs(lr - rr) < 0.01 &&
+        abs(lg - rg) < 0.01 &&
+        abs(lb - rb) < 0.01 &&
+        abs(la - ra) < 0.01
+}
+
 private func redactionBrightness(for row: Int, column: Int, preset: RedactionBlurPreset) -> Double {
     let phase = Double((row + column) % preset.cycleLength)
     return min(0.82, preset.baseBrightness + phase * preset.contrastStep)
@@ -629,15 +669,15 @@ private struct ScreenshotEditorView: View {
     private var styleControls: some View {
         VStack(alignment: .leading, spacing: 10) {
             if let primaryColorLabel {
-                ColorPicker(primaryColorLabel, selection: primaryColorBinding, supportsOpacity: true)
+                SwatchColorPicker(label: primaryColorLabel, color: primaryColorBinding, supportsOpacity: true)
             }
 
             if showsFillColorPicker {
-                ColorPicker("Fill", selection: $viewModel.selectedFillColor, supportsOpacity: true)
+                SwatchColorPicker(label: "Fill", color: $viewModel.selectedFillColor, supportsOpacity: true)
             }
 
             if showsNumberTextColorPicker {
-                ColorPicker("Text", selection: numberTextColorBinding, supportsOpacity: true)
+                SwatchColorPicker(label: "Text", color: numberTextColorBinding, supportsOpacity: true)
             }
 
             if viewModel.showsTextStyleControls {
@@ -713,10 +753,10 @@ private struct ScreenshotEditorView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                ColorPicker("Color", selection: $viewModel.backgroundColor, supportsOpacity: true)
+                SwatchColorPicker(label: "Color", color: $viewModel.backgroundColor, supportsOpacity: true)
 
                 if viewModel.backgroundStyle == .gradient {
-                    ColorPicker("Color 2", selection: $viewModel.backgroundSecondaryColor, supportsOpacity: true)
+                    SwatchColorPicker(label: "Color 2", color: $viewModel.backgroundSecondaryColor, supportsOpacity: true)
                 }
 
                 HStack(spacing: 8) {
@@ -1019,6 +1059,68 @@ private struct WallpaperPresetSwatch: View {
             }
         }
         .frame(width: 28, height: 28)
+    }
+}
+
+private struct AnnotationColorSwatch: View {
+    let color: Color
+    let isSelected: Bool
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(color)
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(.separator, lineWidth: 1))
+                .frame(width: 18, height: 18)
+
+            if isSelected {
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(Color.accentColor, lineWidth: 2)
+                    .frame(width: 22, height: 22)
+            }
+        }
+        .frame(width: 22, height: 22)
+    }
+}
+
+/// Reusable color control: shows common preset swatches first, plus a trailing
+/// native "Custom…" color well for full precision/opacity. Used across the
+/// editor's annotation and background color surfaces.
+private struct SwatchColorPicker: View {
+    let label: String
+    @Binding var color: Color
+    var supportsOpacity: Bool = true
+
+    private let columns = Array(repeating: GridItem(.fixed(22), spacing: 6), count: 6)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
+                ForEach(annotationColorPresets) { preset in
+                    let isSelected = annotationColorsEqual(preset.color, color)
+                    Button {
+                        color = preset.color
+                    } label: {
+                        AnnotationColorSwatch(color: preset.color, isSelected: isSelected)
+                    }
+                    .buttonStyle(.plain)
+                    .help(preset.name)
+                    .accessibilityLabel("\(preset.name) \(label.lowercased())")
+                    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                }
+
+                ColorPicker("", selection: $color, supportsOpacity: supportsOpacity)
+                    .labelsHidden()
+                    .frame(width: 22, height: 22)
+                    .help("Custom color")
+                    .accessibilityLabel("Custom \(label.lowercased()) color")
+                    .accessibilityHint("Opens the full color picker")
+            }
+        }
     }
 }
 

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -20,6 +20,7 @@ own `CHANGELOG.md` at the repository root.
 
 ### Improved
 - **Countdown animation polish** - the Windows countdown overlay now fades in/out, animates each number, and gives the final second stronger emphasis while remaining excluded from capture.
+- **Faster editor color picking with preset swatches** — the screenshot editor color controls (stroke, fill, text, and number badge) now show common preset color swatches first with a **Custom…** button that opens the full native color picker, so the common case is a single click while full precision/opacity stays available. The reusable `SwatchColorPicker` control is applied across those inspector color surfaces.
 - **Screenshot editor background settings now round the screenshot content itself** — the Image corners control now explicitly clips the screenshot preview content to match the rounded-corner export behavior.
 - **Video/GIF recording now matches the macOS target-first setup flow** — after choosing Region,
   Screen, or Window, Windows now shows a pre-record panel before countdown. Video captures can pick

--- a/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml
+++ b/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml
@@ -267,33 +267,12 @@
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Text="Color" />
-                            <Button
-                                x:Name="ColorButton"
-                                HorizontalAlignment="Stretch"
-                                HorizontalContentAlignment="Left"
+                            <local:SwatchColorPicker
+                                x:Name="AnnotationColorPicker"
                                 AutomationProperties.AutomationId="EditorColorButton"
-                                AutomationProperties.Name="Color">
-                                <StackPanel Orientation="Horizontal" Spacing="10">
-                                    <Border
-                                        x:Name="ColorSwatch"
-                                        Width="22"
-                                        Height="22"
-                                        Background="Red"
-                                        CornerRadius="4" />
-                                    <TextBlock VerticalAlignment="Center" Text="Pick color" />
-                                </StackPanel>
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker
-                                            x:Name="AnnotationColorPicker"
-                                            ColorChanged="OnColorChanged"
-                                            ColorSpectrumShape="Ring"
-                                            IsAlphaEnabled="False"
-                                            IsColorChannelTextInputVisible="False"
-                                            IsHexInputVisible="True" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
+                                AutomationProperties.Name="Color"
+                                ColorChanged="OnColorChanged"
+                                IsAlphaEnabled="False" />
                         </StackPanel>
 
                         <!--  Stroke width  -->
@@ -333,35 +312,12 @@
                                 Checked="OnFillToggled"
                                 Content="Fill shape"
                                 Unchecked="OnFillToggled" />
-                            <Button
-                                x:Name="FillColorButton"
-                                HorizontalAlignment="Stretch"
-                                HorizontalContentAlignment="Left"
+                            <local:SwatchColorPicker
+                                x:Name="FillColorPicker"
                                 AutomationProperties.AutomationId="EditorFillColorButton"
-                                AutomationProperties.Name="Fill color">
-                                <StackPanel Orientation="Horizontal" Spacing="10">
-                                    <Border
-                                        x:Name="FillColorSwatch"
-                                        Width="22"
-                                        Height="22"
-                                        Background="Transparent"
-                                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="4" />
-                                    <TextBlock VerticalAlignment="Center" Text="Fill color" />
-                                </StackPanel>
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker
-                                            x:Name="FillColorPicker"
-                                            ColorChanged="OnFillColorChanged"
-                                            ColorSpectrumShape="Ring"
-                                            IsAlphaEnabled="True"
-                                            IsColorChannelTextInputVisible="False"
-                                            IsHexInputVisible="True" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
+                                AutomationProperties.Name="Fill color"
+                                ColorChanged="OnFillColorChanged"
+                                IsAlphaEnabled="True" />
                         </StackPanel>
 
                         <!--  Text  -->
@@ -400,35 +356,12 @@
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                     Style="{StaticResource CaptionTextBlockStyle}"
                                     Text="Number color" />
-                                <Button
-                                    x:Name="NumberColorButton"
-                                    HorizontalAlignment="Stretch"
-                                    HorizontalContentAlignment="Left"
+                                <local:SwatchColorPicker
+                                    x:Name="NumberColorPicker"
                                     AutomationProperties.AutomationId="EditorNumberColorButton"
-                                    AutomationProperties.Name="Number color">
-                                    <StackPanel Orientation="Horizontal" Spacing="10">
-                                        <Border
-                                            x:Name="NumberColorSwatch"
-                                            Width="22"
-                                            Height="22"
-                                            Background="White"
-                                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                                            BorderThickness="1"
-                                            CornerRadius="4" />
-                                        <TextBlock VerticalAlignment="Center" Text="Pick color" />
-                                    </StackPanel>
-                                    <Button.Flyout>
-                                        <Flyout>
-                                            <ColorPicker
-                                                x:Name="NumberColorPicker"
-                                                ColorChanged="OnNumberColorChanged"
-                                                ColorSpectrumShape="Ring"
-                                                IsAlphaEnabled="False"
-                                                IsColorChannelTextInputVisible="False"
-                                                IsHexInputVisible="True" />
-                                        </Flyout>
-                                    </Button.Flyout>
-                                </Button>
+                                    AutomationProperties.Name="Number color"
+                                    ColorChanged="OnNumberColorChanged"
+                                    IsAlphaEnabled="False" />
                             </StackPanel>
                         </StackPanel>
 

--- a/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
@@ -204,9 +204,7 @@ public sealed partial class ScreenshotEditorWindow : Window
         };
 
         AnnotationColorPicker.Color = _strokeColor;
-        ColorSwatch.Background = new SolidColorBrush(_strokeColor);
         NumberColorPicker.Color = _numberTextColor;
-        NumberColorSwatch.Background = new SolidColorBrush(_numberTextColor);
         RedactionCombo.SelectedIndex = 1;
         RedactStyleCombo.SelectedIndex = 0;
 
@@ -252,7 +250,6 @@ public sealed partial class ScreenshotEditorWindow : Window
         FontSizeSlider.Value = _textFontSize;
         FillCheck.IsChecked = _fillEnabled;
         FillColorPicker.Color = _fillColor;
-        FillColorSwatch.Background = new SolidColorBrush(_fillEnabled ? _fillColor : Colors.Transparent);
         UpdateInspectorHeaders();
 
         _inspectorInitializing = false;
@@ -476,7 +473,6 @@ public sealed partial class ScreenshotEditorWindow : Window
         if (hasColor)
         {
             AnnotationColorPicker.Color = ann.Color;
-            ColorSwatch.Background = new SolidColorBrush(ann.Color);
         }
         if (isShape)
         {
@@ -488,7 +484,6 @@ public sealed partial class ScreenshotEditorWindow : Window
             FillCheck.IsChecked = hasFill;
             var pick = hasFill ? ann.FillColor : _fillColor;
             FillColorPicker.Color = pick;
-            FillColorSwatch.Background = new SolidColorBrush(hasFill ? ann.FillColor : Colors.Transparent);
         }
         if (isText)
         {
@@ -499,7 +494,6 @@ public sealed partial class ScreenshotEditorWindow : Window
         {
             NumberSizeSlider.Value = ann.SizeScale;
             NumberColorPicker.Color = ann.TextColor;
-            NumberColorSwatch.Background = new SolidColorBrush(ann.TextColor);
         }
         if (isRedact)
         {
@@ -537,10 +531,9 @@ public sealed partial class ScreenshotEditorWindow : Window
         yield return (ToolRedact, EditTool.Redact);
     }
 
-    private void OnColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    private void OnColorChanged(object? sender, Color color)
     {
-        _strokeColor = args.NewColor;
-        ColorSwatch.Background = new SolidColorBrush(_strokeColor);
+        _strokeColor = color;
         if (_selectedAnnotation is not null)
         {
             _selectedAnnotation.Color = _strokeColor;
@@ -548,10 +541,9 @@ public sealed partial class ScreenshotEditorWindow : Window
         }
     }
 
-    private void OnNumberColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    private void OnNumberColorChanged(object? sender, Color color)
     {
-        _numberTextColor = args.NewColor;
-        NumberColorSwatch.Background = new SolidColorBrush(_numberTextColor);
+        _numberTextColor = color;
         if (_selectedAnnotation is { Tool: EditTool.Counter } ann)
         {
             ann.TextColor = _numberTextColor;
@@ -602,7 +594,6 @@ public sealed partial class ScreenshotEditorWindow : Window
         }
 
         _fillEnabled = FillCheck.IsChecked == true;
-        FillColorSwatch.Background = new SolidColorBrush(_fillEnabled ? _fillColor : Colors.Transparent);
         if (_selectedAnnotation is { Tool: EditTool.Rectangle or EditTool.Ellipse } ann)
         {
             ann.FillColor = _fillEnabled ? _fillColor : Colors.Transparent;
@@ -610,17 +601,16 @@ public sealed partial class ScreenshotEditorWindow : Window
         }
     }
 
-    private void OnFillColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    private void OnFillColorChanged(object? sender, Color color)
     {
         if (_inspectorInitializing)
         {
             return;
         }
 
-        _fillColor = args.NewColor;
+        _fillColor = color;
         _fillEnabled = true;
         FillCheck.IsChecked = true;
-        FillColorSwatch.Background = new SolidColorBrush(_fillColor);
         if (_selectedAnnotation is { Tool: EditTool.Rectangle or EditTool.Ellipse } ann)
         {
             ann.FillColor = _fillColor;

--- a/windows/src/TinyClips.App/SwatchColorPicker.xaml
+++ b/windows/src/TinyClips.App/SwatchColorPicker.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="TinyClips.App.SwatchColorPicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <!--  Preset color swatches shown first, plus a Custom… button that opens the native picker.  -->
+    <StackPanel Spacing="6">
+        <VariableSizedWrapGrid
+            x:Name="PART_Swatches"
+            AutomationProperties.Name="Preset colors"
+            ItemHeight="34"
+            ItemWidth="34"
+            Orientation="Horizontal" />
+
+        <Button
+            x:Name="PART_CustomButton"
+            HorizontalAlignment="Stretch"
+            HorizontalContentAlignment="Left"
+            AutomationProperties.Name="Custom color">
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <Border
+                    x:Name="PART_CurrentSwatch"
+                    Width="22"
+                    Height="22"
+                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4" />
+                <TextBlock VerticalAlignment="Center" Text="Custom…" />
+            </StackPanel>
+            <Button.Flyout>
+                <Flyout>
+                    <ColorPicker
+                        x:Name="PART_Picker"
+                        ColorChanged="OnPickerColorChanged"
+                        ColorSpectrumShape="Ring"
+                        IsColorChannelTextInputVisible="False"
+                        IsHexInputVisible="True" />
+                </Flyout>
+            </Button.Flyout>
+        </Button>
+    </StackPanel>
+</UserControl>

--- a/windows/src/TinyClips.App/SwatchColorPicker.xaml.cs
+++ b/windows/src/TinyClips.App/SwatchColorPicker.xaml.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Color = Windows.UI.Color;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Reusable color control for the editor: shows a grid of common preset color swatches first,
+/// plus a "Custom…" button that opens the platform-native full color picker. Used across the
+/// editor's annotation color surfaces (stroke, fill, text, number badge) so the common case is a
+/// single tap while full precision/opacity stays available through Custom.
+/// </summary>
+/// <remarks>
+/// Assigning <see cref="Color"/> programmatically re-syncs the picker and selection ring without
+/// raising <see cref="ColorChanged"/>, so hosts can push state in (e.g. when selecting an
+/// annotation) with no feedback loop. <see cref="ColorChanged"/> fires only for user input.
+/// </remarks>
+public sealed partial class SwatchColorPicker : UserControl
+{
+    public sealed record ColorSwatchPreset(string Name, Color Color);
+
+    private static readonly ColorSwatchPreset[] Presets =
+    {
+        new("Black", Color.FromArgb(255, 0, 0, 0)),
+        new("White", Color.FromArgb(255, 255, 255, 255)),
+        new("Gray", Color.FromArgb(255, 140, 140, 145)),
+        new("Red", Color.FromArgb(255, 230, 51, 46)),
+        new("Orange", Color.FromArgb(255, 255, 148, 41)),
+        new("Yellow", Color.FromArgb(255, 255, 214, 51)),
+        new("Green", Color.FromArgb(255, 61, 179, 87)),
+        new("Teal", Color.FromArgb(255, 0, 184, 184)),
+        new("Blue", Color.FromArgb(255, 51, 133, 245)),
+        new("Purple", Color.FromArgb(255, 140, 89, 230)),
+        new("Pink", Color.FromArgb(255, 255, 92, 168)),
+        new("Brown", Color.FromArgb(255, 153, 102, 61)),
+    };
+
+    private readonly List<Button> _swatchButtons = new();
+    private bool _syncing;
+
+    public SwatchColorPicker()
+    {
+        InitializeComponent();
+        BuildSwatches();
+        SyncFromColor(Color);
+    }
+
+    public static readonly DependencyProperty ColorProperty = DependencyProperty.Register(
+        nameof(Color),
+        typeof(Color),
+        typeof(SwatchColorPicker),
+        new PropertyMetadata(Colors.Red, OnColorPropertyChanged));
+
+    public Color Color
+    {
+        get => (Color)GetValue(ColorProperty);
+        set => SetValue(ColorProperty, value);
+    }
+
+    public static readonly DependencyProperty IsAlphaEnabledProperty = DependencyProperty.Register(
+        nameof(IsAlphaEnabled),
+        typeof(bool),
+        typeof(SwatchColorPicker),
+        new PropertyMetadata(false, OnIsAlphaEnabledChanged));
+
+    public bool IsAlphaEnabled
+    {
+        get => (bool)GetValue(IsAlphaEnabledProperty);
+        set => SetValue(IsAlphaEnabledProperty, value);
+    }
+
+    /// <summary>Raised only when the user selects a preset swatch or changes the custom picker.</summary>
+    public event EventHandler<Color>? ColorChanged;
+
+    private static void OnColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        ((SwatchColorPicker)d).SyncFromColor((Color)e.NewValue);
+    }
+
+    private static void OnIsAlphaEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        ((SwatchColorPicker)d).PART_Picker.IsAlphaEnabled = (bool)e.NewValue;
+    }
+
+    private void BuildSwatches()
+    {
+        foreach (var preset in Presets)
+        {
+            var button = new Button
+            {
+                Width = 28,
+                Height = 28,
+                Padding = new Thickness(0),
+                Margin = new Thickness(0),
+                CornerRadius = new CornerRadius(6),
+                Background = new SolidColorBrush(preset.Color),
+                BorderThickness = new Thickness(1),
+                BorderBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(48, 0, 0, 0)),
+                Tag = preset,
+            };
+            ToolTipService.SetToolTip(button, preset.Name);
+            AutomationProperties.SetName(button, preset.Name);
+            button.Click += OnSwatchClick;
+            _swatchButtons.Add(button);
+            PART_Swatches.Children.Add(button);
+        }
+    }
+
+    private void OnSwatchClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: ColorSwatchPreset preset })
+        {
+            ApplyColor(preset.Color);
+        }
+    }
+
+    private void OnPickerColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+
+        ApplyColor(args.NewColor);
+    }
+
+    private void ApplyColor(Color color)
+    {
+        if (!ColorsEqual(Color, color))
+        {
+            Color = color;
+        }
+        else
+        {
+            SyncFromColor(color);
+        }
+
+        ColorChanged?.Invoke(this, color);
+    }
+
+    private void SyncFromColor(Color color)
+    {
+        _syncing = true;
+
+        if (!ColorsEqual(PART_Picker.Color, color))
+        {
+            PART_Picker.Color = color;
+        }
+
+        PART_CurrentSwatch.Background = new SolidColorBrush(color);
+        UpdateSelectionVisuals(color);
+
+        _syncing = false;
+    }
+
+    private void UpdateSelectionVisuals(Color color)
+    {
+        var accent = AccentBrush();
+        var idle = new SolidColorBrush(Windows.UI.Color.FromArgb(48, 0, 0, 0));
+
+        foreach (var button in _swatchButtons)
+        {
+            if (button.Tag is ColorSwatchPreset preset)
+            {
+                var selected = ColorsEqual(preset.Color, color);
+                button.BorderBrush = selected ? accent : idle;
+                button.BorderThickness = new Thickness(selected ? 2 : 1);
+            }
+        }
+    }
+
+    private static Brush AccentBrush()
+    {
+        if (Application.Current.Resources.TryGetValue("AccentFillColorDefaultBrush", out var value)
+            && value is Brush brush)
+        {
+            return brush;
+        }
+
+        return new SolidColorBrush(Colors.DodgerBlue);
+    }
+
+    private static bool ColorsEqual(Color a, Color b) =>
+        a.A == b.A && a.R == b.R && a.G == b.G && a.B == b.B;
+}


### PR DESCRIPTION
## Why

Picking a color in the screenshot editor always opened the full native color picker, which is slow for the common case (red, black, white, etc.). This adds a faster two-step experience: common preset swatches first, plus a Custom option that still opens the platform-native picker for full precision.

Fixes: #129
Part of #121.

## What changed

A reusable "preset swatches + Custom..." color control on each platform, wired into the editor's annotation color surfaces so a common color is a single click while full precision/opacity stays available through Custom. Both platforms share a ~12-color palette (black, white, gray, red, orange, yellow, green, teal, blue, purple, pink, brown).

**macOS** (`mac/TinyClips/Views/ScreenshotEditorWindow.swift`)
- New `SwatchColorPicker` SwiftUI view (swatch grid with selected-state ring + a trailing native color well as Custom).
- Applied to the stroke/primary, fill, and text controls, plus the background custom color(s).
- Accessibility labels/values/hints on each swatch and the Custom well.

**Windows** (`windows/src/TinyClips.App/`)
- New `SwatchColorPicker` UserControl (`VariableSizedWrapGrid` of swatch buttons + a Custom flyout hosting the WinUI `ColorPicker`), with `Color`/`IsAlphaEnabled` dependency properties and a `ColorChanged` event. Assigning `Color` programmatically re-syncs without raising the event, so there is no feedback loop when the host pushes state in.
- Replaced the Color, Fill, and Number color inspector controls; updated the change handlers and removed the old inline swatch borders. Automation IDs and per-surface alpha behavior are preserved.

## Notes for reviewers

- Chose `VariableSizedWrapGrid` over `GridView` for the Windows swatches so the panel sizes to content inside the inspector's vertical `StackPanel` (avoids the internal-scroll sizing pitfall).
- The Windows background color section already had presets + custom, so it was left as-is; this PR focuses on the annotation surfaces that jumped straight to the full picker.

## Validation

- macOS: both `TinyClips` and `TinyClipsMAS` Debug schemes build.
- Windows: `TinyClips.Core` and `TinyClips.Core.Tests` compile. The full WinUI App build could not be run on the macOS dev host (the XAML compiler is a Windows-only binary), so please confirm the Windows app build on Windows/CI.