### PR TITLE
Editor: color preview dropdown + transparent shape fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Added SF Symbol icons to each action in the macOS menu bar menu so capture and app commands are easier to scan at a glance.
 - macOS screenshot editor image-corner and shadow controls now apply to the actual screenshot content instead of the padded export background, matching the editor preview and saved output.
 - macOS screenshot editor color controls (stroke, fill, text, number badge, and background) now show common preset color swatches first with a **Custom…** option that opens the full native color picker, so picking a common color is a single click while full precision stays available.
+- macOS screenshot editor color controls are now compact dropdowns that preview the current color and its name; the shape **Fill** control adds a **None** option so rectangles and circles can be left unfilled.
 
 ## v1.5.1-mac - 2026-07-03
 

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -673,7 +673,7 @@ private struct ScreenshotEditorView: View {
             }
 
             if showsFillColorPicker {
-                SwatchColorPicker(label: "Fill", color: $viewModel.selectedFillColor, supportsOpacity: true)
+                SwatchColorPicker(label: "Fill", color: $viewModel.selectedFillColor, supportsOpacity: true, allowsTransparent: true)
             }
 
             if showsNumberTextColorPicker {
@@ -1062,14 +1062,29 @@ private struct WallpaperPresetSwatch: View {
     }
 }
 
+private func isEffectivelyClear(_ color: Color) -> Bool {
+    guard let resolved = NSColor(color).usingColorSpace(.deviceRGB) else {
+        return false
+    }
+    return resolved.alphaComponent < 0.01
+}
+
 private struct AnnotationColorSwatch: View {
     let color: Color
     let isSelected: Bool
+    var isTransparent: Bool = false
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 5)
-                .fill(color)
+                .fill(isTransparent ? AnyShapeStyle(.regularMaterial) : AnyShapeStyle(color))
+                .overlay {
+                    if isTransparent {
+                        Image(systemName: "slash.circle")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 .overlay(RoundedRectangle(cornerRadius: 5).stroke(.separator, lineWidth: 1))
                 .frame(width: 18, height: 18)
 
@@ -1083,27 +1098,108 @@ private struct AnnotationColorSwatch: View {
     }
 }
 
-/// Reusable color control: shows common preset swatches first, plus a trailing
-/// native "Custom…" color well for full precision/opacity. Used across the
-/// editor's annotation and background color surfaces.
+/// Compact preview of the current color shown on the closed dropdown control.
+private struct ColorPreviewSwatch: View {
+    let color: Color
+    var isTransparent: Bool = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(isTransparent ? AnyShapeStyle(.regularMaterial) : AnyShapeStyle(color))
+            .overlay {
+                if isTransparent {
+                    Image(systemName: "slash")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(.separator, lineWidth: 1))
+            .frame(width: 22, height: 16)
+    }
+}
+
+/// Reusable color control: a dropdown that previews the current color and opens
+/// a popover of common preset swatches plus a native "Custom…" color well for
+/// full precision/opacity. When `allowsTransparent` is set it also offers a
+/// "None" (transparent) option. Used across the editor's annotation and
+/// background color surfaces.
 private struct SwatchColorPicker: View {
     let label: String
     @Binding var color: Color
     var supportsOpacity: Bool = true
+    var allowsTransparent: Bool = false
+
+    @State private var isPresented = false
 
     private let columns = Array(repeating: GridItem(.fixed(22), spacing: 6), count: 6)
 
+    private var isClear: Bool {
+        allowsTransparent && isEffectivelyClear(color)
+    }
+
+    private var currentColorName: String {
+        if isClear {
+            return "None"
+        }
+        if let match = annotationColorPresets.first(where: { annotationColorsEqual($0.color, color) }) {
+            return match.name
+        }
+        return "Custom"
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        HStack {
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            Spacer()
+
+            Button {
+                isPresented.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    ColorPreviewSwatch(color: color, isTransparent: isClear)
+                    Text(currentColorName)
+                        .font(.caption)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel("\(label) color")
+            .accessibilityValue(currentColorName)
+            .accessibilityHint("Opens color options")
+            .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+                popoverContent
+            }
+        }
+    }
+
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
             LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
+                if allowsTransparent {
+                    Button {
+                        color = .clear
+                        isPresented = false
+                    } label: {
+                        AnnotationColorSwatch(color: .clear, isSelected: isClear, isTransparent: true)
+                    }
+                    .buttonStyle(.plain)
+                    .help("None (transparent)")
+                    .accessibilityLabel("No \(label.lowercased())")
+                    .accessibilityValue(isClear ? "Selected" : "Not selected")
+                }
+
                 ForEach(annotationColorPresets) { preset in
-                    let isSelected = annotationColorsEqual(preset.color, color)
+                    let isSelected = !isClear && annotationColorsEqual(preset.color, color)
                     Button {
                         color = preset.color
+                        isPresented = false
                     } label: {
                         AnnotationColorSwatch(color: preset.color, isSelected: isSelected)
                     }
@@ -1112,15 +1208,23 @@ private struct SwatchColorPicker: View {
                     .accessibilityLabel("\(preset.name) \(label.lowercased())")
                     .accessibilityValue(isSelected ? "Selected" : "Not selected")
                 }
+            }
 
+            Divider()
+
+            HStack {
+                Text("Custom")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
                 ColorPicker("", selection: $color, supportsOpacity: supportsOpacity)
                     .labelsHidden()
-                    .frame(width: 22, height: 22)
-                    .help("Custom color")
                     .accessibilityLabel("Custom \(label.lowercased()) color")
                     .accessibilityHint("Opens the full color picker")
             }
         }
+        .padding(12)
+        .frame(width: 208)
     }
 }
 

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -21,6 +21,7 @@ own `CHANGELOG.md` at the repository root.
 ### Improved
 - **Countdown animation polish** - the Windows countdown overlay now fades in/out, animates each number, and gives the final second stronger emphasis while remaining excluded from capture.
 - **Faster editor color picking with preset swatches** — the screenshot editor color controls (stroke, fill, text, and number badge) now show common preset color swatches first with a **Custom…** button that opens the full native color picker, so the common case is a single click while full precision/opacity stays available. The reusable `SwatchColorPicker` control is applied across those inspector color surfaces.
+- **Editor color controls are now preview dropdowns** — each `SwatchColorPicker` collapses into a compact button that previews the current color and its name, opening the swatch grid and Custom picker on demand. The shape **Fill** control adds a **None** (transparent) swatch so rectangles and circles can be left unfilled directly from the color control.
 - **Screenshot editor background settings now round the screenshot content itself** — the Image corners control now explicitly clips the screenshot preview content to match the rounded-corner export behavior.
 - **Video/GIF recording now matches the macOS target-first setup flow** — after choosing Region,
   Screen, or Window, Windows now shows a pre-record panel before countdown. Video captures can pick

--- a/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml
+++ b/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml
@@ -316,6 +316,7 @@
                                 x:Name="FillColorPicker"
                                 AutomationProperties.AutomationId="EditorFillColorButton"
                                 AutomationProperties.Name="Fill color"
+                                AllowTransparent="True"
                                 ColorChanged="OnFillColorChanged"
                                 IsAlphaEnabled="True" />
                         </StackPanel>

--- a/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
@@ -249,7 +249,7 @@ public sealed partial class ScreenshotEditorWindow : Window
         NumberSizeSlider.Value = _numberScale;
         FontSizeSlider.Value = _textFontSize;
         FillCheck.IsChecked = _fillEnabled;
-        FillColorPicker.Color = _fillColor;
+        FillColorPicker.Color = _fillEnabled ? _fillColor : Colors.Transparent;
         UpdateInspectorHeaders();
 
         _inspectorInitializing = false;
@@ -482,7 +482,7 @@ public sealed partial class ScreenshotEditorWindow : Window
         {
             var hasFill = ann.FillColor.A > 0;
             FillCheck.IsChecked = hasFill;
-            var pick = hasFill ? ann.FillColor : _fillColor;
+            var pick = hasFill ? ann.FillColor : Colors.Transparent;
             FillColorPicker.Color = pick;
         }
         if (isText)
@@ -594,6 +594,7 @@ public sealed partial class ScreenshotEditorWindow : Window
         }
 
         _fillEnabled = FillCheck.IsChecked == true;
+        FillColorPicker.Color = _fillEnabled ? _fillColor : Colors.Transparent;
         if (_selectedAnnotation is { Tool: EditTool.Rectangle or EditTool.Ellipse } ann)
         {
             ann.FillColor = _fillEnabled ? _fillColor : Colors.Transparent;
@@ -605,6 +606,19 @@ public sealed partial class ScreenshotEditorWindow : Window
     {
         if (_inspectorInitializing)
         {
+            return;
+        }
+
+        if (color.A == 0)
+        {
+            // "None" swatch clears the fill without discarding the last chosen color.
+            _fillEnabled = false;
+            FillCheck.IsChecked = false;
+            if (_selectedAnnotation is { Tool: EditTool.Rectangle or EditTool.Ellipse } cleared)
+            {
+                cleared.FillColor = Colors.Transparent;
+                RedrawOverlay();
+            }
             return;
         }
 

--- a/windows/src/TinyClips.App/SwatchColorPicker.xaml
+++ b/windows/src/TinyClips.App/SwatchColorPicker.xaml
@@ -7,40 +7,85 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <!--  Preset color swatches shown first, plus a Custom… button that opens the native picker.  -->
-    <StackPanel Spacing="6">
-        <VariableSizedWrapGrid
-            x:Name="PART_Swatches"
-            AutomationProperties.Name="Preset colors"
-            ItemHeight="34"
-            ItemWidth="34"
-            Orientation="Horizontal" />
+    <!--  Dropdown that previews the current color and opens preset swatches + a Custom picker.  -->
+    <Button
+        x:Name="PART_DropButton"
+        HorizontalAlignment="Stretch"
+        HorizontalContentAlignment="Stretch">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Border
+                x:Name="PART_CurrentSwatch"
+                Grid.Column="0"
+                Width="22"
+                Height="22"
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="4">
+                <FontIcon
+                    x:Name="PART_TransparentGlyph"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="12"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Glyph="&#xE711;"
+                    Visibility="Collapsed" />
+            </Border>
+            <TextBlock
+                x:Name="PART_ColorLabel"
+                Grid.Column="1"
+                Margin="10,0,0,0"
+                VerticalAlignment="Center"
+                Text="Pick color" />
+            <FontIcon
+                Grid.Column="2"
+                Margin="8,0,0,0"
+                FontFamily="{StaticResource SymbolThemeFontFamily}"
+                FontSize="12"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Glyph="&#xE70D;" />
+        </Grid>
+        <Button.Flyout>
+            <Flyout>
+                <StackPanel MinWidth="224" Spacing="10">
+                    <VariableSizedWrapGrid
+                        x:Name="PART_Swatches"
+                        AutomationProperties.Name="Preset colors"
+                        ItemHeight="34"
+                        ItemWidth="34"
+                        Orientation="Horizontal" />
 
-        <Button
-            x:Name="PART_CustomButton"
-            HorizontalAlignment="Stretch"
-            HorizontalContentAlignment="Left"
-            AutomationProperties.Name="Custom color">
-            <StackPanel Orientation="Horizontal" Spacing="10">
-                <Border
-                    x:Name="PART_CurrentSwatch"
-                    Width="22"
-                    Height="22"
-                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="4" />
-                <TextBlock VerticalAlignment="Center" Text="Custom…" />
-            </StackPanel>
-            <Button.Flyout>
-                <Flyout>
-                    <ColorPicker
-                        x:Name="PART_Picker"
-                        ColorChanged="OnPickerColorChanged"
-                        ColorSpectrumShape="Ring"
-                        IsColorChannelTextInputVisible="False"
-                        IsHexInputVisible="True" />
-                </Flyout>
-            </Button.Flyout>
-        </Button>
-    </StackPanel>
+                    <Button
+                        x:Name="PART_CustomButton"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        AutomationProperties.Name="Custom color">
+                        <StackPanel Orientation="Horizontal" Spacing="10">
+                            <Border
+                                x:Name="PART_CustomSwatch"
+                                Width="22"
+                                Height="22"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4" />
+                            <TextBlock VerticalAlignment="Center" Text="Custom…" />
+                        </StackPanel>
+                        <Button.Flyout>
+                            <Flyout>
+                                <ColorPicker
+                                    x:Name="PART_Picker"
+                                    ColorChanged="OnPickerColorChanged"
+                                    ColorSpectrumShape="Ring"
+                                    IsColorChannelTextInputVisible="False"
+                                    IsHexInputVisible="True" />
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+                </StackPanel>
+            </Flyout>
+        </Button.Flyout>
+    </Button>
 </UserControl>

--- a/windows/src/TinyClips.App/SwatchColorPicker.xaml.cs
+++ b/windows/src/TinyClips.App/SwatchColorPicker.xaml.cs
@@ -10,14 +10,14 @@ using Color = Windows.UI.Color;
 namespace TinyClips.App;
 
 /// <summary>
-/// Reusable color control for the editor: shows a grid of common preset color swatches first,
-/// plus a "Custom…" button that opens the platform-native full color picker. Used across the
-/// editor's annotation color surfaces (stroke, fill, text, number badge) so the common case is a
-/// single tap while full precision/opacity stays available through Custom.
+/// Reusable color control for the editor: a dropdown button that previews the current color and
+/// opens a flyout with a grid of common preset color swatches plus a "Custom…" button that reveals
+/// the platform-native full color picker. When <see cref="AllowTransparent"/> is set it also offers
+/// a "None" (transparent) swatch so surfaces like shape fill can be cleared.
 /// </summary>
 /// <remarks>
-/// Assigning <see cref="Color"/> programmatically re-syncs the picker and selection ring without
-/// raising <see cref="ColorChanged"/>, so hosts can push state in (e.g. when selecting an
+/// Assigning <see cref="Color"/> programmatically re-syncs the picker, preview, and selection ring
+/// without raising <see cref="ColorChanged"/>, so hosts can push state in (e.g. when selecting an
 /// annotation) with no feedback loop. <see cref="ColorChanged"/> fires only for user input.
 /// </remarks>
 public sealed partial class SwatchColorPicker : UserControl
@@ -41,6 +41,7 @@ public sealed partial class SwatchColorPicker : UserControl
     };
 
     private readonly List<Button> _swatchButtons = new();
+    private Button? _transparentButton;
     private bool _syncing;
 
     public SwatchColorPicker()
@@ -74,6 +75,19 @@ public sealed partial class SwatchColorPicker : UserControl
         set => SetValue(IsAlphaEnabledProperty, value);
     }
 
+    public static readonly DependencyProperty AllowTransparentProperty = DependencyProperty.Register(
+        nameof(AllowTransparent),
+        typeof(bool),
+        typeof(SwatchColorPicker),
+        new PropertyMetadata(false, OnAllowTransparentChanged));
+
+    /// <summary>When true, a leading "None" (transparent) swatch is offered.</summary>
+    public bool AllowTransparent
+    {
+        get => (bool)GetValue(AllowTransparentProperty);
+        set => SetValue(AllowTransparentProperty, value);
+    }
+
     /// <summary>Raised only when the user selects a preset swatch or changes the custom picker.</summary>
     public event EventHandler<Color>? ColorChanged;
 
@@ -87,8 +101,45 @@ public sealed partial class SwatchColorPicker : UserControl
         ((SwatchColorPicker)d).PART_Picker.IsAlphaEnabled = (bool)e.NewValue;
     }
 
+    private static void OnAllowTransparentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var control = (SwatchColorPicker)d;
+        control.BuildSwatches();
+        control.SyncFromColor(control.Color);
+    }
+
     private void BuildSwatches()
     {
+        PART_Swatches.Children.Clear();
+        _swatchButtons.Clear();
+        _transparentButton = null;
+
+        if (AllowTransparent)
+        {
+            var noneButton = new Button
+            {
+                Width = 28,
+                Height = 28,
+                Padding = new Thickness(0),
+                Margin = new Thickness(0),
+                CornerRadius = new CornerRadius(6),
+                Background = new SolidColorBrush(Colors.Transparent),
+                BorderThickness = new Thickness(1),
+                BorderBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(48, 0, 0, 0)),
+                Content = new FontIcon
+                {
+                    FontFamily = (FontFamily)Application.Current.Resources["SymbolThemeFontFamily"],
+                    FontSize = 12,
+                    Glyph = "\uE711",
+                },
+            };
+            ToolTipService.SetToolTip(noneButton, "None (transparent)");
+            AutomationProperties.SetName(noneButton, "None");
+            noneButton.Click += OnTransparentClick;
+            _transparentButton = noneButton;
+            PART_Swatches.Children.Add(noneButton);
+        }
+
         foreach (var preset in Presets)
         {
             var button = new Button
@@ -119,6 +170,11 @@ public sealed partial class SwatchColorPicker : UserControl
         }
     }
 
+    private void OnTransparentClick(object sender, RoutedEventArgs e)
+    {
+        ApplyColor(Colors.Transparent);
+    }
+
     private void OnPickerColorChanged(ColorPicker sender, ColorChangedEventArgs args)
     {
         if (_syncing)
@@ -147,28 +203,59 @@ public sealed partial class SwatchColorPicker : UserControl
     {
         _syncing = true;
 
-        if (!ColorsEqual(PART_Picker.Color, color))
+        var transparent = IsTransparent(color);
+
+        if (!transparent && !ColorsEqual(PART_Picker.Color, color))
         {
             PART_Picker.Color = color;
         }
 
-        PART_CurrentSwatch.Background = new SolidColorBrush(color);
-        UpdateSelectionVisuals(color);
+        PART_CurrentSwatch.Background = new SolidColorBrush(transparent ? Colors.Transparent : color);
+        PART_CustomSwatch.Background = new SolidColorBrush(transparent ? Colors.Transparent : color);
+        PART_TransparentGlyph.Visibility = transparent ? Visibility.Visible : Visibility.Collapsed;
+        PART_ColorLabel.Text = DescribeColor(color, transparent);
+
+        UpdateSelectionVisuals(color, transparent);
 
         _syncing = false;
     }
 
-    private void UpdateSelectionVisuals(Color color)
+    private string DescribeColor(Color color, bool transparent)
+    {
+        if (transparent && AllowTransparent)
+        {
+            return "None";
+        }
+
+        foreach (var preset in Presets)
+        {
+            if (ColorsEqual(preset.Color, color))
+            {
+                return preset.Name;
+            }
+        }
+
+        return "Custom";
+    }
+
+    private void UpdateSelectionVisuals(Color color, bool transparent)
     {
         var accent = AccentBrush();
-        var idle = new SolidColorBrush(Windows.UI.Color.FromArgb(48, 0, 0, 0));
+        Brush Idle() => new SolidColorBrush(Windows.UI.Color.FromArgb(48, 0, 0, 0));
+
+        if (_transparentButton is not null)
+        {
+            var selected = transparent && AllowTransparent;
+            _transparentButton.BorderBrush = selected ? accent : Idle();
+            _transparentButton.BorderThickness = new Thickness(selected ? 2 : 1);
+        }
 
         foreach (var button in _swatchButtons)
         {
             if (button.Tag is ColorSwatchPreset preset)
             {
-                var selected = ColorsEqual(preset.Color, color);
-                button.BorderBrush = selected ? accent : idle;
+                var selected = !transparent && ColorsEqual(preset.Color, color);
+                button.BorderBrush = selected ? accent : Idle();
                 button.BorderThickness = new Thickness(selected ? 2 : 1);
             }
         }
@@ -184,6 +271,8 @@ public sealed partial class SwatchColorPicker : UserControl
 
         return new SolidColorBrush(Colors.DodgerBlue);
     }
+
+    private static bool IsTransparent(Color color) => color.A == 0;
 
     private static bool ColorsEqual(Color a, Color b) =>
         a.A == b.A && a.R == b.R && a.G == b.G && a.B == b.B;


### PR DESCRIPTION
## Why

Follow-up UX refinement to the editor color controls introduced in #129 / #136. Two asks:
- The shape **Fill** (rectangle/circle) should be able to be left transparent (no fill).
- The color controls should read as a picker dropdown that previews the currently selected color, rather than always exposing a swatch grid inline.

## What changed

- **Preview dropdown.** The reusable `SwatchColorPicker` (macOS SwiftUI + Windows WinUI) now collapses into a compact button that previews the current color and its name ("Red" / "Custom" / "None"). The preset swatch grid and the Custom native color picker open on demand from the dropdown instead of taking up inspector space.
- **Transparent shape fill.** The Fill control gains a **None** (transparent) swatch.
  - macOS: choosing None sets `selectedFillColor = .clear`, so the shape renders unfilled.
  - Windows: `AllowTransparent="True"` on the Fill picker. Picking None sets `_fillEnabled = false`, unchecks "Fill shape", and applies `Colors.Transparent`. Init and selection-sync now show "None" when a shape has no fill.

## Validation

- macOS: both `TinyClips` and `TinyClipsMAS` schemes build successfully.
- Windows: self-review only. The WinUI XAML compiler is Windows-only and cannot run on the macOS build host, so the App project can't be compiled here. Automation IDs and the picker's re-sync guard were preserved.

Both changelogs updated under Unreleased.

Fixes: #129