### PR TITLE
Polish pre-capture countdown transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed the macOS Settings → Analytics view freezing with "Publishing changes from within view updates is not allowed" faults, caused by the analytics history being pruned (and its published state reassigned) while the view was rendering. Pruning now runs only at launch and when a capture is recorded.
+- Fixed the macOS pre-capture countdown number transition so each tick now animates smoothly instead of rebuilding the SwiftUI hosting view every second (which prevented the numeric text transition from running).
 
 ### Improved
 - Added SF Symbol icons to each action in the macOS menu bar menu so capture and app commands are easier to scan at a glance.

--- a/mac/TinyClips/Views/CountdownWindow.swift
+++ b/mac/TinyClips/Views/CountdownWindow.swift
@@ -4,10 +4,16 @@ import SwiftUI
 class CountdownWindow: NSPanel {
     private var completion: (() -> Void)?
     private var countdownTimer: Timer?
+    private let countdownState: CountdownState
+    private let hostingView: NSHostingView<CountdownView>
     private var remaining: Int
+    private var didComplete = false
 
     init(duration: Int, completion: @escaping () -> Void) {
-        self.remaining = duration
+        let initialRemaining = max(1, duration)
+        self.remaining = initialRemaining
+        self.countdownState = CountdownState(remaining: initialRemaining)
+        self.hostingView = NSHostingView(rootView: CountdownView(state: countdownState))
         self.completion = completion
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 120, height: 120),
@@ -22,6 +28,8 @@ class CountdownWindow: NSPanel {
         self.hasShadow = true
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
+        hostingView.frame = NSRect(x: 0, y: 0, width: 120, height: 120)
+        self.contentView = hostingView
         updateDisplay()
     }
 
@@ -46,10 +54,13 @@ class CountdownWindow: NSPanel {
             self.remaining -= 1
             if self.remaining <= 0 {
                 timer.invalidate()
+                self.countdownTimer = nil
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = 0.16
                     self.animator().alphaValue = 0
                 } completionHandler: {
+                    guard !self.didComplete else { return }
+                    self.didComplete = true
                     let completion = self.completion
                     self.completion = nil
                     self.orderOut(nil)
@@ -62,12 +73,11 @@ class CountdownWindow: NSPanel {
     }
 
     private func updateDisplay() {
-        let hostingView = NSHostingView(rootView: CountdownView(remaining: remaining))
-        hostingView.frame = NSRect(x: 0, y: 0, width: 120, height: 120)
-        self.contentView = hostingView
+        countdownState.remaining = remaining
     }
 
     func cancel() {
+        didComplete = true
         countdownTimer?.invalidate()
         countdownTimer = nil
         completion = nil
@@ -75,10 +85,20 @@ class CountdownWindow: NSPanel {
     }
 }
 
+private final class CountdownState: ObservableObject {
+    @Published var remaining: Int
+
+    init(remaining: Int) {
+        self.remaining = remaining
+    }
+}
+
 private struct CountdownView: View {
-    let remaining: Int
+    @ObservedObject var state: CountdownState
 
     var body: some View {
+        let remaining = state.remaining
+
         ZStack {
             Circle()
                 .fill(.black.opacity(0.75))

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -20,6 +20,7 @@ own `CHANGELOG.md` at the repository root.
 
 ### Improved
 - **Countdown animation polish** - the Windows countdown overlay now fades in/out, animates each number, and gives the final second stronger emphasis while remaining excluded from capture.
+- **Smoother countdown number handoff** - each countdown tick now performs a quick ease-out before the next number eases in, and the final second now also shifts to a bolder weight for clearer emphasis.
 - **Faster editor color picking with preset swatches** — the screenshot editor color controls (stroke, fill, text, and number badge) now show common preset color swatches first with a **Custom…** button that opens the full native color picker, so the common case is a single click while full precision/opacity stays available. The reusable `SwatchColorPicker` control is applied across those inspector color surfaces.
 - **Editor color controls are now preview dropdowns** — each `SwatchColorPicker` collapses into a compact button that previews the current color and its name, opening the swatch grid and Custom picker on demand. The shape **Fill** control adds a **None** (transparent) swatch so rectangles and circles can be left unfilled directly from the color control.
 - **Screenshot editor background settings now round the screenshot content itself** — the Image corners control now explicitly clips the screenshot preview content to match the rounded-corner export behavior.

--- a/windows/src/TinyClips.App/CountdownWindow.xaml.cs
+++ b/windows/src/TinyClips.App/CountdownWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Text;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Animation;
@@ -75,16 +76,12 @@ public sealed partial class CountdownWindow : Window
             return;
         }
 
-        AnimateCountText(finalSecond: _remaining == 1);
+        await AnimateCountTransitionAsync(finalSecond: _remaining == 1);
     }
 
     private void AnimateCountText(bool finalSecond)
     {
-        CountText.Text = _remaining.ToString();
-        CountText.FontSize = finalSecond ? 78 : 64;
-        CountText.Opacity = 0;
-        CountScale.ScaleX = finalSecond ? 1.35 : 1.18;
-        CountScale.ScaleY = finalSecond ? 1.35 : 1.18;
+        ApplyCountVisualState(finalSecond);
 
         var storyboard = new Storyboard();
         storyboard.Children.Add(CreateAnimation(CountText, "Opacity", 1, 220));
@@ -93,10 +90,43 @@ public sealed partial class CountdownWindow : Window
         storyboard.Begin();
     }
 
+    private async Task AnimateCountTransitionAsync(bool finalSecond)
+    {
+        await AnimateCountOutAsync();
+        AnimateCountText(finalSecond);
+    }
+
+    private Task AnimateCountOutAsync()
+    {
+        var storyboard = new Storyboard();
+        storyboard.Children.Add(CreateAnimation(CountText, "Opacity", 0, 90));
+        storyboard.Children.Add(CreateAnimation(CountScale, "ScaleX", 0.94, 90));
+        storyboard.Children.Add(CreateAnimation(CountScale, "ScaleY", 0.94, 90));
+        return RunStoryboardAsync(storyboard);
+    }
+
+    private void ApplyCountVisualState(bool finalSecond)
+    {
+        CountText.Text = _remaining.ToString();
+        CountText.FontSize = finalSecond ? 78 : 64;
+        CountText.FontWeight = finalSecond ? FontWeights.Bold : FontWeights.SemiBold;
+        CountText.Opacity = 0.06;
+        CountScale.ScaleX = finalSecond ? 1.35 : 1.18;
+        CountScale.ScaleY = finalSecond ? 1.35 : 1.18;
+    }
+
     private Task AnimateFadeAsync(UIElement target, double to, int milliseconds)
     {
         var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var storyboard = AnimateFade(target, to, milliseconds);
+        storyboard.Completed += (_, _) => completion.TrySetResult(true);
+        storyboard.Begin();
+        return completion.Task;
+    }
+
+    private static Task RunStoryboardAsync(Storyboard storyboard)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         storyboard.Completed += (_, _) => completion.TrySetResult(true);
         storyboard.Begin();
         return completion.Task;

--- a/windows/src/TinyClips.App/CountdownWindow.xaml.cs
+++ b/windows/src/TinyClips.App/CountdownWindow.xaml.cs
@@ -110,18 +110,14 @@ public sealed partial class CountdownWindow : Window
         CountText.Text = _remaining.ToString();
         CountText.FontSize = finalSecond ? 78 : 64;
         CountText.FontWeight = finalSecond ? FontWeights.Bold : FontWeights.SemiBold;
-        CountText.Opacity = 0.06;
+        CountText.Opacity = 0;
         CountScale.ScaleX = finalSecond ? 1.35 : 1.18;
         CountScale.ScaleY = finalSecond ? 1.35 : 1.18;
     }
 
     private Task AnimateFadeAsync(UIElement target, double to, int milliseconds)
     {
-        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var storyboard = AnimateFade(target, to, milliseconds);
-        storyboard.Completed += (_, _) => completion.TrySetResult(true);
-        storyboard.Begin();
-        return completion.Task;
+        return RunStoryboardAsync(AnimateFade(target, to, milliseconds));
     }
 
     private static Task RunStoryboardAsync(Storyboard storyboard)


### PR DESCRIPTION
This refines the pre-capture countdown animation so it feels smoother and more deliberate across macOS and Windows, matching the issue intent while preserving current accessibility and capture-exclusion behavior.

## What changed
- macOS countdown now keeps a persistent SwiftUI hosting view and updates countdown state in place, so the numeric text/content transition actually animates between ticks.
- macOS countdown completion/cancel paths were tightened to avoid double-completion race behavior.
- Windows countdown now uses a short ease-out before each number swap, then eases the next number in for a smoother handoff.
- Windows final-second emphasis now also increases text weight for a clearer visual cue.
- Updated macOS and Windows changelogs under Unreleased.

## Notes for reviewers
- This is intentionally focused on countdown animation polish only, with no changes to countdown settings, capture timing semantics, or broader capture flow behavior.

Fixes: #132