### PR TITLE
Fix camera permission for direct macOS builds

### DIFF
--- a/mac/TinyClips/TinyClips.entitlements
+++ b/mac/TinyClips/TinyClips.entitlements
@@ -6,6 +6,8 @@
 	<false/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Summary

- add the camera entitlement to the direct-distribution macOS target
- allow Hardened Runtime builds to request camera access and appear in macOS Camera privacy settings

## Testing

- `plutil -lint mac/TinyClips/TinyClips.entitlements`
- installed a locally re-signed v1.5.2 build with the updated entitlement
- reset Camera TCC and confirmed the permission prompt appears and camera access works

Fixes #157