### PR TITLE
Add TinyClips release dashboard canvas

### DIFF
--- a/.github/extensions/tinyclips-release-hub/extension.mjs
+++ b/.github/extensions/tinyclips-release-hub/extension.mjs
@@ -1,0 +1,208 @@
+import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
+import { createCanvas, CanvasError, joinSession } from "@github/copilot-sdk/extension";
+import {
+    generateReleaseNotes,
+    getReleaseSnapshot,
+    performReleaseAction,
+} from "./release-data.mjs";
+import { renderHtml } from "./renderer.mjs";
+
+const servers = new Map();
+
+function sendJson(res, statusCode, value) {
+    res.writeHead(statusCode, {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify(value));
+}
+
+async function readJsonBody(req) {
+    const chunks = [];
+    let size = 0;
+
+    for await (const chunk of req) {
+        size += chunk.length;
+        if (size > 64 * 1024) {
+            throw new Error("Request body is too large.");
+        }
+        chunks.push(chunk);
+    }
+
+    if (chunks.length === 0) {
+        return {};
+    }
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function startServer(instanceId) {
+    const token = randomBytes(24).toString("hex");
+    const server = createServer(async (req, res) => {
+        const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+
+        try {
+            if (req.method === "GET" && requestUrl.pathname === "/") {
+                res.writeHead(200, {
+                    "Content-Type": "text/html; charset=utf-8",
+                    "Cache-Control": "no-store",
+                    "Content-Security-Policy": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; img-src 'self' data:",
+                });
+                res.end(renderHtml({ instanceId, token }));
+                return;
+            }
+
+            if (req.method === "GET" && requestUrl.pathname === "/api/status") {
+                sendJson(res, 200, await getReleaseSnapshot());
+                return;
+            }
+
+            if (req.method === "POST" && requestUrl.pathname === "/api/action") {
+                if (req.headers["x-release-hub-token"] !== token) {
+                    sendJson(res, 403, { error: "Invalid release hub token." });
+                    return;
+                }
+
+                const body = await readJsonBody(req);
+                const result = body.action === "generate_notes"
+                    ? await generateReleaseNotes(body.platform, body.version)
+                    : await performReleaseAction(body.action, body);
+                sendJson(res, 200, { result, snapshot: await getReleaseSnapshot() });
+                return;
+            }
+
+            sendJson(res, 404, { error: "Not found." });
+        } catch (error) {
+            sendJson(res, 400, {
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    return { server, url: `http://127.0.0.1:${port}/` };
+}
+
+const platformSchema = { type: "string", enum: ["mac", "windows"] };
+
+await joinSession({
+    canvases: [
+        createCanvas({
+            id: "tinyclips-release-hub",
+            displayName: "TinyClips Release Hub",
+            description: "Manage macOS and Windows release readiness, notes, tags, workflows, and winget submission.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    platform: platformSchema,
+                },
+                additionalProperties: false,
+            },
+            actions: [
+                {
+                    name: "refresh_status",
+                    description: "Refresh TinyClips release readiness, tags, releases, and workflow status.",
+                    handler: async () => getReleaseSnapshot(),
+                },
+                {
+                    name: "generate_release_notes",
+                    description: "Generate a release-notes preview from a platform changelog.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            platform: platformSchema,
+                            version: { type: "string" },
+                        },
+                        required: ["platform"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => generateReleaseNotes(ctx.input.platform, ctx.input.version),
+                },
+                {
+                    name: "prepare_release",
+                    description: "Create the changelog commit and annotated tag after exact typed confirmation.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            platform: platformSchema,
+                            version: { type: "string", minLength: 1 },
+                            confirmation: { type: "string", minLength: 1 },
+                        },
+                        required: ["platform", "version", "confirmation"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => performReleaseAction("prepare_release", ctx.input),
+                },
+                {
+                    name: "push_release",
+                    description: "Push the main branch and release tag to origin after exact typed confirmation.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            tag: { type: "string", minLength: 1 },
+                            confirmation: { type: "string", minLength: 1 },
+                        },
+                        required: ["tag", "confirmation"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => performReleaseAction("push_release", ctx.input),
+                },
+                {
+                    name: "run_release_workflow",
+                    description: "Dispatch the platform GitHub release workflow after exact typed confirmation.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            platform: platformSchema,
+                            tag: { type: "string", minLength: 1 },
+                            confirmation: { type: "string", minLength: 1 },
+                        },
+                        required: ["platform", "tag", "confirmation"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => performReleaseAction("run_release_workflow", ctx.input),
+                },
+                {
+                    name: "submit_winget",
+                    description: "Dispatch the manually gated winget submission workflow for a published Windows release.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            tag: { type: "string", minLength: 1 },
+                            confirmation: { type: "string", minLength: 1 },
+                        },
+                        required: ["tag", "confirmation"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => performReleaseAction("submit_winget", ctx.input),
+                },
+            ],
+            open: async (ctx) => {
+                let entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    entry = await startServer(ctx.instanceId);
+                    servers.set(ctx.instanceId, entry);
+                }
+                return {
+                    title: "TinyClips Release Hub",
+                    status: "Release status and operations",
+                    url: entry.url,
+                };
+            },
+            onClose: async (ctx) => {
+                const entry = servers.get(ctx.instanceId);
+                if (entry) {
+                    servers.delete(ctx.instanceId);
+                    await new Promise((resolve) => entry.server.close(resolve));
+                }
+            },
+        }),
+    ],
+}).catch((error) => {
+    throw new CanvasError("release_hub_start_failed", error instanceof Error ? error.message : String(error));
+});

--- a/.github/extensions/tinyclips-release-hub/release-data.mjs
+++ b/.github/extensions/tinyclips-release-hub/release-data.mjs
@@ -1,0 +1,387 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TAG_PATTERNS = {
+    mac: /^v\d+\.\d+\.\d+(?:\.\d+)?-mac$/,
+    windows: /^v\d+\.\d+\.\d+(?:\.\d+)?-windows$/,
+};
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+async function run(command, args, options = {}) {
+    const result = await execFileAsync(command, args, {
+        cwd: options.cwd ?? await getRepoRoot(),
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: 4 * 1024 * 1024,
+        env: { ...process.env, GH_PAGER: "cat", PAGER: "cat" },
+    });
+    return result.stdout.trim();
+}
+
+async function tryRun(command, args) {
+    try {
+        return { ok: true, output: await run(command, args) };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, output: "", error: message.split(/\r?\n/)[0] };
+    }
+}
+
+async function getRepoRoot() {
+    return repoRoot;
+}
+
+function platformConfig(platform) {
+    if (platform === "mac") {
+        return {
+            changelog: "CHANGELOG.md",
+            unreleasedHeading: "## Unreleased",
+            workflow: "release.yml",
+            workflowInput: "version",
+        };
+    }
+    if (platform === "windows") {
+        return {
+            changelog: "windows/CHANGELOG.md",
+            unreleasedHeading: "## [Unreleased]",
+            workflow: "windows-release.yml",
+            workflowInput: "tag",
+        };
+    }
+    throw new Error(`Unsupported platform: ${platform}`);
+}
+
+function parseVersion(tag) {
+    const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?-(?:mac|windows)$/);
+    return match ? match.slice(1).map((value) => Number(value ?? 0)) : [0, 0, 0, 0];
+}
+
+function compareTags(left, right) {
+    const a = parseVersion(left);
+    const b = parseVersion(right);
+    for (let index = 0; index < a.length; index += 1) {
+        if (a[index] !== b[index]) {
+            return b[index] - a[index];
+        }
+    }
+    return 0;
+}
+
+function nextPatchTag(platform, latestTag, appVersion) {
+    if (platform === "mac" && appVersion) {
+        const prefix = `v${appVersion}.`;
+        const matchingPatch = latestTag?.startsWith(prefix) ? parseVersion(latestTag)[2] : -1;
+        return `${prefix}${matchingPatch + 1}-mac`;
+    }
+    const [major, minor, patch] = parseVersion(latestTag ?? "");
+    return `v${major}.${minor}.${patch + 1}-windows`;
+}
+
+function extractSection(markdown, heading) {
+    const lines = markdown.split(/\r?\n/);
+    const start = lines.findIndex((line) => line.trim() === heading);
+    if (start < 0) {
+        return "";
+    }
+    const body = [];
+    for (let index = start + 1; index < lines.length; index += 1) {
+        if (lines[index].startsWith("## ")) {
+            break;
+        }
+        body.push(lines[index]);
+    }
+    return body.join("\n").trim();
+}
+
+function releaseHeadingMatches(line, platform, version) {
+    if (platform === "mac") {
+        return line === `## ${version}` || line.startsWith(`## ${version} -`);
+    }
+    return line === `## [${version}]` || line.startsWith(`## [${version}] -`);
+}
+
+function extractReleaseSection(markdown, platform, version) {
+    const lines = markdown.split(/\r?\n/);
+    const start = lines.findIndex((line) => releaseHeadingMatches(line.trim(), platform, version));
+    if (start < 0) {
+        return "";
+    }
+    const body = [];
+    for (let index = start + 1; index < lines.length; index += 1) {
+        if (lines[index].startsWith("## ")) {
+            break;
+        }
+        body.push(lines[index]);
+    }
+    return body.join("\n").trim();
+}
+
+function countNotes(markdown) {
+    return markdown.split(/\r?\n/).filter((line) => line.trim().startsWith("- ")).length;
+}
+
+async function readMacVersion(root) {
+    const plist = await readFile(`${root}/mac/TinyClips/Info.plist`, "utf8");
+    const match = plist.match(/<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/);
+    return match?.[1] ?? "unknown";
+}
+
+async function getTags(platform) {
+    const output = await run("git", ["tag", "--list", `v*-${platform}`]);
+    return output.split(/\r?\n/).filter((tag) => TAG_PATTERNS[platform].test(tag)).sort(compareTags);
+}
+
+async function getWorkflow(workflow) {
+    const result = await tryRun("gh", [
+        "run", "list", "--workflow", workflow, "--limit", "8",
+        "--json", "status,conclusion,displayTitle,createdAt,url",
+    ]);
+    if (!result.ok) {
+        return { available: false, error: result.error };
+    }
+    const runs = JSON.parse(result.output || "[]");
+    return { available: true, run: runs[0] ?? null, runs };
+}
+
+async function getReleases() {
+    const result = await tryRun("gh", [
+        "release", "list", "--limit", "20",
+        "--json", "tagName,name,isDraft,isPrerelease,publishedAt",
+    ]);
+    if (!result.ok) {
+        return { available: false, releases: [], error: result.error };
+    }
+    return { available: true, releases: JSON.parse(result.output || "[]") };
+}
+
+function comparePackageVersions(left, right) {
+    const a = left.split(".").map(Number);
+    const b = right.split(".").map(Number);
+    const length = Math.max(a.length, b.length);
+    for (let index = 0; index < length; index += 1) {
+        const difference = (b[index] ?? 0) - (a[index] ?? 0);
+        if (difference !== 0) {
+            return difference;
+        }
+    }
+    return 0;
+}
+
+function windowsTagToPackageVersion(tag) {
+    const match = tag?.match(/^v(\d+\.\d+\.\d+)(?:\.(\d+))?-windows$/);
+    return match ? `${match[1]}.${match[2] ?? "0"}` : null;
+}
+
+async function getWingetPublishedVersion() {
+    const url = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/r/Refractored/TinyClips";
+    try {
+        const response = await fetch(url, {
+            headers: {
+                Accept: "application/vnd.github+json",
+                "User-Agent": "tinyclips-release-hub",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+            throw new Error(`GitHub API returned ${response.status}.`);
+        }
+        const entries = await response.json();
+        if (!Array.isArray(entries)) {
+            throw new Error("Unexpected winget package response.");
+        }
+        const versions = entries
+            .filter((entry) => entry.type === "dir" && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name))
+            .sort((left, right) => comparePackageVersions(left.name, right.name));
+        const latest = versions[0];
+        return latest
+            ? { available: true, version: latest.name, url: latest.html_url }
+            : { available: true, version: null, url: null };
+    } catch (error) {
+        return {
+            available: false,
+            version: null,
+            url: null,
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
+}
+
+export async function generateReleaseNotes(platform, version) {
+    const config = platformConfig(platform);
+    const root = await getRepoRoot();
+    const markdown = await readFile(`${root}/${config.changelog}`, "utf8");
+    const body = version
+        ? extractReleaseSection(markdown, platform, version) || extractSection(markdown, config.unreleasedHeading)
+        : extractSection(markdown, config.unreleasedHeading);
+    const tag = version || "NEXT_VERSION";
+    const install = platform === "mac"
+        ? [
+            "## Install",
+            "Install Tiny Clips for macOS with Homebrew:",
+            "",
+            "```text",
+            "brew install --cask tiny-clips",
+            "```",
+            "",
+            "Already installed? Update with `brew upgrade --cask tiny-clips`.",
+            "",
+            "## Release validation",
+            "- Apple notarization and stapling completed successfully.",
+            "- Signature verification passed (`spctl` and `codesign`).",
+            "- Sparkle appcast and Homebrew cask metadata will be updated.",
+        ]
+        : [
+            "## Install",
+            "Install Tiny Clips for Windows from any Windows 11 terminal:",
+            "",
+            "```text",
+            "winget install Refractored.TinyClips",
+            "```",
+            "",
+            "Update later with `winget upgrade Refractored.TinyClips`.",
+            "",
+            "## Release validation",
+            "- Azure Artifact Signing, SignTool verification, and WACK run in the release workflow.",
+            "- x64 and ARM64 MSIX packages are published before the separate winget submission.",
+        ];
+    const notes = [body || "- Maintenance release.", "", ...install].join("\n").trim();
+    return { platform, version: tag, source: config.changelog, notes, itemCount: countNotes(body) };
+}
+
+export async function getReleaseSnapshot() {
+    const root = await getRepoRoot();
+    const [branch, status, macTags, windowsTags, macVersion, releases, macWorkflow, windowsWorkflow, wingetWorkflow, wingetPublished] =
+        await Promise.all([
+            run("git", ["branch", "--show-current"]),
+            run("git", ["status", "--porcelain"]),
+            getTags("mac"),
+            getTags("windows"),
+            readMacVersion(root),
+            getReleases(),
+            getWorkflow("release.yml"),
+            getWorkflow("windows-release.yml"),
+            getWorkflow("winget-submit.yml"),
+            getWingetPublishedVersion(),
+        ]);
+
+    const releaseByTag = new Map(releases.releases.map((release) => [release.tagName, release]));
+    const buildPlatform = async (platform, tags, workflow) => {
+        const config = platformConfig(platform);
+        const markdown = await readFile(`${root}/${config.changelog}`, "utf8");
+        const latestTag = tags[0] ?? null;
+        const suggestedTag = nextPatchTag(platform, latestTag, platform === "mac" ? macVersion : null);
+        const releasePackageVersion = platform === "windows" ? windowsTagToPackageVersion(latestTag) : null;
+        const wingetStatus = platform === "windows" && wingetPublished.available && wingetPublished.version && releasePackageVersion
+            ? (comparePackageVersions(wingetPublished.version, releasePackageVersion) === 0 ? "current" : "outdated")
+            : "unavailable";
+        return {
+            id: platform,
+            label: platform === "mac" ? "macOS" : "Windows",
+            latestTag,
+            latestRelease: latestTag ? releaseByTag.get(latestTag) ?? null : null,
+            suggestedTag,
+            appVersion: platform === "mac" ? macVersion : null,
+            changelog: config.changelog,
+            unreleasedNotes: extractSection(markdown, config.unreleasedHeading),
+            unreleasedCount: countNotes(extractSection(markdown, config.unreleasedHeading)),
+            workflow,
+            wingetWorkflow: platform === "windows" ? wingetWorkflow : null,
+            wingetPublished: platform === "windows"
+                ? { ...wingetPublished, releasePackageVersion, status: wingetStatus }
+                : null,
+        };
+    };
+
+    return {
+        generatedAt: new Date().toISOString(),
+        repository: root,
+        git: {
+            branch,
+            clean: status.length === 0,
+            changeCount: status ? status.split(/\r?\n/).length : 0,
+            canPushRelease: branch === "main",
+        },
+        githubAvailable: releases.available,
+        githubError: releases.error ?? null,
+        platforms: {
+            mac: await buildPlatform("mac", macTags, macWorkflow),
+            windows: await buildPlatform("windows", windowsTags, windowsWorkflow),
+        },
+    };
+}
+
+function assertTag(platform, tag) {
+    if (!TAG_PATTERNS[platform].test(tag)) {
+        throw new Error(`Invalid ${platform} release tag: ${tag}`);
+    }
+}
+
+function assertConfirmation(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`Confirmation must exactly match: ${expected}`);
+    }
+}
+
+export async function performReleaseAction(action, input) {
+    if (action === "prepare_release") {
+        assertTag(input.platform, input.version);
+        assertConfirmation(input.confirmation, `PREPARE ${input.version}`);
+        const root = await getRepoRoot();
+        if (process.platform === "win32") {
+            const output = await run("powershell", [
+                "-NoProfile", "-ExecutionPolicy", "Bypass",
+                "-File", `${root}\\.github\\skills\\tag-new-release\\tag-new-release.ps1`,
+                "-Platform", input.platform, "-Version", input.version,
+            ]);
+            return { action, tag: input.version, output };
+        }
+        const output = await run("bash", [
+            `${root}/.github/skills/tag-new-release/tag-new-release.sh`,
+            "--platform", input.platform, "--version", input.version,
+        ]);
+        return { action, tag: input.version, output };
+    }
+
+    if (action === "push_release") {
+        const platform = input.tag.endsWith("-mac") ? "mac" : "windows";
+        assertTag(platform, input.tag);
+        assertConfirmation(input.confirmation, `PUSH ${input.tag}`);
+        const branch = await run("git", ["branch", "--show-current"]);
+        if (branch !== "main") {
+            throw new Error(`Release pushes are only allowed from main; current branch is ${branch}.`);
+        }
+        await run("git", ["push", "origin", "main"]);
+        const output = await run("git", ["push", "origin", input.tag]);
+        return { action, tag: input.tag, output: output || `Pushed ${input.tag}.` };
+    }
+
+    if (action === "run_release_workflow") {
+        assertTag(input.platform, input.tag);
+        assertConfirmation(input.confirmation, `RUN ${input.tag}`);
+        const config = platformConfig(input.platform);
+        const output = await run("gh", [
+            "workflow", "run", config.workflow, "-f", `${config.workflowInput}=${input.tag}`,
+        ]);
+        return { action, tag: input.tag, output: output || `Dispatched ${config.workflow}.` };
+    }
+
+    if (action === "submit_winget") {
+        assertTag("windows", input.tag);
+        assertConfirmation(input.confirmation, `SUBMIT ${input.tag}`);
+        const releaseResult = await tryRun("gh", ["release", "view", input.tag, "--json", "isDraft"]);
+        if (!releaseResult.ok || JSON.parse(releaseResult.output).isDraft) {
+            throw new Error(`Published GitHub release ${input.tag} was not found.`);
+        }
+        const output = await run("gh", [
+            "workflow", "run", "winget-submit.yml", "-f", `tag=${input.tag}`,
+        ]);
+        return { action, tag: input.tag, output: output || "Dispatched winget submission." };
+    }
+
+    throw new Error(`Unknown release action: ${action}`);
+}

--- a/.github/extensions/tinyclips-release-hub/release-data.mjs
+++ b/.github/extensions/tinyclips-release-hub/release-data.mjs
@@ -135,6 +135,20 @@ async function getTags(platform) {
     return output.split(/\r?\n/).filter((tag) => TAG_PATTERNS[platform].test(tag)).sort(compareTags);
 }
 
+async function getRemoteTags(platform) {
+    const result = await tryRun("git", [
+        "ls-remote", "--tags", "origin", `refs/tags/v*-${platform}`,
+    ]);
+    if (!result.ok) {
+        return { available: false, tags: [], error: result.error };
+    }
+    const tags = result.output
+        .split(/\r?\n/)
+        .map((line) => line.match(/refs\/tags\/(.+?)(?:\^\{\})?$/)?.[1])
+        .filter((tag) => tag && TAG_PATTERNS[platform].test(tag));
+    return { available: true, tags: [...new Set(tags)].sort(compareTags) };
+}
+
 async function getWorkflow(workflow) {
     const result = await tryRun("gh", [
         "run", "list", "--workflow", workflow, "--limit", "8",
@@ -255,12 +269,14 @@ export async function generateReleaseNotes(platform, version) {
 
 export async function getReleaseSnapshot() {
     const root = await getRepoRoot();
-    const [branch, status, macTags, windowsTags, macVersion, releases, macWorkflow, windowsWorkflow, wingetWorkflow, wingetPublished] =
+    const [branch, status, macTags, windowsTags, remoteMacTags, remoteWindowsTags, macVersion, releases, macWorkflow, windowsWorkflow, wingetWorkflow, wingetPublished] =
         await Promise.all([
             run("git", ["branch", "--show-current"]),
             run("git", ["status", "--porcelain"]),
             getTags("mac"),
             getTags("windows"),
+            getRemoteTags("mac"),
+            getRemoteTags("windows"),
             readMacVersion(root),
             getReleases(),
             getWorkflow("release.yml"),
@@ -269,13 +285,22 @@ export async function getReleaseSnapshot() {
             getWingetPublishedVersion(),
         ]);
 
-    const releaseByTag = new Map(releases.releases.map((release) => [release.tagName, release]));
-    const buildPlatform = async (platform, tags, workflow) => {
+    const buildPlatform = async (platform, tags, remoteTagResult, workflow) => {
         const config = platformConfig(platform);
         const markdown = await readFile(`${root}/${config.changelog}`, "utf8");
         const latestTag = tags[0] ?? null;
-        const suggestedTag = nextPatchTag(platform, latestTag, platform === "mac" ? macVersion : null);
-        const releasePackageVersion = platform === "windows" ? windowsTagToPackageVersion(latestTag) : null;
+        const remoteTagSet = new Set(remoteTagResult.tags);
+        const latestRemoteTag = remoteTagResult.tags[0] ?? null;
+        const pendingTag = remoteTagResult.available
+            ? tags.find((tag) => !remoteTagSet.has(tag)) ?? null
+            : null;
+        const suggestedTag = pendingTag ?? nextPatchTag(
+            platform,
+            latestRemoteTag ?? latestTag,
+            platform === "mac" ? macVersion : null,
+        );
+        const latestRelease = releases.releases.find((release) => TAG_PATTERNS[platform].test(release.tagName)) ?? null;
+        const releasePackageVersion = platform === "windows" ? windowsTagToPackageVersion(latestRelease?.tagName) : null;
         const wingetStatus = platform === "windows" && wingetPublished.available && wingetPublished.version && releasePackageVersion
             ? (comparePackageVersions(wingetPublished.version, releasePackageVersion) === 0 ? "current" : "outdated")
             : "unavailable";
@@ -283,7 +308,10 @@ export async function getReleaseSnapshot() {
             id: platform,
             label: platform === "mac" ? "macOS" : "Windows",
             latestTag,
-            latestRelease: latestTag ? releaseByTag.get(latestTag) ?? null : null,
+            latestRemoteTag,
+            remoteTags: remoteTagResult.tags.slice(0, 20),
+            pendingTag,
+            latestRelease,
             suggestedTag,
             appVersion: platform === "mac" ? macVersion : null,
             changelog: config.changelog,
@@ -304,13 +332,14 @@ export async function getReleaseSnapshot() {
             branch,
             clean: status.length === 0,
             changeCount: status ? status.split(/\r?\n/).length : 0,
+            canPrepareRelease: branch === "main" && status.length === 0,
             canPushRelease: branch === "main",
         },
         githubAvailable: releases.available,
         githubError: releases.error ?? null,
         platforms: {
-            mac: await buildPlatform("mac", macTags, macWorkflow),
-            windows: await buildPlatform("windows", windowsTags, windowsWorkflow),
+            mac: await buildPlatform("mac", macTags, remoteMacTags, macWorkflow),
+            windows: await buildPlatform("windows", windowsTags, remoteWindowsTags, windowsWorkflow),
         },
     };
 }
@@ -331,6 +360,10 @@ export async function performReleaseAction(action, input) {
     if (action === "prepare_release") {
         assertTag(input.platform, input.version);
         assertConfirmation(input.confirmation, `PREPARE ${input.version}`);
+        const branch = await run("git", ["branch", "--show-current"]);
+        if (branch !== "main") {
+            throw new Error(`Release preparation is only allowed from main; current branch is ${branch}.`);
+        }
         const root = await getRepoRoot();
         if (process.platform === "win32") {
             const output = await run("powershell", [

--- a/.github/extensions/tinyclips-release-hub/renderer.mjs
+++ b/.github/extensions/tinyclips-release-hub/renderer.mjs
@@ -191,6 +191,7 @@ export function renderHtml({ instanceId, token }) {
     let generatedNotes = {};
     let notesViews = { mac: "preview", windows: "preview" };
     let historyViews = { mac: false, windows: false };
+    let releaseTags = { mac: null, windows: null };
     let pendingAction;
 
     const app = document.getElementById("app");
@@ -365,10 +366,34 @@ export function renderHtml({ instanceId, token }) {
 
     function renderDashboard() {
       const data = snapshot.platforms[platform];
-      const version = data.suggestedTag;
+      const version = releaseTags[platform] || data.pendingTag || data.suggestedTag;
+      releaseTags[platform] = version;
       const notes = currentNotes();
       const notesView = notesViews[platform];
-      const releasePublished = Boolean(data.latestRelease);
+      const preparedLocally = data.pendingTag === version;
+      const tagPushed = data.remoteTags?.includes(version);
+      const releasePublished = data.latestRelease?.tagName === version;
+      const onMain = snapshot.git.branch === "main";
+      const readinessBadge = preparedLocally
+        ? '<span class="badge good">Prepared locally</span>'
+        : (!onMain
+          ? '<span class="badge warn">Main branch required</span>'
+          : (snapshot.git.clean
+            ? '<span class="badge good">Ready to prepare</span>'
+            : '<span class="badge warn">Commit changes first</span>'));
+      const prepareDetail = preparedLocally
+        ? "The changelog commit and annotated tag are ready locally."
+        : (!onMain
+          ? "Merge this dashboard work, then prepare the release from main."
+          : "Moves Unreleased notes into a dated section, commits, and creates an annotated tag.");
+      const pushDetail = !onMain
+        ? "Release tags cannot be pushed from a feature branch."
+        : (tagPushed ? "This tag is already on origin." : (preparedLocally
+          ? "Pushes main and the prepared tag; the tag push starts the release workflow."
+          : "Prepare the release tag first."));
+      const workflowDetail = tagPushed
+        ? "The tag push starts this automatically; use this only to recover or re-run it."
+        : "Push the prepared tag before manually dispatching this workflow.";
       const wingetStep = platform === "windows"
         ? step(4, "Submit to winget", "Runs only after the GitHub release is published.", "submit_winget", "Submit", !releasePublished)
         : step(4, "Publish update metadata", "Sparkle appcast and Homebrew cask update in the macOS workflow.", "view_workflow", "In workflow", true);
@@ -377,14 +402,13 @@ export function renderHtml({ instanceId, token }) {
         '<article class="panel"><div class="panel-head"><div><h2>' + escapeHtml(data.label) +
         ' release path</h2><div class="muted">' + escapeHtml(data.unreleasedCount) +
         ' unreleased changelog items</div></div>' +
-        (snapshot.git.clean ? '<span class="badge good">Ready to prepare</span>' :
-          '<span class="badge warn">Commit changes first</span>') + '</div>' +
+        readinessBadge + '</div>' +
         '<label for="version">Release tag</label><div class="version-row"><input id="version" value="' +
         escapeHtml(version) + '" spellcheck="false" /><button class="action" data-action="generate_notes" type="button">Generate notes</button></div>' +
         '<div class="steps">' +
-        step(1, "Prepare release", "Moves Unreleased notes into a dated section, commits, and creates an annotated tag.", "prepare_release", "Prepare", !snapshot.git.clean, "primary") +
-        step(2, "Push release tag", "Pushes main, then the tag. Tag push starts the platform release workflow.", "push_release", "Push", !snapshot.git.canPushRelease) +
-        step(3, "Run release workflow", "Manual dispatch path for rebuilding or recovering a release.", "run_release_workflow", "Run workflow") +
+        step(1, "Prepare release", prepareDetail, "prepare_release", preparedLocally ? "Prepared" : "Prepare", preparedLocally || !snapshot.git.canPrepareRelease, "primary") +
+        step(2, "Push release tag", pushDetail, "push_release", tagPushed ? "Pushed" : "Push", !snapshot.git.canPushRelease || !preparedLocally || tagPushed) +
+        step(3, "Run release workflow", workflowDetail, "run_release_workflow", "Re-run workflow", !tagPushed) +
         wingetStep + '</div>' +
         '<div class="workflow"><div class="workflow-head"><h2>Automation status</h2>' +
         '<button class="action" data-action="toggle_history" type="button" aria-expanded="' +
@@ -413,6 +437,9 @@ export function renderHtml({ instanceId, token }) {
 
       dashboard.querySelectorAll("[data-action]").forEach((button) => {
         button.addEventListener("click", () => handleButton(button.dataset.action));
+      });
+      document.getElementById("version")?.addEventListener("input", (event) => {
+        releaseTags[platform] = event.target.value;
       });
     }
 
@@ -443,7 +470,24 @@ export function renderHtml({ instanceId, token }) {
     }
 
     function currentVersion() {
-      return document.getElementById("version")?.value.trim() || snapshot.platforms[platform].suggestedTag;
+      return document.getElementById("version")?.value.trim() || releaseTags[platform] ||
+        snapshot.platforms[platform].suggestedTag;
+    }
+
+    function operationSuccessMessage(result) {
+      if (result.action === "prepare_release") {
+        return "Prepared " + result.tag + " locally. Continue with Push release tag.";
+      }
+      if (result.action === "push_release") {
+        return "Pushed " + result.tag + ". The release workflow should start automatically.";
+      }
+      if (result.action === "run_release_workflow") {
+        return "Dispatched the release workflow for " + result.tag + ".";
+      }
+      if (result.action === "submit_winget") {
+        return "Dispatched winget submission for " + result.tag + ".";
+      }
+      return "Release operation completed.";
     }
 
     async function handleButton(action) {
@@ -517,8 +561,11 @@ export function renderHtml({ instanceId, token }) {
       dialog.close();
       try {
         const result = await api(active.action, { ...active.body, confirmation: active.phrase });
+        if (result.tag) {
+          releaseTags[platform] = result.tag;
+        }
         renderSummary(); renderDashboard();
-        showToast(result.output || "Release operation completed.");
+        showToast(operationSuccessMessage(result));
       } catch (error) { showToast(error.message, true); }
     });
 

--- a/.github/extensions/tinyclips-release-hub/renderer.mjs
+++ b/.github/extensions/tinyclips-release-hub/renderer.mjs
@@ -1,0 +1,529 @@
+function escapeInline(value) {
+    return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+}
+
+export function renderHtml({ instanceId, token }) {
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TinyClips Release Hub</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --hub-surface: color-mix(in srgb, var(--background-color-default, #ffffff) 96%, var(--text-color-default, #1f2328) 4%);
+      --hub-control: color-mix(in srgb, var(--background-color-default, #ffffff) 90%, var(--text-color-default, #1f2328) 10%);
+      --hub-code: color-mix(in srgb, var(--background-color-default, #ffffff) 92%, var(--true-color-blue, #0969da) 8%);
+      --hub-shadow: rgb(0 0 0 / 18%);
+      --hub-backdrop: rgb(0 0 0 / 55%);
+    }
+    :root[data-color-mode="light"], body[data-color-mode="light"] { color-scheme: light; }
+    :root[data-color-mode="dark"], body[data-color-mode="dark"] {
+      color-scheme: dark;
+      --hub-shadow: rgb(0 0 0 / 45%);
+      --hub-backdrop: rgb(0 0 0 / 70%);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; background: var(--background-color-default, #0d1117);
+      color: var(--text-color-default, #f0f6fc);
+      font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+      font-size: var(--text-body-medium, 14px); line-height: var(--leading-body-medium, 20px);
+    }
+    button, input { font: inherit; }
+    button { cursor: pointer; }
+    button:hover:not(:disabled) { filter: brightness(1.08); }
+    button:focus-visible, input:focus-visible, [role="tab"]:focus-visible {
+      outline: 2px solid var(--color-focus-outline, #2f81f7); outline-offset: 2px;
+    }
+    .shell { max-width: 1180px; margin: 0 auto; padding: 24px; }
+    .topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 22px; }
+    .eyebrow { color: var(--true-color-blue, #58a6ff); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    h1 { margin: 3px 0 4px; font-size: var(--text-title-large, 28px); line-height: 1.2; }
+    .muted { color: var(--text-color-muted, #8b949e); }
+    .refresh {
+      border: 1px solid var(--border-color-default, #30363d); border-radius: 8px;
+      background: transparent; color: inherit; padding: 8px 12px;
+    }
+    .summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 18px; }
+    .metric, .panel {
+      border: 1px solid var(--border-color-default, #30363d); border-radius: 12px;
+      background: var(--hub-surface);
+    }
+    .metric { padding: 14px; min-height: 82px; }
+    .metric-label { color: var(--text-color-muted, #8b949e); font-size: 12px; }
+    .metric-value { font-size: 18px; font-weight: 650; margin-top: 5px; overflow-wrap: anywhere; }
+    .tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border-color-default, #30363d); margin-bottom: 18px; }
+    .tab {
+      border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--text-color-muted, #8b949e);
+      padding: 10px 15px; font-weight: 650;
+    }
+    .tab[aria-selected="true"] { color: inherit; border-bottom-color: var(--true-color-blue, #58a6ff); }
+    .grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(300px, .8fr); gap: 16px; }
+    .panel { padding: 18px; }
+    .panel h2 { margin: 0 0 4px; font-size: 17px; }
+    .panel-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-bottom: 14px; }
+    .badge { display: inline-flex; align-items: center; gap: 6px; padding: 3px 8px; border-radius: 999px; font-size: 12px; font-weight: 650; }
+    .good { background: var(--true-color-green-muted, #1b4721); color: var(--true-color-green, #7ee787); }
+    .warn { background: var(--true-color-yellow-muted, #4d3b05); color: var(--true-color-yellow, #f2cc60); }
+    .bad { background: var(--true-color-red-muted, #4c1c1c); color: var(--true-color-red, #ff7b72); }
+    .steps { display: grid; gap: 8px; }
+    .step { display: grid; grid-template-columns: 26px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 10px; border: 1px solid var(--border-color-default, #30363d); border-radius: 9px; }
+    .step-num { width: 24px; height: 24px; display: grid; place-items: center; border-radius: 50%; background: var(--hub-control); font-size: 12px; font-weight: 700; }
+    .step-title { font-weight: 650; }
+    .step-detail { color: var(--text-color-muted, #8b949e); font-size: 12px; margin-top: 1px; }
+    .action {
+      border: 1px solid var(--border-color-default, #30363d); border-radius: 7px;
+      background: var(--hub-control); color: inherit; padding: 6px 10px; white-space: nowrap;
+    }
+    .action.primary { background: var(--true-color-blue, #0969da); border-color: transparent; color: var(--color-white, #fff); }
+    .action.danger { color: var(--true-color-red, #ff7b72); }
+    .action:disabled { cursor: not-allowed; opacity: .5; }
+    .version-row { display: flex; gap: 8px; margin: 12px 0; }
+    input {
+      width: 100%; border: 1px solid var(--border-color-default, #30363d); border-radius: 7px;
+      background: var(--background-color-default, #0d1117); color: inherit; padding: 7px 9px;
+    }
+    .notes-source, .markdown-preview {
+      width: 100%; min-height: 380px; margin: 0; padding: 14px; overflow: auto; white-space: pre-wrap;
+      border: 1px solid var(--border-color-default, #30363d); border-radius: 9px;
+      background: var(--background-color-default, #0d1117); color: inherit;
+    }
+    .notes-source {
+      font-family: var(--font-mono, Consolas, monospace); font-size: 12px; line-height: 1.55;
+    }
+    .markdown-preview { white-space: normal; line-height: 1.6; }
+    .markdown-preview > :first-child { margin-top: 0; }
+    .markdown-preview > :last-child { margin-bottom: 0; }
+    .markdown-preview h2 { margin: 24px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--border-color-default, #30363d); font-size: 18px; }
+    .markdown-preview h3 { margin: 20px 0 7px; font-size: 15px; }
+    .markdown-preview p { margin: 8px 0; }
+    .markdown-preview ul { margin: 8px 0; padding-left: 24px; }
+    .markdown-preview li + li { margin-top: 6px; }
+    .markdown-preview code, .confirm-code {
+      border-radius: 5px; background: var(--hub-code);
+      font-family: var(--font-mono, Consolas, monospace); font-size: var(--text-code-inline, 12px);
+    }
+    .markdown-preview code { padding: 2px 5px; }
+    .markdown-preview pre { overflow: auto; margin: 12px 0; padding: 12px; border: 1px solid var(--border-color-default, #30363d); border-radius: 8px; background: var(--hub-code); }
+    .markdown-preview pre code { padding: 0; background: transparent; }
+    .markdown-preview a { color: var(--true-color-blue, #0969da); }
+    .inline-actions { display: flex; gap: 7px; flex-wrap: wrap; }
+    .view-switch { display: inline-flex; padding: 2px; border: 1px solid var(--border-color-default, #30363d); border-radius: 8px; background: var(--background-color-default, #0d1117); }
+    .view-switch .action { border: 0; background: transparent; }
+    .view-switch .action[aria-pressed="true"] { background: var(--hub-control); }
+    .workflow { margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--border-color-default, #30363d); }
+    .workflow-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .workflow-row { display: flex; justify-content: space-between; gap: 10px; margin-top: 7px; }
+    .workflow-link { margin-inline: -7px; padding: 6px 7px; border-radius: 7px; color: inherit; text-decoration: none; }
+    .workflow-link:hover { background: var(--hub-control); }
+    .history-panel { display: grid; gap: 14px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-color-default, #30363d); }
+    .history-label { margin-bottom: 6px; color: var(--text-color-muted, #8b949e); font-size: 12px; font-weight: 650; text-transform: uppercase; letter-spacing: .04em; }
+    .history-list { display: grid; gap: 6px; }
+    .history-item { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 8px; border: 1px solid var(--border-color-default, #30363d); border-radius: 8px; color: inherit; text-decoration: none; }
+    .history-item:hover { background: var(--hub-control); }
+    .history-title { overflow: hidden; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+    .history-meta { color: var(--text-color-muted, #8b949e); font-size: 12px; }
+    .history-side { display: flex; align-items: center; gap: 8px; }
+    dialog {
+      width: min(480px, calc(100vw - 32px)); border: 1px solid var(--border-color-default, #30363d);
+      border-radius: 12px; background: var(--background-color-default, #0d1117); color: inherit; padding: 20px;
+      box-shadow: 0 16px 50px var(--hub-shadow);
+    }
+    dialog::backdrop { background: var(--hub-backdrop); }
+    dialog h2 { margin: 0 0 8px; }
+    .confirm-code { display: block; margin: 10px 0; padding: 9px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 15px; }
+    .toast {
+      position: fixed; right: 20px; bottom: 20px; max-width: min(520px, calc(100vw - 40px));
+      padding: 11px 14px; border: 1px solid var(--border-color-default, #30363d); border-radius: 9px;
+      background: var(--hub-surface); box-shadow: 0 8px 30px var(--hub-shadow); display: none; white-space: pre-wrap;
+    }
+    .loading { opacity: .65; pointer-events: none; }
+    @media (max-width: 800px) {
+      .summary { grid-template-columns: repeat(2, 1fr); }
+      .grid { grid-template-columns: 1fr; }
+      .shell { padding: 16px; }
+      .step { grid-template-columns: 26px minmax(0, 1fr); }
+      .step .action { grid-column: 2; justify-self: start; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell" id="app">
+    <header class="topbar">
+      <div>
+        <div class="eyebrow">TinyClips delivery</div>
+        <h1>Release Hub</h1>
+        <div class="muted">Tags, release notes, GitHub Actions, Homebrew, Sparkle, MSIX, and winget.</div>
+      </div>
+      <button class="refresh" id="refresh" type="button">Refresh</button>
+    </header>
+    <section class="summary" id="summary" aria-label="Repository release summary"></section>
+    <div class="tabs" role="tablist" aria-label="Release platform">
+      <button class="tab" id="tab-mac" role="tab" aria-controls="dashboard" aria-selected="true" data-platform="mac">macOS</button>
+      <button class="tab" id="tab-windows" role="tab" aria-controls="dashboard" aria-selected="false" data-platform="windows">Windows</button>
+    </div>
+    <section class="grid" id="dashboard" role="tabpanel" aria-live="polite"></section>
+  </main>
+  <dialog id="confirm-dialog" aria-labelledby="confirm-title">
+    <h2 id="confirm-title">Confirm release operation</h2>
+    <p id="confirm-description" class="muted"></p>
+    <span class="confirm-code" id="confirm-code"></span>
+    <input id="confirm-input" autocomplete="off" aria-label="Type confirmation text" />
+    <div class="dialog-actions">
+      <button class="action" id="confirm-cancel" type="button">Cancel</button>
+      <button class="action danger" id="confirm-run" type="button">Run operation</button>
+    </div>
+  </dialog>
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  <script>
+    const TOKEN = ${JSON.stringify(token)};
+    const INSTANCE_ID = ${JSON.stringify(escapeInline(instanceId))};
+    let snapshot;
+    let platform = "mac";
+    let generatedNotes = {};
+    let notesViews = { mac: "preview", windows: "preview" };
+    let historyViews = { mac: false, windows: false };
+    let pendingAction;
+
+    const app = document.getElementById("app");
+    const dashboard = document.getElementById("dashboard");
+    const dialog = document.getElementById("confirm-dialog");
+    const confirmInput = document.getElementById("confirm-input");
+
+    const escapeHtml = (value) => String(value ?? "")
+      .replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+
+    function renderInlineMarkdown(value) {
+      return escapeHtml(value)
+        .replace(/\\[([^\\]]+)\\]\\((https?:\\/\\/[^\\s)]+)\\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>')
+        .replace(/\\*\\*([^*]+)\\*\\*/g, "<strong>$1</strong>")
+        .replace(/\`([^\`]+)\`/g, "<code>$1</code>");
+    }
+
+    function renderMarkdown(markdown) {
+      const lines = String(markdown ?? "").split(/\\r?\\n/);
+      const output = [];
+      let inCode = false;
+      let codeLines = [];
+      let inList = false;
+
+      const closeList = () => {
+        if (inList) {
+          output.push("</ul>");
+          inList = false;
+        }
+      };
+
+      for (const line of lines) {
+        if (line.trim().startsWith("\`\`\`")) {
+          closeList();
+          if (inCode) {
+            output.push("<pre><code>" + escapeHtml(codeLines.join("\\n")) + "</code></pre>");
+            codeLines = [];
+          }
+          inCode = !inCode;
+          continue;
+        }
+        if (inCode) {
+          codeLines.push(line);
+          continue;
+        }
+        if (!line.trim()) {
+          closeList();
+          continue;
+        }
+        const heading = line.match(/^(#{2,3})\\s+(.+)$/);
+        if (heading) {
+          closeList();
+          const level = heading[1].length;
+          output.push("<h" + level + ">" + renderInlineMarkdown(heading[2]) + "</h" + level + ">");
+          continue;
+        }
+        if (line.startsWith("- ")) {
+          if (!inList) {
+            output.push("<ul>");
+            inList = true;
+          }
+          output.push("<li>" + renderInlineMarkdown(line.slice(2)) + "</li>");
+          continue;
+        }
+        closeList();
+        output.push("<p>" + renderInlineMarkdown(line) + "</p>");
+      }
+      closeList();
+      if (inCode) {
+        output.push("<pre><code>" + escapeHtml(codeLines.join("\\n")) + "</code></pre>");
+      }
+      return output.join("");
+    }
+
+    function currentNotes() {
+      const data = snapshot.platforms[platform];
+      return generatedNotes[platform]?.notes || data.unreleasedNotes || "No unreleased notes yet.";
+    }
+
+    function showToast(message, isError = false) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.style.display = "block";
+      toast.style.borderColor = isError ? "var(--true-color-red, #ff7b72)" : "var(--border-color-default, #30363d)";
+      window.clearTimeout(showToast.timer);
+      showToast.timer = window.setTimeout(() => { toast.style.display = "none"; }, 7000);
+    }
+
+    function workflowLabel(workflow) {
+      if (!workflow?.available) return "Unavailable";
+      if (!workflow.run) return "No runs";
+      return workflow.run.conclusion || workflow.run.status || "Unknown";
+    }
+
+    function workflowBadge(workflow) {
+      const label = workflowLabel(workflow);
+      const kind = label === "success" ? "good" : (label === "failure" ? "bad" : "warn");
+      return '<span class="badge ' + kind + '">' + escapeHtml(label) + '</span>';
+    }
+
+    function workflowRow(label, workflow) {
+      const content = '<span>' + escapeHtml(label) + '</span>' + workflowBadge(workflow);
+      return workflow?.run?.url
+        ? '<a class="workflow-row workflow-link" href="' + escapeHtml(workflow.run.url) +
+          '" target="_blank" rel="noreferrer" title="Open latest GitHub Actions run">' + content + '</a>'
+        : '<div class="workflow-row">' + content + '</div>';
+    }
+
+    function formatRunDate(value) {
+      if (!value) return "Unknown date";
+      return new Date(value).toLocaleString([], {
+        month: "short", day: "numeric", hour: "numeric", minute: "2-digit"
+      });
+    }
+
+    function workflowHistorySection(label, workflow) {
+      const runs = workflow?.runs || [];
+      if (!runs.length) {
+        return '<section><div class="history-label">' + escapeHtml(label) +
+          '</div><div class="muted">No recent runs found.</div></section>';
+      }
+      return '<section><div class="history-label">' + escapeHtml(label) + '</div><div class="history-list">' +
+        runs.map((run) =>
+          '<a class="history-item" href="' + escapeHtml(run.url) + '" target="_blank" rel="noreferrer">' +
+          '<div><div class="history-title">' + escapeHtml(run.displayTitle || label) +
+          '</div><div class="history-meta">' + escapeHtml(formatRunDate(run.createdAt)) + '</div></div>' +
+          '<div class="history-side">' + workflowBadge({ available: true, run }) + '<span aria-hidden="true">↗</span></div></a>'
+        ).join("") + '</div></section>';
+    }
+
+    function renderWorkflowHistory(data) {
+      if (!historyViews[platform]) return "";
+      return '<div class="history-panel">' +
+        workflowHistorySection(data.label + " release", data.workflow) +
+        (platform === "windows" ? workflowHistorySection("winget submission", data.wingetWorkflow) : "") +
+        '</div>';
+    }
+
+    function wingetVersionStatus(winget) {
+      if (!winget?.available) {
+        return '<span class="badge warn" title="' + escapeHtml(winget?.error || "winget version unavailable") + '">Unavailable</span>';
+      }
+      if (!winget.version) {
+        return '<span class="badge warn">Not published</span>';
+      }
+      const kind = winget.status === "current" ? "good" : "warn";
+      const label = winget.status === "current" ? "Current" : "Behind release";
+      return '<span class="badge ' + kind + '">' + escapeHtml(label) + '</span>';
+    }
+
+    function renderSummary() {
+      const mac = snapshot.platforms.mac;
+      const windows = snapshot.platforms.windows;
+      document.getElementById("summary").innerHTML = [
+        ["Branch", snapshot.git.branch],
+        ["Working tree", snapshot.git.clean ? "Clean" : snapshot.git.changeCount + " changes"],
+        ["Latest macOS", mac.latestTag || "No tag"],
+        ["Latest Windows", windows.latestTag || "No tag"],
+      ].map(([label, value]) =>
+        '<div class="metric"><div class="metric-label">' + escapeHtml(label) +
+        '</div><div class="metric-value">' + escapeHtml(value) + '</div></div>'
+      ).join("");
+    }
+
+    function step(number, title, detail, action, label, disabled = false, extraClass = "") {
+      return '<div class="step"><div class="step-num">' + number + '</div><div><div class="step-title">' +
+        escapeHtml(title) + '</div><div class="step-detail">' + escapeHtml(detail) +
+        '</div></div><button class="action ' + extraClass + '" data-action="' + action + '" type="button"' +
+        (disabled ? " disabled" : "") + '>' + escapeHtml(label) + '</button></div>';
+    }
+
+    function renderDashboard() {
+      const data = snapshot.platforms[platform];
+      const version = data.suggestedTag;
+      const notes = currentNotes();
+      const notesView = notesViews[platform];
+      const releasePublished = Boolean(data.latestRelease);
+      const wingetStep = platform === "windows"
+        ? step(4, "Submit to winget", "Runs only after the GitHub release is published.", "submit_winget", "Submit", !releasePublished)
+        : step(4, "Publish update metadata", "Sparkle appcast and Homebrew cask update in the macOS workflow.", "view_workflow", "In workflow", true);
+
+      dashboard.innerHTML =
+        '<article class="panel"><div class="panel-head"><div><h2>' + escapeHtml(data.label) +
+        ' release path</h2><div class="muted">' + escapeHtml(data.unreleasedCount) +
+        ' unreleased changelog items</div></div>' +
+        (snapshot.git.clean ? '<span class="badge good">Ready to prepare</span>' :
+          '<span class="badge warn">Commit changes first</span>') + '</div>' +
+        '<label for="version">Release tag</label><div class="version-row"><input id="version" value="' +
+        escapeHtml(version) + '" spellcheck="false" /><button class="action" data-action="generate_notes" type="button">Generate notes</button></div>' +
+        '<div class="steps">' +
+        step(1, "Prepare release", "Moves Unreleased notes into a dated section, commits, and creates an annotated tag.", "prepare_release", "Prepare", !snapshot.git.clean, "primary") +
+        step(2, "Push release tag", "Pushes main, then the tag. Tag push starts the platform release workflow.", "push_release", "Push", !snapshot.git.canPushRelease) +
+        step(3, "Run release workflow", "Manual dispatch path for rebuilding or recovering a release.", "run_release_workflow", "Run workflow") +
+        wingetStep + '</div>' +
+        '<div class="workflow"><div class="workflow-head"><h2>Automation status</h2>' +
+        '<button class="action" data-action="toggle_history" type="button" aria-expanded="' +
+        historyViews[platform] + '">' + (historyViews[platform] ? "Hide history" : "Show history") + '</button></div>' +
+        workflowRow(data.label + " release", data.workflow) +
+        (platform === "windows" ? workflowRow("winget submission", data.wingetWorkflow) : '') +
+        '<div class="workflow-row"><span>Latest GitHub release</span><strong>' +
+        escapeHtml(data.latestRelease?.tagName || "Not found") + '</strong></div>' +
+        (platform === "windows"
+          ? '<div class="workflow-row"><span>Published on winget</span><span><strong>' +
+            escapeHtml(data.wingetPublished?.version || "Not found") + '</strong> ' +
+            wingetVersionStatus(data.wingetPublished) + '</span></div>'
+          : '') +
+        renderWorkflowHistory(data) +
+        '</div></article>' +
+        '<article class="panel"><div class="panel-head"><div><h2>Release notes</h2><div class="muted">' +
+        escapeHtml(generatedNotes[platform]?.source || data.changelog) + '</div></div><div class="inline-actions">' +
+        '<div class="view-switch" role="group" aria-label="Release notes view">' +
+        '<button class="action" data-action="show_preview" type="button" aria-pressed="' + (notesView === "preview") + '">Preview</button>' +
+        '<button class="action" data-action="show_markdown" type="button" aria-pressed="' + (notesView === "markdown") + '">Markdown</button></div>' +
+        '<button class="action" data-action="copy_notes" type="button">Copy Markdown</button></div></div>' +
+        (notesView === "preview"
+          ? '<div class="markdown-preview" id="notes-preview">' + renderMarkdown(notes) + '</div>'
+          : '<pre class="notes-source" id="notes-source">' + escapeHtml(notes) + '</pre>') +
+        '</article>';
+
+      dashboard.querySelectorAll("[data-action]").forEach((button) => {
+        button.addEventListener("click", () => handleButton(button.dataset.action));
+      });
+    }
+
+    async function api(action, body = {}) {
+      app.classList.add("loading");
+      try {
+        const response = await fetch("/api/action", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Release-Hub-Token": TOKEN },
+          body: JSON.stringify({ action, ...body }),
+        });
+        const payload = await response.json();
+        if (!response.ok || payload.error) throw new Error(payload.error || "Release operation failed.");
+        if (payload.snapshot) snapshot = payload.snapshot;
+        return payload.result;
+      } finally {
+        app.classList.remove("loading");
+      }
+    }
+
+    function openConfirmation(action, body, phrase, description) {
+      pendingAction = { action, body, phrase };
+      document.getElementById("confirm-description").textContent = description + " Type this exact phrase:";
+      document.getElementById("confirm-code").textContent = phrase;
+      confirmInput.value = "";
+      dialog.showModal();
+      confirmInput.focus();
+    }
+
+    function currentVersion() {
+      return document.getElementById("version")?.value.trim() || snapshot.platforms[platform].suggestedTag;
+    }
+
+    async function handleButton(action) {
+      const tag = currentVersion();
+      if (action === "generate_notes") {
+        try {
+          generatedNotes[platform] = await api("generate_notes", { platform, version: tag });
+          renderSummary(); renderDashboard();
+          showToast("Release notes generated from " + generatedNotes[platform].source + ".");
+        } catch (error) { showToast(error.message, true); }
+        return;
+      }
+      if (action === "copy_notes") {
+        await navigator.clipboard.writeText(currentNotes());
+        showToast("Release notes copied as Markdown.");
+        return;
+      }
+      if (action === "show_preview" || action === "show_markdown") {
+        notesViews[platform] = action === "show_preview" ? "preview" : "markdown";
+        renderDashboard();
+        return;
+      }
+      if (action === "toggle_history") {
+        historyViews[platform] = !historyViews[platform];
+        renderDashboard();
+        return;
+      }
+      if (action === "prepare_release") {
+        openConfirmation(action, { platform, version: tag }, "PREPARE " + tag,
+          "This creates a changelog commit and annotated tag locally.");
+      } else if (action === "push_release") {
+        openConfirmation(action, { tag }, "PUSH " + tag,
+          "This pushes main and the tag to origin, which starts the release workflow.");
+      } else if (action === "run_release_workflow") {
+        openConfirmation(action, { platform, tag }, "RUN " + tag,
+          "This manually dispatches the platform release workflow.");
+      } else if (action === "submit_winget") {
+        openConfirmation(action, { tag }, "SUBMIT " + tag,
+          "This submits the published Windows release to microsoft/winget-pkgs.");
+      }
+    }
+
+    async function refresh() {
+      app.classList.add("loading");
+      try {
+        const response = await fetch("/api/status");
+        const payload = await response.json();
+        if (!response.ok || payload.error) throw new Error(payload.error || "Refresh failed.");
+        snapshot = payload;
+        renderSummary(); renderDashboard();
+      } catch (error) { showToast(error.message, true); }
+      finally { app.classList.remove("loading"); }
+    }
+
+    document.querySelectorAll("[role=tab]").forEach((tab) => {
+      tab.addEventListener("click", () => {
+        platform = tab.dataset.platform;
+        document.querySelectorAll("[role=tab]").forEach((item) =>
+          item.setAttribute("aria-selected", String(item === tab)));
+        renderDashboard();
+      });
+    });
+    document.getElementById("refresh").addEventListener("click", refresh);
+    document.getElementById("confirm-cancel").addEventListener("click", () => dialog.close());
+    document.getElementById("confirm-run").addEventListener("click", async () => {
+      if (!pendingAction || confirmInput.value !== pendingAction.phrase) {
+        showToast("Confirmation text does not match.", true);
+        return;
+      }
+      const active = pendingAction;
+      dialog.close();
+      try {
+        const result = await api(active.action, { ...active.body, confirmation: active.phrase });
+        renderSummary(); renderDashboard();
+        showToast(result.output || "Release operation completed.");
+      } catch (error) { showToast(error.message, true); }
+    });
+
+    refresh();
+  </script>
+</body>
+</html>`;
+}

--- a/.github/skills/tag-new-release/tag-new-release.ps1
+++ b/.github/skills/tag-new-release/tag-new-release.ps1
@@ -27,8 +27,10 @@ function Get-PlistValue {
         [string]$KeyName
     )
 
-    [xml]$plist = Get-Content -Raw -Path $Path
-    $dict = $plist.plist.dict
+    $plist = New-Object System.Xml.XmlDocument
+    $plist.XmlResolver = $null
+    $plist.LoadXml([System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8))
+    $dict = $plist.SelectSingleNode("/plist/dict")
     if (-not $dict) {
         throw "Could not parse plist dict in $Path"
     }
@@ -161,7 +163,7 @@ if (-not (Test-Path $changelogPath)) {
     throw "Changelog not found: $changelogPath"
 }
 
-$originalLines = Get-Content -Path $changelogPath
+$originalLines = [System.IO.File]::ReadAllLines($changelogPath, [System.Text.Encoding]::UTF8)
 $unreleasedIndex = [Array]::IndexOf($originalLines, $unreleasedLine)
 if ($unreleasedIndex -lt 0) {
     throw "Could not find expected Unreleased heading in $changelogPath"
@@ -190,7 +192,8 @@ if ($DryRun) {
     exit 0
 }
 
-Set-Content -Path $changelogPath -Value ($updatedLines -join "`n") -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($changelogPath, ($updatedLines -join "`n"), $utf8NoBom)
 
 git add $changelogPath
 git commit -m @"
@@ -201,7 +204,7 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
 $tagMessageFile = New-TemporaryFile
 try {
-    Set-Content -Path $tagMessageFile -Value $tagMessage -NoNewline
+    [System.IO.File]::WriteAllText($tagMessageFile, $tagMessage, $utf8NoBom)
     git tag -a $Version -F $tagMessageFile
 } finally {
     Remove-Item -Force $tagMessageFile -ErrorAction SilentlyContinue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v1.5.3-mac - 2026-07-17
+
 ### Added
 - Added a new macOS Settings → Analytics view that tracks daily screenshot, video, and GIF capture counts locally, shows rolling 7-day or 30-day bar charts, and lets you reset the stored history.
 - Extended macOS capture analytics with lifetime (all-time) totals per capture type, a per-type series toggle to show/hide screenshots/videos/GIFs on the chart, hover tooltips with exact daily counts, a "busiest day of week" and "most active hour" insights breakdown, and Copy Summary / Share buttons for a quick text summary of your capture activity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## v1.5.3-mac - 2026-07-17
-
 ### Added
 - Added a new macOS Settings → Analytics view that tracks daily screenshot, video, and GIF capture counts locally, shows rolling 7-day or 30-day bar charts, and lets you reset the stored history.
 - Extended macOS capture analytics with lifetime (all-time) totals per capture type, a per-type series toggle to show/hide screenshots/videos/GIFs on the chart, hover tooltips with exact daily counts, a "busiest day of week" and "most active hour" insights breakdown, and Copy Summary / Share buttons for a quick text summary of your capture activity.


### PR DESCRIPTION
TinyClips has separate macOS and Windows release paths spanning changelogs, tags, GitHub Actions, Sparkle/Homebrew, signed MSIX packages, and winget. This adds one project-shared dashboard for understanding release readiness and safely coordinating those operations.

## What changed

- Adds a Copilot canvas with platform-specific release status, suggested tags, generated release notes, and rendered/raw Markdown views.
- Surfaces recent macOS release, Windows release, and winget submission runs with clickable GitHub Actions history.
- Queries the public winget catalog and compares its published package version with the latest Windows GitHub release.
- Provides prepare, push, workflow dispatch, and winget submission controls backed by the existing scripts and workflows.
- Models local versus remote tag state so a prepared tag remains selected and each next release step unlocks only when its prerequisite is complete.
- Fixes the PowerShell release skill's macOS plist parsing and preserves UTF-8 changelog/tag content when release preparation runs on Windows.
- Requires exact typed confirmation for every mutating operation, restricts release preparation and pushes to `main`, and keeps the iframe server loopback-only with a per-instance action token.
- Uses concise operation feedback instead of surfacing raw script output in oversized notifications.
- Uses the documented canvas theme tokens for light and dark modes.