### PR TITLE
Support releases from main-based project sessions

### DIFF
--- a/.github/extensions/tinyclips-release-hub/extension.mjs
+++ b/.github/extensions/tinyclips-release-hub/extension.mjs
@@ -140,7 +140,7 @@ await joinSession({
                 },
                 {
                     name: "push_release",
-                    description: "Push the main branch and release tag to origin after exact typed confirmation.",
+                    description: "Fast-forward main with the prepared release commit and push its tag after exact typed confirmation.",
                     inputSchema: {
                         type: "object",
                         properties: {

--- a/.github/extensions/tinyclips-release-hub/release-data.mjs
+++ b/.github/extensions/tinyclips-release-hub/release-data.mjs
@@ -269,10 +269,14 @@ export async function generateReleaseNotes(platform, version) {
 
 export async function getReleaseSnapshot() {
     const root = await getRepoRoot();
-    const [branch, status, macTags, windowsTags, remoteMacTags, remoteWindowsTags, macVersion, releases, macWorkflow, windowsWorkflow, wingetWorkflow, wingetPublished] =
+    const [branch, status, head, originMain, aheadOfMain, behindMain, macTags, windowsTags, remoteMacTags, remoteWindowsTags, macVersion, releases, macWorkflow, windowsWorkflow, wingetWorkflow, wingetPublished] =
         await Promise.all([
             run("git", ["branch", "--show-current"]),
             run("git", ["status", "--porcelain"]),
+            run("git", ["rev-parse", "HEAD"]),
+            run("git", ["rev-parse", "origin/main"]),
+            run("git", ["rev-list", "--count", "origin/main..HEAD"]),
+            run("git", ["rev-list", "--count", "HEAD..origin/main"]),
             getTags("mac"),
             getTags("windows"),
             getRemoteTags("mac"),
@@ -332,8 +336,11 @@ export async function getReleaseSnapshot() {
             branch,
             clean: status.length === 0,
             changeCount: status ? status.split(/\r?\n/).length : 0,
-            canPrepareRelease: branch === "main" && status.length === 0,
-            canPushRelease: branch === "main",
+            atMainTip: head === originMain,
+            aheadOfMain: Number(aheadOfMain),
+            behindMain: Number(behindMain),
+            canPrepareRelease: status.length === 0 && head === originMain,
+            canPushRelease: status.length === 0 && Number(behindMain) === 0 && Number(aheadOfMain) <= 1,
         },
         githubAvailable: releases.available,
         githubError: releases.error ?? null,
@@ -360,9 +367,17 @@ export async function performReleaseAction(action, input) {
     if (action === "prepare_release") {
         assertTag(input.platform, input.version);
         assertConfirmation(input.confirmation, `PREPARE ${input.version}`);
-        const branch = await run("git", ["branch", "--show-current"]);
-        if (branch !== "main") {
-            throw new Error(`Release preparation is only allowed from main; current branch is ${branch}.`);
+        await run("git", ["fetch", "--quiet", "origin", "main"]);
+        const [head, originMain, status] = await Promise.all([
+            run("git", ["rev-parse", "HEAD"]),
+            run("git", ["rev-parse", "origin/main"]),
+            run("git", ["status", "--porcelain"]),
+        ]);
+        if (status) {
+            throw new Error("Release preparation requires a clean working tree.");
+        }
+        if (head !== originMain) {
+            throw new Error("Release preparation requires a session based exactly on the latest origin/main.");
         }
         const root = await getRepoRoot();
         if (process.platform === "win32") {
@@ -384,11 +399,29 @@ export async function performReleaseAction(action, input) {
         const platform = input.tag.endsWith("-mac") ? "mac" : "windows";
         assertTag(platform, input.tag);
         assertConfirmation(input.confirmation, `PUSH ${input.tag}`);
-        const branch = await run("git", ["branch", "--show-current"]);
-        if (branch !== "main") {
-            throw new Error(`Release pushes are only allowed from main; current branch is ${branch}.`);
+        await run("git", ["fetch", "--quiet", "origin", "main"]);
+        const [head, originMain, status, aheadOfMain, behindMain, tagCommit] = await Promise.all([
+            run("git", ["rev-parse", "HEAD"]),
+            run("git", ["rev-parse", "origin/main"]),
+            run("git", ["status", "--porcelain"]),
+            run("git", ["rev-list", "--count", "origin/main..HEAD"]),
+            run("git", ["rev-list", "--count", "HEAD..origin/main"]),
+            run("git", ["rev-list", "-n", "1", input.tag]),
+        ]);
+        if (status) {
+            throw new Error("Release push requires a clean working tree.");
         }
-        await run("git", ["push", "origin", "main"]);
+        if (tagCommit !== head) {
+            throw new Error(`Tag ${input.tag} does not point at the current release commit.`);
+        }
+        if (Number(behindMain) !== 0 || Number(aheadOfMain) > 1) {
+            throw new Error("Release push requires at most one release commit ahead of the latest origin/main.");
+        }
+        if (Number(aheadOfMain) === 1) {
+            await run("git", ["push", "origin", "HEAD:refs/heads/main"]);
+        } else if (head !== originMain) {
+            throw new Error("Current release commit does not match origin/main.");
+        }
         const output = await run("git", ["push", "origin", input.tag]);
         return { action, tag: input.tag, output: output || `Pushed ${input.tag}.` };
     }

--- a/.github/extensions/tinyclips-release-hub/renderer.mjs
+++ b/.github/extensions/tinyclips-release-hub/renderer.mjs
@@ -373,24 +373,23 @@ export function renderHtml({ instanceId, token }) {
       const preparedLocally = data.pendingTag === version;
       const tagPushed = data.remoteTags?.includes(version);
       const releasePublished = data.latestRelease?.tagName === version;
-      const onMain = snapshot.git.branch === "main";
       const readinessBadge = preparedLocally
         ? '<span class="badge good">Prepared locally</span>'
-        : (!onMain
-          ? '<span class="badge warn">Main branch required</span>'
+        : (!snapshot.git.atMainTip
+          ? '<span class="badge warn">Latest main required</span>'
           : (snapshot.git.clean
             ? '<span class="badge good">Ready to prepare</span>'
             : '<span class="badge warn">Commit changes first</span>'));
       const prepareDetail = preparedLocally
         ? "The changelog commit and annotated tag are ready locally."
-        : (!onMain
-          ? "Merge this dashboard work, then prepare the release from main."
+        : (!snapshot.git.atMainTip
+          ? "Start from the latest origin/main with no additional commits."
           : "Moves Unreleased notes into a dated section, commits, and creates an annotated tag.");
-      const pushDetail = !onMain
-        ? "Release tags cannot be pushed from a feature branch."
-        : (tagPushed ? "This tag is already on origin." : (preparedLocally
-          ? "Pushes main and the prepared tag; the tag push starts the release workflow."
-          : "Prepare the release tag first."));
+      const pushDetail = tagPushed
+        ? "This tag is already on origin."
+        : (preparedLocally
+          ? "Fast-forwards main with the release commit, then pushes the tag to start the workflow."
+          : "Prepare the release tag first.");
       const workflowDetail = tagPushed
         ? "The tag push starts this automatically; use this only to recover or re-run it."
         : "Push the prepared tag before manually dispatching this workflow.";
@@ -406,7 +405,7 @@ export function renderHtml({ instanceId, token }) {
         '<label for="version">Release tag</label><div class="version-row"><input id="version" value="' +
         escapeHtml(version) + '" spellcheck="false" /><button class="action" data-action="generate_notes" type="button">Generate notes</button></div>' +
         '<div class="steps">' +
-        step(1, "Prepare release", prepareDetail, "prepare_release", preparedLocally ? "Prepared" : "Prepare", preparedLocally || !snapshot.git.canPrepareRelease, "primary") +
+        step(1, "Prepare release", prepareDetail, "prepare_release", tagPushed ? "Released" : (preparedLocally ? "Prepared" : "Prepare"), preparedLocally || tagPushed || !snapshot.git.canPrepareRelease, "primary") +
         step(2, "Push release tag", pushDetail, "push_release", tagPushed ? "Pushed" : "Push", !snapshot.git.canPushRelease || !preparedLocally || tagPushed) +
         step(3, "Run release workflow", workflowDetail, "run_release_workflow", "Re-run workflow", !tagPushed) +
         wingetStep + '</div>' +
@@ -520,7 +519,7 @@ export function renderHtml({ instanceId, token }) {
           "This creates a changelog commit and annotated tag locally.");
       } else if (action === "push_release") {
         openConfirmation(action, { tag }, "PUSH " + tag,
-          "This pushes main and the tag to origin, which starts the release workflow.");
+          "This fast-forwards main with the prepared release commit, then pushes the tag to start the release workflow.");
       } else if (action === "run_release_workflow") {
         openConfirmation(action, { platform, tag }, "RUN " + tag,
           "This manually dispatches the platform release workflow.");


### PR DESCRIPTION
Local Copilot project sessions use generated branches even when they start from `main`, so requiring the literal branch name `main` prevented the release dashboard from being tested or used in a clean session.

## What changed

- Treats a clean session whose `HEAD` exactly matches `origin/main` as ready for release preparation.
- After preparation, permits only the single generated release commit ahead of `origin/main`.
- Verifies the selected annotated tag points at that release commit.
- Fast-forwards `main` with `HEAD:main` before pushing the release tag, without force pushing.
- Supports retrying the tag push if the main fast-forward succeeded first.
- Keeps stale, diverged, dirty, and unrelated feature branches blocked.