### PR TITLE
Add undo for local release preparation

### DIFF
--- a/.github/extensions/tinyclips-release-hub/extension.mjs
+++ b/.github/extensions/tinyclips-release-hub/extension.mjs
@@ -166,6 +166,21 @@ await joinSession({
                     handler: async (ctx) => performReleaseAction("prepare_release", ctx.input),
                 },
                 {
+                    name: "undo_prepare",
+                    description: "Delete an unpushed local release tag and restore its single release commit after exact typed confirmation.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            platform: platformSchema,
+                            tag: { type: "string", minLength: 1 },
+                            confirmation: { type: "string", minLength: 1 },
+                        },
+                        required: ["platform", "tag", "confirmation"],
+                        additionalProperties: false,
+                    },
+                    handler: async (ctx) => performReleaseAction("undo_prepare", ctx.input),
+                },
+                {
                     name: "push_release",
                     description: "Fast-forward main with the prepared release commit and push its tag after exact typed confirmation.",
                     inputSchema: {

--- a/.github/extensions/tinyclips-release-hub/release-data.mjs
+++ b/.github/extensions/tinyclips-release-hub/release-data.mjs
@@ -421,6 +421,48 @@ export async function performReleaseAction(action, input) {
         return { action, tag: input.version, output };
     }
 
+    if (action === "undo_prepare") {
+        assertTag(input.platform, input.tag);
+        assertConfirmation(input.confirmation, `UNDO ${input.tag}`);
+        await run("git", ["fetch", "--quiet", "origin", "main"]);
+        const config = platformConfig(input.platform);
+        const [head, originMain, status, aheadOfMain, behindMain, tagCommit, tagType, subject, changedFiles, remoteTag] =
+            await Promise.all([
+                run("git", ["rev-parse", "HEAD"]),
+                run("git", ["rev-parse", "origin/main"]),
+                run("git", ["status", "--porcelain"]),
+                run("git", ["rev-list", "--count", "origin/main..HEAD"]),
+                run("git", ["rev-list", "--count", "HEAD..origin/main"]),
+                run("git", ["rev-list", "-n", "1", input.tag]),
+                run("git", ["cat-file", "-t", `refs/tags/${input.tag}`]),
+                run("git", ["log", "-1", "--format=%s"]),
+                run("git", ["diff", "--name-only", "origin/main..HEAD"]),
+                run("git", ["ls-remote", "--tags", "origin", `refs/tags/${input.tag}`]),
+            ]);
+        const files = changedFiles.split(/\r?\n/).filter(Boolean);
+        if (status) {
+            throw new Error("Undo preparation requires a clean working tree.");
+        }
+        if (remoteTag) {
+            throw new Error(`Cannot undo ${input.tag} because the tag already exists on origin.`);
+        }
+        if (Number(behindMain) !== 0 || Number(aheadOfMain) !== 1) {
+            throw new Error("Undo preparation requires exactly one local release commit ahead of origin/main.");
+        }
+        if (tagCommit !== head || tagType !== "tag") {
+            throw new Error(`Tag ${input.tag} is not the annotated tag for the current release commit.`);
+        }
+        if (subject !== `Mark ${input.tag} release`) {
+            throw new Error(`Current commit is not the expected ${input.tag} release commit.`);
+        }
+        if (files.length !== 1 || files[0].replaceAll("\\", "/") !== config.changelog) {
+            throw new Error(`Release commit must only change ${config.changelog}.`);
+        }
+        await run("git", ["tag", "-d", input.tag]);
+        const output = await run("git", ["reset", "--hard", originMain]);
+        return { action, tag: input.tag, output };
+    }
+
     if (action === "push_release") {
         const platform = input.tag.endsWith("-mac") ? "mac" : "windows";
         assertTag(platform, input.tag);

--- a/.github/extensions/tinyclips-release-hub/renderer.mjs
+++ b/.github/extensions/tinyclips-release-hub/renderer.mjs
@@ -343,6 +343,9 @@ export function renderHtml({ instanceId, token }) {
       if (action === "prepare_release") {
         return ["Preparing " + tag, "Updating the changelog, committing it, and creating the annotated tag."];
       }
+      if (action === "undo_prepare") {
+        return ["Undoing " + tag, "Deleting the local tag and restoring this session to origin/main."];
+      }
       if (action === "push_release") {
         return ["Publishing " + tag, "Fast-forwarding main and pushing the release tag."];
       }
@@ -543,7 +546,7 @@ export function renderHtml({ instanceId, token }) {
             ? '<span class="badge good">Ready to prepare</span>'
             : '<span class="badge warn">Commit changes first</span>'));
       const prepareDetail = preparedLocally
-        ? "The changelog commit and annotated tag are ready locally."
+        ? "Prepared locally. Undo removes only this unpushed tag and its release commit."
         : (!snapshot.git.atMainTip
           ? "Start from the latest origin/main with no additional commits."
           : "Moves Unreleased notes into a dated section, commits, and creates an annotated tag.");
@@ -572,7 +575,15 @@ export function renderHtml({ instanceId, token }) {
           '" target="_blank" rel="noreferrer">Open release</a>' : '') +
         '</div>' +
         '<div class="steps">' +
-        step(1, "Prepare release", prepareDetail, "prepare_release", tagPushed ? "Released" : (preparedLocally ? "Prepared" : "Prepare"), preparedLocally || tagPushed || !snapshot.git.canPrepareRelease, "primary") +
+        step(
+          1,
+          "Prepare release",
+          prepareDetail,
+          preparedLocally ? "undo_prepare" : "prepare_release",
+          tagPushed ? "Released" : (preparedLocally ? "Undo" : "Prepare"),
+          tagPushed || (!preparedLocally && !snapshot.git.canPrepareRelease),
+          preparedLocally ? "danger" : "primary"
+        ) +
         step(2, "Push release tag", pushDetail, "push_release", tagPushed ? "Pushed" : "Push", !snapshot.git.canPushRelease || !preparedLocally || tagPushed) +
         step(3, "Run release workflow", workflowDetail, "run_release_workflow", "Re-run workflow", !tagPushed) +
         wingetStep + '</div>' +
@@ -652,6 +663,9 @@ export function renderHtml({ instanceId, token }) {
       if (result.action === "prepare_release") {
         return "Prepared " + result.tag + " locally. Continue with Push release tag.";
       }
+      if (result.action === "undo_prepare") {
+        return "Undid local preparation for " + result.tag + ". The release is ready to prepare again.";
+      }
       if (result.action === "push_release") {
         return "Pushed " + result.tag + ". The release workflow should start automatically.";
       }
@@ -698,6 +712,9 @@ export function renderHtml({ instanceId, token }) {
       if (action === "prepare_release") {
         openConfirmation(action, { platform, version: tag }, "PREPARE " + tag,
           "This creates a changelog commit and annotated tag locally.");
+      } else if (action === "undo_prepare") {
+        openConfirmation(action, { platform, tag }, "UNDO " + tag,
+          "This deletes the unpushed local tag and permanently removes its single release commit from this session.");
       } else if (action === "push_release") {
         openConfirmation(action, { tag }, "PUSH " + tag,
           "This fast-forwards main with the prepared release commit, then pushes the tag to start the release workflow.");
@@ -766,7 +783,11 @@ export function renderHtml({ instanceId, token }) {
           );
           trackWorkflow(result.tracking.platform, result.tracking.kind, result.tag, startedAt);
         } else {
-          setOperationProgress("Release prepared", operationSuccessMessage(result), "success");
+          setOperationProgress(
+            result.action === "undo_prepare" ? "Preparation undone" : "Release prepared",
+            operationSuccessMessage(result),
+            "success"
+          );
           hideOperationProgress(6000);
         }
         showToast(operationSuccessMessage(result));


### PR DESCRIPTION
Preparing a release creates a local changelog commit and annotated tag, but there was no safe way to back out before publishing when testing or correcting release notes.

## What changed

- Changes the prepared Step 1 action to an **Undo** control.
- Requires exact `UNDO <tag>` typed confirmation.
- Refuses to run if the tag exists on origin, the worktree is dirty, or the session is stale/diverged.
- Verifies the tag is annotated and points at the current commit.
- Verifies there is exactly one commit ahead of `origin/main`, with the expected release subject and only the platform changelog changed.
- Deletes the local tag and restores the session to `origin/main`, making the same version ready to prepare again.
- Shows dedicated progress and success/failure feedback for the undo operation.