### PR TITLE
Fix macOS curved arrow exports with padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed the macOS Settings → Analytics view freezing with "Publishing changes from within view updates is not allowed" faults, caused by the analytics history being pruned (and its published state reassigned) while the view was rendering. Pruning now runs only at launch and when a capture is recorded.
 - Fixed the macOS pre-capture countdown number transition so each tick now animates smoothly instead of rebuilding the SwiftUI hosting view every second (which prevented the numeric text transition from running).
+- Fixed macOS screenshot editor exports so curved arrows keep their preview-aligned curve direction and position when background padding is applied.
 
 ### Improved
 - Added a "Download the Latest Version" link to the macOS Settings → About section (Direct Download builds) so that when the in-app Sparkle update check fails with "An error occurred in retrieving update information", users always have a reliable path to update by downloading the newest release directly from GitHub.

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -2644,17 +2644,29 @@ private class EditorViewModel: ObservableObject {
 
         case .arrow:
             let line = linePoints(for: annotation)
-            let start = CGPoint(
+            let startTopLeft = CGPoint(
                 x: (line.start.x * fullSize.width) - cropOrigin.x + contentOffset.x,
-                y: imageOutputHeight - ((line.start.y * fullSize.height) - cropOrigin.y) + contentOffset.y
+                y: (line.start.y * fullSize.height) - cropOrigin.y + contentOffset.y
+            )
+            let endTopLeft = CGPoint(
+                x: (line.end.x * fullSize.width) - cropOrigin.x + contentOffset.x,
+                y: (line.end.y * fullSize.height) - cropOrigin.y + contentOffset.y
+            )
+            let controlTopLeft = arrowControlPoint(start: startTopLeft, end: endTopLeft, style: annotation.arrowStyle)
+            let start = CGPoint(
+                x: startTopLeft.x,
+                y: outputSize.height - startTopLeft.y
             )
             let end = CGPoint(
-                x: (line.end.x * fullSize.width) - cropOrigin.x + contentOffset.x,
-                y: imageOutputHeight - ((line.end.y * fullSize.height) - cropOrigin.y) + contentOffset.y
+                x: endTopLeft.x,
+                y: outputSize.height - endTopLeft.y
+            )
+            let control = CGPoint(
+                x: controlTopLeft.x,
+                y: outputSize.height - controlTopLeft.y
             )
             let headLength = max(26, strokeWidth * 5.0)
             let headAngle: CGFloat = .pi / 6
-            let control = arrowControlPoint(start: start, end: end, style: annotation.arrowStyle)
             let tipAngle: CGFloat
             switch annotation.arrowStyle {
             case .straight:


### PR DESCRIPTION
## Summary
- Fix macOS screenshot editor export geometry for curved arrows when background padding is applied
- Keep curved-arrow control points aligned with the live editor preview before mapping into Core Graphics coordinates
- Add a changelog entry for the macOS fix

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -quiet`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -quiet`