### PR TITLE
Fix Windows hotkey editing and registration

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,9 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Windows keyboard shortcut changes now provide clear feedback and reliably take effect** — Settings now uses a focused shortcut recorder with a live chord preview and explicit Save/Cancel actions, rejects incomplete or duplicate bindings (including the fixed Stop recording shortcut), reports shortcuts owned by Windows or another app, and restores the previous binding if registration fails. Native hotkeys are fully unregistered before replacement so stale registrations no longer prevent changes from sticking.
+
 ### Added
 - **In-app update checks with guided upgrade actions (Windows Direct build)** — Tiny Clips can now check GitHub Releases for newer stable versions once per launch and via a new tray **Check for updates** action. Settings → About now shows update status and, when a newer version exists, provides guided actions to copy `winget upgrade Refractored.TinyClips` and open the latest GitHub Release page.
 - Added in-app **File a Bug** entry points in both the tray popup and Settings → About. Both now open a lightweight two-field bug form (title + what happened) and then launch a pre-filled GitHub issue using the new quick bug template.

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -1366,11 +1366,15 @@ public partial class App : Application
         }
     }
 
-    private void RegisterGlobalHotKeys()
+    private GlobalHotKeyRegistrationResult RegisterGlobalHotKeys()
     {
         if (_dispatcher is null)
         {
-            return;
+            return GlobalHotKeyRegistrationResult.Failed(
+                new GlobalHotKeyRegistrationFailure(
+                    "TinyClips hotkey service",
+                    0,
+                    "The UI dispatcher is not available."));
         }
 
         // Allow re-registration after the user edits a shortcut: tear down the old manager first.
@@ -1379,37 +1383,79 @@ public partial class App : Application
         try
         {
             var hotKeys = Services.GetRequiredService<IHotKeyService>();
-            _hotKeyManager = new GlobalHotKeyManager(_dispatcher);
+            var manager = new GlobalHotKeyManager(_dispatcher);
 
             var screenshot = hotKeys.GetBinding(CaptureType.Screenshot);
-            _hotKeyManager.Add(screenshot.ModifiersValue, screenshot.VirtualKey, () => _ = CaptureScreenshotAsync());
+            manager.Add(
+                $"Screenshot ({screenshot.DisplayString})",
+                screenshot.ModifiersValue,
+                screenshot.VirtualKey,
+                () => _ = CaptureScreenshotAsync());
 
             var videoBinding = hotKeys.GetBinding(CaptureType.Video);
-            _hotKeyManager.Add(videoBinding.ModifiersValue, videoBinding.VirtualKey, () => _ = ToggleVideoAsync());
+            manager.Add(
+                $"Record video ({videoBinding.DisplayString})",
+                videoBinding.ModifiersValue,
+                videoBinding.VirtualKey,
+                () => _ = ToggleVideoAsync());
 
             var gifBinding = hotKeys.GetBinding(CaptureType.Gif);
-            _hotKeyManager.Add(gifBinding.ModifiersValue, gifBinding.VirtualKey, () => _ = ToggleGifAsync());
+            manager.Add(
+                $"Record GIF ({gifBinding.DisplayString})",
+                gifBinding.ModifiersValue,
+                gifBinding.VirtualKey,
+                () => _ = ToggleGifAsync());
 
             var stopBinding = hotKeys.GetStopBinding();
-            _hotKeyManager.Add(stopBinding.ModifiersValue, stopBinding.VirtualKey, () => _ = StopActiveRecordingAsync());
+            manager.Add(
+                $"Stop recording ({stopBinding.DisplayString})",
+                stopBinding.ModifiersValue,
+                stopBinding.VirtualKey,
+                () => _ = StopActiveRecordingAsync());
 
-            _hotKeyManager.Start();
+            var result = manager.Start();
+            if (!result.IsSuccess)
+            {
+                foreach (var failure in result.Failures)
+                {
+                    Debug.WriteLine(
+                        $"Global hotkey registration failed for {failure.Name}: " +
+                        $"{failure.Message} Win32 error {failure.NativeErrorCode}.");
+                }
+
+                // Keep any other shortcuts that Windows accepted active. A Settings rollback
+                // will dispose this manager before restoring the previous complete set.
+                _hotKeyManager = manager;
+                return result;
+            }
+
+            _hotKeyManager = manager;
+            return result;
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Global hotkey registration failed: {ex}");
+            return GlobalHotKeyRegistrationResult.Failed(
+                new GlobalHotKeyRegistrationFailure(
+                    "TinyClips hotkey service",
+                    ex.HResult,
+                    ex.Message));
         }
     }
 
     /// <summary>Re-registers the global hotkeys after the user edits a shortcut in Settings.</summary>
-    public void ReapplyGlobalHotKeys()
+    internal GlobalHotKeyRegistrationResult ReapplyGlobalHotKeys()
     {
-        if (_dispatcher is null)
+        if (_dispatcher is null || !_dispatcher.HasThreadAccess)
         {
-            return;
+            return GlobalHotKeyRegistrationResult.Failed(
+                new GlobalHotKeyRegistrationFailure(
+                    "TinyClips hotkey service",
+                    0,
+                    "Hotkeys can only be updated from the TinyClips UI thread."));
         }
 
-        _dispatcher.TryEnqueue(RegisterGlobalHotKeys);
+        return RegisterGlobalHotKeys();
     }
 
     private static void RevealInExplorer(string path)

--- a/windows/src/TinyClips.App/GlobalHotKeyManager.cs
+++ b/windows/src/TinyClips.App/GlobalHotKeyManager.cs
@@ -13,21 +13,30 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 {
     private const int WM_HOTKEY = 0x0312;
     private const int WM_CLOSE = 0x0010;
+    private const int WM_QUIT = 0x0012;
     private const uint MOD_NOREPEAT = 0x4000;
     private static readonly nint HWND_MESSAGE = new(-3);
 
     private readonly DispatcherQueue _dispatcher;
     private readonly Dictionary<int, Action> _callbacks = new();
-    private readonly List<(int Modifiers, uint VirtualKey)> _pending = new();
+    private readonly List<PendingHotKey> _pending = new();
+    private readonly List<int> _registeredIds = new();
     private readonly ManualResetEventSlim _ready = new(false);
 
     private Thread? _thread;
+    private uint _threadId;
     private nint _hwnd;
     private WndProcDelegate? _wndProc; // held to keep the native callback alive
+    private GlobalHotKeyRegistrationResult _startResult = GlobalHotKeyRegistrationResult.Success;
     private int _nextId = 1;
     private bool _disposed;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
+    private sealed record PendingHotKey(
+        int Id,
+        string Name,
+        int Modifiers,
+        uint VirtualKey);
 
     public GlobalHotKeyManager(DispatcherQueue dispatcher)
     {
@@ -35,7 +44,7 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     }
 
     /// <summary>Queues a hotkey to register when <see cref="Start"/> is called.</summary>
-    public void Add(int modifiers, uint virtualKey, Action callback)
+    public void Add(string name, int modifiers, uint virtualKey, Action callback)
     {
         if (virtualKey == 0)
         {
@@ -44,14 +53,19 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 
         var id = _nextId++;
         _callbacks[id] = callback;
-        _pending.Add((modifiers, virtualKey));
+        _pending.Add(new PendingHotKey(id, name, modifiers, virtualKey));
     }
 
-    public void Start()
+    public GlobalHotKeyRegistrationResult Start()
     {
-        if (_thread is not null || _pending.Count == 0)
+        if (_thread is not null)
         {
-            return;
+            return _startResult;
+        }
+
+        if (_pending.Count == 0)
+        {
+            return GlobalHotKeyRegistrationResult.Success;
         }
 
         _thread = new Thread(MessageLoop)
@@ -61,11 +75,21 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
         };
         _thread.SetApartmentState(ApartmentState.STA);
         _thread.Start();
-        _ready.Wait(TimeSpan.FromSeconds(5));
+        if (!_ready.Wait(TimeSpan.FromSeconds(5)))
+        {
+            return GlobalHotKeyRegistrationResult.Failed(
+                new GlobalHotKeyRegistrationFailure(
+                    "TinyClips hotkey service",
+                    0,
+                    "Timed out while starting the Windows hotkey service."));
+        }
+
+        return _startResult;
     }
 
     private void MessageLoop()
     {
+        _threadId = GetCurrentThreadId();
         var className = "TinyClipsHotKeyWindow_" + Guid.NewGuid().ToString("N");
         var hInstance = GetModuleHandleW(null);
         _wndProc = WndProc;
@@ -79,6 +103,8 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 
         if (RegisterClassW(ref wndClass) == 0)
         {
+            _startResult = GlobalHotKeyRegistrationResult.Failed(
+                CreateNativeFailure("TinyClips hotkey service", "Could not create the hotkey window class."));
             _ready.Set();
             return;
         }
@@ -86,18 +112,34 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
         _hwnd = CreateWindowExW(0, className, string.Empty, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInstance, 0);
         if (_hwnd == 0)
         {
+            _startResult = GlobalHotKeyRegistrationResult.Failed(
+                CreateNativeFailure("TinyClips hotkey service", "Could not create the hotkey window."));
             _ready.Set();
             return;
         }
 
-        var index = 0;
-        foreach (var (modifiers, virtualKey) in _pending)
+        var failures = new List<GlobalHotKeyRegistrationFailure>();
+        foreach (var hotKey in _pending)
         {
-            var id = index + 1;
-            RegisterHotKey(_hwnd, id, (uint)modifiers | MOD_NOREPEAT, virtualKey);
-            index++;
+            if (RegisterHotKey(
+                _hwnd,
+                hotKey.Id,
+                (uint)hotKey.Modifiers | MOD_NOREPEAT,
+                hotKey.VirtualKey))
+            {
+                _registeredIds.Add(hotKey.Id);
+            }
+            else
+            {
+                failures.Add(CreateNativeFailure(
+                    hotKey.Name,
+                    "Windows rejected this shortcut, usually because another app already uses it."));
+            }
         }
 
+        _startResult = failures.Count == 0
+            ? GlobalHotKeyRegistrationResult.Success
+            : new GlobalHotKeyRegistrationResult(failures);
         _ready.Set();
 
         while (GetMessageW(out var msg, 0, 0, 0) > 0)
@@ -115,17 +157,51 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
             DispatchMessageW(ref msg);
         }
 
-        for (var i = 0; i < _pending.Count; i++)
+        UnregisterAll();
+        DestroyHotKeyWindow();
+    }
+
+    private nint WndProc(nint hWnd, uint msg, nint wParam, nint lParam)
+    {
+        if (msg == WM_CLOSE)
         {
-            UnregisterHotKey(_hwnd, i + 1);
+            UnregisterAll();
+            DestroyHotKeyWindow();
+            PostQuitMessage(0);
+            return 0;
+        }
+
+        return DefWindowProcW(hWnd, msg, wParam, lParam);
+    }
+
+    private static GlobalHotKeyRegistrationFailure CreateNativeFailure(string name, string message)
+        => new(name, Marshal.GetLastWin32Error(), message);
+
+    private void UnregisterAll()
+    {
+        if (_hwnd == 0)
+        {
+            return;
+        }
+
+        foreach (var id in _registeredIds)
+        {
+            UnregisterHotKey(_hwnd, id);
+        }
+
+        _registeredIds.Clear();
+    }
+
+    private void DestroyHotKeyWindow()
+    {
+        if (_hwnd == 0)
+        {
+            return;
         }
 
         DestroyWindow(_hwnd);
         _hwnd = 0;
     }
-
-    private nint WndProc(nint hWnd, uint msg, nint wParam, nint lParam)
-        => DefWindowProcW(hWnd, msg, wParam, lParam);
 
     public void Dispose()
     {
@@ -136,12 +212,16 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 
         _disposed = true;
 
-        if (_hwnd != 0)
+        if (_thread is { IsAlive: true })
         {
-            PostMessageW(_hwnd, WM_CLOSE, 0, 0);
+            if (_hwnd == 0 || !PostMessageW(_hwnd, WM_CLOSE, 0, 0))
+            {
+                PostThreadMessageW(_threadId, WM_QUIT, 0, 0);
+            }
+
+            _thread.Join();
         }
 
-        _thread?.Join(TimeSpan.FromSeconds(2));
         _ready.Dispose();
     }
 
@@ -205,6 +285,31 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern bool PostMessageW(nint hWnd, uint msg, nint wParam, nint lParam);
 
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool PostThreadMessageW(uint idThread, uint msg, nint wParam, nint lParam);
+
+    [DllImport("user32.dll")]
+    private static extern void PostQuitMessage(int nExitCode);
+
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
     private static extern nint GetModuleHandleW(string? lpModuleName);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+}
+
+internal sealed record GlobalHotKeyRegistrationFailure(
+    string Name,
+    int NativeErrorCode,
+    string Message);
+
+internal sealed record GlobalHotKeyRegistrationResult(
+    IReadOnlyList<GlobalHotKeyRegistrationFailure> Failures)
+{
+    public bool IsSuccess => Failures.Count == 0;
+
+    public static GlobalHotKeyRegistrationResult Success { get; } = new([]);
+
+    public static GlobalHotKeyRegistrationResult Failed(GlobalHotKeyRegistrationFailure failure)
+        => new([failure]);
 }

--- a/windows/src/TinyClips.App/GlobalHotKeyManager.cs
+++ b/windows/src/TinyClips.App/GlobalHotKeyManager.cs
@@ -15,6 +15,7 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     private const int WM_CLOSE = 0x0010;
     private const int WM_QUIT = 0x0012;
     private const uint MOD_NOREPEAT = 0x4000;
+    private const uint PM_NOREMOVE = 0x0000;
     private static readonly nint HWND_MESSAGE = new(-3);
 
     private readonly DispatcherQueue _dispatcher;
@@ -22,6 +23,7 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     private readonly List<PendingHotKey> _pending = new();
     private readonly List<int> _registeredIds = new();
     private readonly ManualResetEventSlim _ready = new(false);
+    private readonly ManualResetEventSlim _messageQueueReady = new(false);
 
     private Thread? _thread;
     private uint _threadId;
@@ -29,6 +31,7 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     private WndProcDelegate? _wndProc; // held to keep the native callback alive
     private GlobalHotKeyRegistrationResult _startResult = GlobalHotKeyRegistrationResult.Success;
     private int _nextId = 1;
+    private int _shutdownRequested;
     private bool _disposed;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
@@ -77,11 +80,14 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
         _thread.Start();
         if (!_ready.Wait(TimeSpan.FromSeconds(5)))
         {
-            return GlobalHotKeyRegistrationResult.Failed(
+            var timeoutResult = GlobalHotKeyRegistrationResult.Failed(
                 new GlobalHotKeyRegistrationFailure(
                     "TinyClips hotkey service",
                     0,
                     "Timed out while starting the Windows hotkey service."));
+            RequestShutdownAndWait();
+            _startResult = timeoutResult;
+            return timeoutResult;
         }
 
         return _startResult;
@@ -90,6 +96,13 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
     private void MessageLoop()
     {
         _threadId = GetCurrentThreadId();
+        PeekMessageW(out _, 0, 0, 0, PM_NOREMOVE);
+        _messageQueueReady.Set();
+        if (Volatile.Read(ref _shutdownRequested) != 0)
+        {
+            return;
+        }
+
         var className = "TinyClipsHotKeyWindow_" + Guid.NewGuid().ToString("N");
         var hInstance = GetModuleHandleW(null);
         _wndProc = WndProc;
@@ -212,17 +225,38 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 
         _disposed = true;
 
-        if (_thread is { IsAlive: true })
+        var stopped = RequestShutdownAndWait();
+        if (stopped)
         {
-            if (_hwnd == 0 || !PostMessageW(_hwnd, WM_CLOSE, 0, 0))
+            _messageQueueReady.Dispose();
+            _ready.Dispose();
+        }
+    }
+
+    private bool RequestShutdownAndWait()
+    {
+        Volatile.Write(ref _shutdownRequested, 1);
+
+        var thread = _thread;
+        if (thread is null || !thread.IsAlive)
+        {
+            return true;
+        }
+
+        if (thread == Thread.CurrentThread)
+        {
+            return false;
+        }
+
+        if (_hwnd == 0 || !PostMessageW(_hwnd, WM_CLOSE, 0, 0))
+        {
+            if (_messageQueueReady.Wait(TimeSpan.FromSeconds(1)) && _threadId != 0)
             {
                 PostThreadMessageW(_threadId, WM_QUIT, 0, 0);
             }
-
-            _thread.Join();
         }
 
-        _ready.Dispose();
+        return thread.Join(TimeSpan.FromSeconds(5));
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -275,6 +309,14 @@ internal sealed partial class GlobalHotKeyManager : IDisposable
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern int GetMessageW(out MSG lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool PeekMessageW(
+        out MSG lpMsg,
+        nint hWnd,
+        uint wMsgFilterMin,
+        uint wMsgFilterMax,
+        uint wRemoveMsg);
 
     [DllImport("user32.dll")]
     private static extern bool TranslateMessage(ref MSG lpMsg);

--- a/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml
@@ -14,10 +14,17 @@
             Text="Keyboard shortcuts" />
 
         <InfoBar
+            AutomationProperties.AutomationId="HotKeyInstructionsInfoBar"
             IsClosable="False"
             IsOpen="True"
-            Message="Click Edit, then press the key combination you want (include Ctrl, Alt, Shift, or Win)."
+            Message="Choose Edit, press a shortcut with Ctrl, Alt, Shift, or Win, then choose Save."
             Severity="Informational" />
+
+        <InfoBar
+            x:Name="HotKeyStatusInfoBar"
+            AutomationProperties.AutomationId="HotKeyStatusInfoBar"
+            AutomationProperties.LiveSetting="Polite"
+            IsOpen="False" />
 
         <Border Style="{StaticResource SettingCardStyle}">
             <StackPanel Spacing="12">

--- a/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using TinyClips.Core.Models;
@@ -47,59 +50,159 @@ public sealed partial class HotkeysSettingsSection : UserControl
             return;
         }
 
-        ViewModel.ResetHotKey(TypeFromTag(element.Tag));
-        (App.Current as App)?.ReapplyGlobalHotKeys();
+        var type = TypeFromTag(element.Tag);
+        var defaultBinding = ViewModel.GetDefaultHotKey(type);
+        var validation = ViewModel.ValidateHotKey(type, defaultBinding);
+        if (!validation.IsValid)
+        {
+            ShowSectionStatus(ValidationMessage(validation), InfoBarSeverity.Error);
+            return;
+        }
+
+        if (TryApplyCandidate(type, defaultBinding, out var errorMessage))
+        {
+            ShowSectionStatus(
+                $"{ActionName(type)} shortcut reset to {defaultBinding.DisplayString}.",
+                InfoBarSeverity.Success);
+        }
+        else
+        {
+            ShowSectionStatus(errorMessage, InfoBarSeverity.Error);
+        }
     }
 
     private async Task RecordShortcutAsync(CaptureType type)
     {
-        var prompt = new TextBlock
+        var instructions = new TextBlock
         {
-            Text = "Press the key combination you want (include Ctrl, Alt, Shift, or Win).",
+            Text = "Focus the shortcut recorder, then press at least one modifier and a non-modifier key.",
             TextWrapping = TextWrapping.Wrap,
         };
 
+        var recorder = new TextBox
+        {
+            Header = "New shortcut",
+            HorizontalTextAlignment = TextAlignment.Center,
+            IsReadOnly = true,
+            MinWidth = 320,
+            Text = "Press a shortcut",
+        };
+        AutomationProperties.SetAutomationId(recorder, "HotKeyRecorderTextBox");
+        AutomationProperties.SetName(recorder, $"New {ActionName(type)} shortcut");
+        AutomationProperties.SetHelpText(
+            recorder,
+            "Press Ctrl, Alt, Shift, or Win together with one non-modifier key.");
+
+        var status = new InfoBar
+        {
+            IsClosable = false,
+            IsOpen = true,
+            Message = "Waiting for a shortcut.",
+            Severity = InfoBarSeverity.Informational,
+        };
+        AutomationProperties.SetAutomationId(status, "HotKeyRecorderStatusInfoBar");
+        AutomationProperties.SetLiveSetting(status, AutomationLiveSetting.Polite);
+
+        var content = new StackPanel
+        {
+            Spacing = 12,
+        };
+        content.Children.Add(instructions);
+        content.Children.Add(recorder);
+        content.Children.Add(status);
+
         var dialog = new ContentDialog
         {
-            Title = "Set shortcut",
-            Content = prompt,
+            Title = $"Set {ActionName(type)} shortcut",
+            Content = content,
+            PrimaryButtonText = "Save",
             CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+            IsPrimaryButtonEnabled = false,
             XamlRoot = XamlRoot,
         };
 
-        HotKeyModifiers chosenModifiers = 0;
-        uint chosenKey = 0;
+        HotKeyDefinition? candidate = null;
 
-        void OnKey(object s, KeyRoutedEventArgs args)
+        void SetRecorderStatus(string message, InfoBarSeverity severity)
+        {
+            status.Message = message;
+            status.Severity = severity;
+            var peer = FrameworkElementAutomationPeer.FromElement(status)
+                ?? FrameworkElementAutomationPeer.CreatePeerForElement(status);
+            peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+        }
+
+        void OnKey(object sender, KeyRoutedEventArgs args)
         {
             args.Handled = true;
 
             if (IsModifierKey(args.Key))
             {
+                candidate = null;
+                dialog.IsPrimaryButtonEnabled = false;
+                recorder.Text = ModifierPreview(CurrentModifiers());
+                SetRecorderStatus(
+                    "Now press a non-modifier key while holding the modifier.",
+                    InfoBarSeverity.Informational);
                 return;
             }
 
             var modifiers = CurrentModifiers();
-            if (modifiers == 0)
+            var proposed = new HotKeyDefinition(modifiers, (uint)args.Key);
+            recorder.Text = proposed.DisplayString;
+            var validation = ViewModel.ValidateHotKey(type, proposed);
+            if (!validation.IsValid)
             {
-                prompt.Text = "Please include at least one modifier (Ctrl, Alt, Shift, or Win).";
+                candidate = null;
+                dialog.IsPrimaryButtonEnabled = false;
+                SetRecorderStatus(ValidationMessage(validation), InfoBarSeverity.Error);
                 return;
             }
 
-            chosenModifiers = modifiers;
-            chosenKey = (uint)args.Key;
-            dialog.Hide();
+            candidate = proposed;
+            dialog.IsPrimaryButtonEnabled = true;
+            SetRecorderStatus(
+                $"{proposed.DisplayString} is ready. Choose Save to apply it.",
+                InfoBarSeverity.Success);
         }
 
-        dialog.KeyDown += OnKey;
-        await dialog.ShowAsync();
-        dialog.KeyDown -= OnKey;
-
-        if (chosenKey != 0)
+        void OnPrimaryButtonClick(
+            ContentDialog sender,
+            ContentDialogButtonClickEventArgs args)
         {
-            ViewModel.SetHotKey(type, chosenModifiers, chosenKey);
-            (App.Current as App)?.ReapplyGlobalHotKeys();
+            if (candidate is not HotKeyDefinition proposed)
+            {
+                args.Cancel = true;
+                SetRecorderStatus(
+                    "Press a valid shortcut before saving.",
+                    InfoBarSeverity.Error);
+                return;
+            }
+
+            if (!TryApplyCandidate(type, proposed, out var errorMessage))
+            {
+                args.Cancel = true;
+                SetRecorderStatus(errorMessage, InfoBarSeverity.Error);
+                recorder.Focus(FocusState.Programmatic);
+                return;
+            }
+
+            ShowSectionStatus(
+                $"{ActionName(type)} shortcut changed to {proposed.DisplayString}.",
+                InfoBarSeverity.Success);
         }
+
+        void OnOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+            => recorder.Focus(FocusState.Programmatic);
+
+        recorder.KeyDown += OnKey;
+        dialog.PrimaryButtonClick += OnPrimaryButtonClick;
+        dialog.Opened += OnOpened;
+        await dialog.ShowAsync();
+        recorder.KeyDown -= OnKey;
+        dialog.PrimaryButtonClick -= OnPrimaryButtonClick;
+        dialog.Opened -= OnOpened;
     }
 
     private static bool IsModifierKey(VirtualKey key) => key is
@@ -136,4 +239,101 @@ public sealed partial class HotkeysSettingsSection : UserControl
 
     private static bool IsKeyDown(VirtualKey key) =>
         InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(CoreVirtualKeyStates.Down);
+
+    private bool TryApplyCandidate(
+        CaptureType type,
+        HotKeyDefinition candidate,
+        out string errorMessage)
+    {
+        var previous = ViewModel.GetHotKey(type);
+        ViewModel.SetHotKey(type, candidate.Modifiers, candidate.VirtualKey);
+
+        if (App.Current is not App app)
+        {
+            ViewModel.SetHotKey(type, previous.Modifiers, previous.VirtualKey);
+            errorMessage = "TinyClips could not access the global hotkey service. The previous shortcut was restored.";
+            return false;
+        }
+
+        var applyResult = app.ReapplyGlobalHotKeys();
+        if (applyResult.IsSuccess)
+        {
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        ViewModel.SetHotKey(type, previous.Modifiers, previous.VirtualKey);
+        var rollbackResult = app.ReapplyGlobalHotKeys();
+
+        var rejectedNames = string.Join(", ", applyResult.Failures.Select(failure => failure.Name));
+        errorMessage =
+            $"Windows could not register {rejectedNames}. Another app may already use this shortcut. " +
+            "Choose a different combination.";
+
+        if (!rollbackResult.IsSuccess)
+        {
+            var rollbackNames = string.Join(", ", rollbackResult.Failures.Select(failure => failure.Name));
+            errorMessage +=
+                $" The previous shortcut was restored in Settings, but Windows could not reactivate {rollbackNames}. " +
+                "Close the competing app or restart TinyClips.";
+        }
+
+        return false;
+    }
+
+    private void ShowSectionStatus(string message, InfoBarSeverity severity)
+    {
+        HotKeyStatusInfoBar.Message = message;
+        HotKeyStatusInfoBar.Severity = severity;
+        HotKeyStatusInfoBar.IsOpen = true;
+        var peer = FrameworkElementAutomationPeer.FromElement(HotKeyStatusInfoBar)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(HotKeyStatusInfoBar);
+        peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+    }
+
+    private static string ValidationMessage(HotKeyValidationResult result) => result.Error switch
+    {
+        HotKeyValidationError.ModifierRequired =>
+            "Include at least one modifier: Ctrl, Alt, Shift, or Win.",
+        HotKeyValidationError.KeyRequired or HotKeyValidationError.ModifierKeyNotAllowed =>
+            "Include one non-modifier key with the modifier.",
+        HotKeyValidationError.DuplicateBinding =>
+            $"That shortcut is already assigned to {ActionName(result.ConflictingCaptureType!.Value)}.",
+        HotKeyValidationError.StopRecordingConflict =>
+            "That shortcut is reserved for Stop recording (Ctrl+Shift+S). Choose a different combination.",
+        _ => string.Empty,
+    };
+
+    private static string ModifierPreview(HotKeyModifiers modifiers)
+    {
+        var tokens = new List<string>();
+        if (modifiers.HasFlag(HotKeyModifiers.Control))
+        {
+            tokens.Add("Ctrl");
+        }
+
+        if (modifiers.HasFlag(HotKeyModifiers.Alt))
+        {
+            tokens.Add("Alt");
+        }
+
+        if (modifiers.HasFlag(HotKeyModifiers.Shift))
+        {
+            tokens.Add("Shift");
+        }
+
+        if (modifiers.HasFlag(HotKeyModifiers.Win))
+        {
+            tokens.Add("Win");
+        }
+
+        return tokens.Count == 0 ? "Press a shortcut" : $"{string.Join("+", tokens)}+…";
+    }
+
+    private static string ActionName(CaptureType type) => type switch
+    {
+        CaptureType.Video => "Record video",
+        CaptureType.Gif => "Record GIF",
+        _ => "Screenshot",
+    };
 }

--- a/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/HotkeysSettingsSection.xaml.cs
@@ -135,6 +135,12 @@ public sealed partial class HotkeysSettingsSection : UserControl
 
         void OnKey(object sender, KeyRoutedEventArgs args)
         {
+            var modifiers = CurrentModifiers();
+            if (modifiers == 0 && IsDialogNavigationKey(args.Key))
+            {
+                return;
+            }
+
             args.Handled = true;
 
             if (IsModifierKey(args.Key))
@@ -148,7 +154,6 @@ public sealed partial class HotkeysSettingsSection : UserControl
                 return;
             }
 
-            var modifiers = CurrentModifiers();
             var proposed = new HotKeyDefinition(modifiers, (uint)args.Key);
             recorder.Text = proposed.DisplayString;
             var validation = ViewModel.ValidateHotKey(type, proposed);
@@ -210,6 +215,9 @@ public sealed partial class HotkeysSettingsSection : UserControl
         VirtualKey.Shift or VirtualKey.LeftShift or VirtualKey.RightShift or
         VirtualKey.Menu or VirtualKey.LeftMenu or VirtualKey.RightMenu or
         VirtualKey.LeftWindows or VirtualKey.RightWindows;
+
+    private static bool IsDialogNavigationKey(VirtualKey key) =>
+        key is VirtualKey.Tab or VirtualKey.Enter or VirtualKey.Escape;
 
     private static HotKeyModifiers CurrentModifiers()
     {

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -457,6 +457,13 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     public string GifHotKeyDisplay => _hotKeys.GetBinding(CaptureType.Gif).DisplayString;
 
+    public HotKeyDefinition GetHotKey(CaptureType type) => _hotKeys.GetBinding(type);
+
+    public HotKeyDefinition GetDefaultHotKey(CaptureType type) => _hotKeys.DefaultFor(type);
+
+    public HotKeyValidationResult ValidateHotKey(CaptureType type, HotKeyDefinition binding)
+        => _hotKeys.ValidateBinding(type, binding);
+
     /// <summary>Persists a new global shortcut for the given capture type and refreshes the display.</summary>
     public void SetHotKey(CaptureType type, HotKeyModifiers modifiers, uint virtualKey)
     {

--- a/windows/src/TinyClips.Core/Models/HotKeyValidationResult.cs
+++ b/windows/src/TinyClips.Core/Models/HotKeyValidationResult.cs
@@ -1,0 +1,20 @@
+namespace TinyClips.Core.Models;
+
+public enum HotKeyValidationError
+{
+    None,
+    ModifierRequired,
+    KeyRequired,
+    ModifierKeyNotAllowed,
+    DuplicateBinding,
+    StopRecordingConflict,
+}
+
+public readonly record struct HotKeyValidationResult(
+    HotKeyValidationError Error,
+    CaptureType? ConflictingCaptureType = null)
+{
+    public bool IsValid => Error == HotKeyValidationError.None;
+
+    public static HotKeyValidationResult Valid => new(HotKeyValidationError.None);
+}

--- a/windows/src/TinyClips.Core/Services/HotKeyService.cs
+++ b/windows/src/TinyClips.Core/Services/HotKeyService.cs
@@ -60,6 +60,24 @@ public sealed class HotKeyService : IHotKeyService
         _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 
+    public HotKeyValidationResult ValidateBinding(CaptureType type, HotKeyDefinition binding)
+    {
+        var captureBindings = new[]
+        {
+            new KeyValuePair<CaptureType, HotKeyDefinition>(
+                CaptureType.Screenshot,
+                GetBinding(CaptureType.Screenshot)),
+            new KeyValuePair<CaptureType, HotKeyDefinition>(
+                CaptureType.Video,
+                GetBinding(CaptureType.Video)),
+            new KeyValuePair<CaptureType, HotKeyDefinition>(
+                CaptureType.Gif,
+                GetBinding(CaptureType.Gif)),
+        };
+
+        return HotKeyValidator.Validate(type, binding, captureBindings, GetStopBinding());
+    }
+
     private int GetStoredModifiers(CaptureType type) => type switch
     {
         CaptureType.Screenshot => _settings.ScreenshotHotKeyModifiers,

--- a/windows/src/TinyClips.Core/Services/HotKeyValidator.cs
+++ b/windows/src/TinyClips.Core/Services/HotKeyValidator.cs
@@ -1,0 +1,54 @@
+using TinyClips.Core.Models;
+
+namespace TinyClips.Core.Services;
+
+public static class HotKeyValidator
+{
+    private static readonly HashSet<uint> ModifierVirtualKeys =
+    [
+        0x10, 0x11, 0x12,
+        0x5B, 0x5C,
+        0xA0, 0xA1,
+        0xA2, 0xA3,
+        0xA4, 0xA5,
+    ];
+
+    public static HotKeyValidationResult Validate(
+        CaptureType targetType,
+        HotKeyDefinition candidate,
+        IEnumerable<KeyValuePair<CaptureType, HotKeyDefinition>> captureBindings,
+        HotKeyDefinition stopRecordingBinding)
+    {
+        if (candidate.Modifiers == HotKeyModifiers.None)
+        {
+            return new HotKeyValidationResult(HotKeyValidationError.ModifierRequired);
+        }
+
+        if (candidate.VirtualKey == 0)
+        {
+            return new HotKeyValidationResult(HotKeyValidationError.KeyRequired);
+        }
+
+        if (ModifierVirtualKeys.Contains(candidate.VirtualKey))
+        {
+            return new HotKeyValidationResult(HotKeyValidationError.ModifierKeyNotAllowed);
+        }
+
+        foreach (var binding in captureBindings)
+        {
+            if (binding.Key != targetType && binding.Value == candidate)
+            {
+                return new HotKeyValidationResult(
+                    HotKeyValidationError.DuplicateBinding,
+                    binding.Key);
+            }
+        }
+
+        if (candidate == stopRecordingBinding)
+        {
+            return new HotKeyValidationResult(HotKeyValidationError.StopRecordingConflict);
+        }
+
+        return HotKeyValidationResult.Valid;
+    }
+}

--- a/windows/src/TinyClips.Core/Services/IHotKeyService.cs
+++ b/windows/src/TinyClips.Core/Services/IHotKeyService.cs
@@ -9,4 +9,5 @@ public interface IHotKeyService
     string StopRecordingDisplayString { get; }
     void SetBinding(CaptureType type, HotKeyDefinition binding);
     HotKeyDefinition DefaultFor(CaptureType type);
+    HotKeyValidationResult ValidateBinding(CaptureType type, HotKeyDefinition binding);
 }

--- a/windows/tests/TinyClips.Core.Tests/HotKeyTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/HotKeyTests.cs
@@ -48,6 +48,59 @@ public sealed class HotKeyTests
         Assert.Equal(new HotKeyDefinition(HotKeyModifiers.Alt | HotKeyModifiers.Control, 0x42), service.GetBinding(CaptureType.Screenshot));
     }
 
+    [Theory]
+    [InlineData(HotKeyModifiers.None, 0x41, HotKeyValidationError.ModifierRequired)]
+    [InlineData(HotKeyModifiers.Control, 0, HotKeyValidationError.KeyRequired)]
+    [InlineData(HotKeyModifiers.Control, 0x11, HotKeyValidationError.ModifierKeyNotAllowed)]
+    public void ValidateBinding_RejectsIncompleteChords(
+        HotKeyModifiers modifiers,
+        uint virtualKey,
+        HotKeyValidationError expectedError)
+    {
+        var service = CreateService();
+
+        var result = service.ValidateBinding(
+            CaptureType.Screenshot,
+            new HotKeyDefinition(modifiers, virtualKey));
+
+        Assert.Equal(expectedError, result.Error);
+    }
+
+    [Fact]
+    public void ValidateBinding_RejectsAnotherCaptureBinding()
+    {
+        var service = CreateService();
+        var videoBinding = service.GetBinding(CaptureType.Video);
+
+        var result = service.ValidateBinding(CaptureType.Screenshot, videoBinding);
+
+        Assert.Equal(HotKeyValidationError.DuplicateBinding, result.Error);
+        Assert.Equal(CaptureType.Video, result.ConflictingCaptureType);
+    }
+
+    [Fact]
+    public void ValidateBinding_RejectsFixedStopRecordingBinding()
+    {
+        var service = CreateService();
+
+        var result = service.ValidateBinding(CaptureType.Gif, service.GetStopBinding());
+
+        Assert.Equal(HotKeyValidationError.StopRecordingConflict, result.Error);
+    }
+
+    [Fact]
+    public void ValidateBinding_AllowsCurrentBindingAndUnusedChord()
+    {
+        var service = CreateService();
+
+        Assert.True(service.ValidateBinding(
+            CaptureType.Screenshot,
+            service.GetBinding(CaptureType.Screenshot)).IsValid);
+        Assert.True(service.ValidateBinding(
+            CaptureType.Screenshot,
+            new HotKeyDefinition(HotKeyModifiers.Alt, 0x41)).IsValid);
+    }
+
     private static IHotKeyService CreateService()
     {
         var settings = new CaptureSettings(new TestSettingsService());


### PR DESCRIPTION
The Windows shortcut editor did not provide a reliable focused input surface or clear feedback, and runtime re-registration could leave old Win32 hotkeys active while silently rejecting replacements.

This change:
- adds a focused shortcut recorder with live chord previews, explicit Save/Cancel actions, and accessible status feedback
- validates modifier requirements and rejects duplicate TinyClips shortcuts, including the fixed Stop Recording binding
- shuts down and unregisters the native hotkey message loop deterministically
- reports Windows registration conflicts and transactionally restores the previous persisted binding when a replacement fails
- preserves unrelated shortcuts that Windows registered successfully when another binding conflicts
- adds focused Core validation tests and updates the Windows changelog

Validation: x64 Debug app build succeeds with 0 warnings and 0 errors; all 60 Core tests pass.

Closes #173