### PR TITLE
Use Apple's Standard EULA for macOS terms links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+- Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
+
 ## v1.5.4-mac - 2026-07-26
 
 ### Added

--- a/mac/TinyClips/Views/Settings/AboutSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/AboutSettingsSection.swift
@@ -63,7 +63,7 @@ struct AboutSettingsSection: View {
                 Link("Privacy Policy", destination: privacyURL)
                     .accessibilityHint("Opens Privacy Policy in your browser.")
             }
-            if let termsURL = URL(string: "https://tinyclips.app/terms.html") {
+            if let termsURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/") {
                 Link("Terms of Use", destination: termsURL)
                     .accessibilityHint("Opens Terms of Use in your browser.")
             }

--- a/mac/TinyClips/Views/SubscriptionView.swift
+++ b/mac/TinyClips/Views/SubscriptionView.swift
@@ -182,7 +182,7 @@ struct ProSubscriptionView: View {
                 .foregroundStyle(.tertiary)
                 .accessibilityHidden(true)
 
-            if let termsURL = URL(string: "https://tinyclips.app/terms.html") {
+            if let termsURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/") {
                 Link("Terms of Use", destination: termsURL)
                     .font(.caption)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
TinyClips should direct macOS users to the legal terms that govern App Store distribution instead of the legacy TinyClips terms page.

This updates every macOS in-app Terms of Use link, including Settings and the subscription view, to open Apple's Standard EULA directly. Privacy links and Windows code remain unchanged, and the macOS changelog records the update.

Validation: Static search confirmed the legacy terms URL no longer appears under `mac/` and the Apple EULA URL is present in both legal-link locations.