### PR TITLE
feat(windows): associate WebP files

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **WebP files can now open in the screenshot editor** — File Explorer lists Tiny Clips as an Open with handler for `.webp` images, and the editor reports a clear message if Windows cannot decode an image.
 - **Faster tray access to saved work** — The tray popup now opens configured capture folders and keeps the 10 most recent screenshots, videos, and GIFs available for reopening in their editor or trimmer.
 - **Share capture analytics summaries** — Settings → Analytics now offers a Share button alongside Copy Summary, opening the native Windows share dialog with the selected-range activity summary.
 - **Resizable screenshot annotations** — Selected annotations now show four corner handles for direct resizing, while arrows and lines retain dedicated endpoint handles and inside dragging still moves annotations.

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -129,7 +129,8 @@ public partial class App : Application
         var ext = Path.GetExtension(path);
         return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
             || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
-            || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
+            || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".webp", StringComparison.OrdinalIgnoreCase);
     }
 
     private void CreateTrayIcon()
@@ -1519,6 +1520,24 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Failed to show clipboard failure notification: {ex}");
+        }
+    }
+
+    internal static void ShowImageLoadFailureNotification(string fileName)
+    {
+        try
+        {
+            EnsureNotificationsRegistered();
+            var notification = new AppNotificationBuilder()
+                .AddText("Couldn't open image")
+                .AddText($"{fileName}. The image may be unsupported or its decoder is unavailable.")
+                .BuildNotification();
+
+            AppNotificationManager.Default.Show(notification);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to show image load failure notification: {ex}");
         }
     }
 

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -60,6 +60,7 @@
               <uap:FileType>.png</uap:FileType>
               <uap:FileType>.jpg</uap:FileType>
               <uap:FileType>.jpeg</uap:FileType>
+              <uap:FileType>.webp</uap:FileType>
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>

--- a/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditorWindow.xaml.cs
@@ -77,6 +77,8 @@ public sealed partial class ScreenshotEditorWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Editor load failed: {ex}");
+            App.ShowImageLoadFailureNotification(System.IO.Path.GetFileName(_filePath));
+            Close();
         }
     }
 


### PR DESCRIPTION
Windows users could not choose Tiny Clips from File Explorer for WebP images, despite the screenshot editor supporting the same image-loading path as PNG and JPEG.

This registers `.webp` in the MSIX file association and permits WebP file activations to open in the screenshot editor. If Windows cannot decode the selected image, Tiny Clips now notifies the user and closes the unusable editor window.

Closes #193