### PR TITLE
Fix screenshot editor text preview scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
 
+### Fixed
+- Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.
+
 ## v1.5.4-mac - 2026-07-26
 
 ### Added

--- a/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
@@ -77,7 +77,7 @@ struct ScreenshotEditorCanvasView: View {
                         Text(annotation.text)
                             .font(textPreviewFont(
                                 family: annotation.fontFamily,
-                                size: viewModel.textFontSize(annotation.fontSize, forImageWidth: imageSize.width),
+                                size: viewModel.textFontSize(annotation.fontSize, forRenderedImageWidth: imageSize.width),
                                 isBold: annotation.isBold
                             ))
                             .italic(annotation.isItalic)

--- a/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
@@ -75,7 +75,11 @@ struct ScreenshotEditorCanvasView: View {
                     ForEach(viewModel.annotations.filter { $0.tool == .text }) { annotation in
                         let scaledRect = viewModel.scaledRect(annotation.rect, imageSize: imageSize, origin: .zero)
                         Text(annotation.text)
-                            .font(textPreviewFont(family: annotation.fontFamily, size: annotation.fontSize, isBold: annotation.isBold))
+                            .font(textPreviewFont(
+                                family: annotation.fontFamily,
+                                size: viewModel.textFontSize(annotation.fontSize, forImageWidth: imageSize.width),
+                                isBold: annotation.isBold
+                            ))
                             .italic(annotation.isItalic)
                             .underline(annotation.isUnderlined)
                             .foregroundColor(annotation.color)

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -179,8 +179,12 @@ class ScreenshotEditorViewModel: ObservableObject {
         }
     }
 
-    func textFontSize(_ fontSize: CGFloat, forImageWidth imageWidth: CGFloat) -> CGFloat {
-        fontSize * (imageWidth / 800.0)
+    /// Returns the text size for an image rendered at `renderedImageWidth`.
+    ///
+    /// Pass points for the SwiftUI preview and pixels for bitmap export so the
+    /// font scales with the image in the same coordinate space as its renderer.
+    func textFontSize(_ fontSize: CGFloat, forRenderedImageWidth renderedImageWidth: CGFloat) -> CGFloat {
+        fontSize * (renderedImageWidth / 800.0)
     }
 
     // Find which annotation is at a normalized point
@@ -1424,7 +1428,7 @@ class ScreenshotEditorViewModel: ObservableObject {
 
         case .text:
             let str = annotation.text as NSString
-            let fontSize = textFontSize(annotation.fontSize, forImageWidth: fullSize.width)
+            let fontSize = textFontSize(annotation.fontSize, forRenderedImageWidth: fullSize.width)
             let font = exportTextFont(
                 family: annotation.fontFamily,
                 size: fontSize,

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -179,6 +179,10 @@ class ScreenshotEditorViewModel: ObservableObject {
         }
     }
 
+    func textFontSize(_ fontSize: CGFloat, forImageWidth imageWidth: CGFloat) -> CGFloat {
+        fontSize * (imageWidth / 800.0)
+    }
+
     // Find which annotation is at a normalized point
     func annotationIndex(at point: CGPoint) -> Int? {
         // Search in reverse so topmost (last drawn) is picked first
@@ -1420,7 +1424,7 @@ class ScreenshotEditorViewModel: ObservableObject {
 
         case .text:
             let str = annotation.text as NSString
-            let fontSize = annotation.fontSize * (fullSize.width / 800.0) // scale to pixel density
+            let fontSize = textFontSize(annotation.fontSize, forImageWidth: fullSize.width)
             let font = exportTextFont(
                 family: annotation.fontFamily,
                 size: fontSize,


### PR DESCRIPTION
Text annotations in the screenshot editor appeared larger in the live preview than in copied or saved images when padding reduced the displayed screenshot size.

The preview now uses the same image-width font scaling as the export renderer, so text remains visually consistent across the editor, clipboard, and saved output.