### PR TITLE
Add Windows temporary file management

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,9 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Added
+- **Temporary-file controls in Settings → General** — an Advanced card now shows the Tiny Clips temporary-file count and size, opens its dedicated `%LOCALAPPDATA%\TinyClips\Temp` folder, and can purge those files without affecting saved captures.
+
 ### Changed
 - Screenshot, video, and GIF settings now each provide matching before/after capture-picker controls.
 

--- a/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml
@@ -231,6 +231,34 @@
             Style="{StaticResource BodyStrongTextBlockStyle}"
             Text="Advanced" />
 
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="12">
+                <StackPanel>
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Temporary files" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Temporary diagnostics are stored separately from your saved captures." />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.TempFolderSummary, Mode=OneWay}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button
+                        AutomationProperties.AutomationId="OpenTempFolderButton"
+                        AutomationProperties.Name="Open Tiny Clips temporary files folder"
+                        Click="OnOpenTempFolder"
+                        Content="Open Temp Folder" />
+                    <Button
+                        AutomationProperties.AutomationId="PurgeTempFilesButton"
+                        AutomationProperties.Name="Purge Tiny Clips temporary files"
+                        Click="OnPurgeTempFiles"
+                        Content="Purge Temp Files Now&#x2026;" />
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
         <Button
             HorizontalAlignment="Left"
             AutomationProperties.AutomationId="ResetAllSettingsButton"

--- a/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
@@ -49,7 +49,18 @@ public sealed partial class GeneralSettingsSection : UserControl
 
         if (await dialog.ShowAsync() == ContentDialogResult.Primary)
         {
-            ViewModel.PurgeTempFiles();
+            var result = ViewModel.PurgeTempFiles();
+            if (result.SkippedFileCount > 0)
+            {
+                var skippedDialog = new ContentDialog
+                {
+                    Title = "Some temporary files are still in use",
+                    Content = $"{result.RemovedFileCount} temporary file(s) were removed. {result.SkippedFileCount} active or unavailable file(s) were kept.",
+                    CloseButtonText = "OK",
+                    XamlRoot = XamlRoot,
+                };
+                await skippedDialog.ShowAsync();
+            }
         }
     }
 

--- a/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
@@ -33,6 +33,26 @@ public sealed partial class GeneralSettingsSection : UserControl
     private void OnBrowseSaveDirectory(object sender, RoutedEventArgs e) =>
         BrowseSaveDirectoryRequested?.Invoke(this, EventArgs.Empty);
 
+    private void OnOpenTempFolder(object sender, RoutedEventArgs e) => ViewModel.OpenTempFolder();
+
+    private async void OnPurgeTempFiles(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = "Purge temporary files?",
+            Content = $"This deletes {ViewModel.TempFolderSummary} from Tiny Clips' temporary folder. Your saved captures will not be affected.",
+            PrimaryButtonText = "Purge",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = XamlRoot,
+        };
+
+        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+        {
+            ViewModel.PurgeTempFiles();
+        }
+    }
+
     private async void OnResetAllSettings(object sender, RoutedEventArgs e)
     {
         var dialog = new ContentDialog

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Dispatching;
+using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 
@@ -175,10 +176,11 @@ public sealed partial class SettingsViewModel : ObservableObject
         });
     }
 
-    public void PurgeTempFiles()
+    public TemporaryFilesPurgeResult PurgeTempFiles()
     {
-        TinyClipsTemporaryFiles.Purge();
+        var result = TinyClipsTemporaryFiles.Purge(WebcamDiagnostics.ActiveFilePaths);
         OnPropertyChanged(nameof(TempFolderSummary));
+        return result;
     }
 
     private static string FormatTemporaryFilesSummary(TemporaryFilesSummary summary)

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -159,9 +159,49 @@ public sealed partial class SettingsViewModel : ObservableObject
         ? "Using defaults by capture type."
         : "Custom save location override applies to all capture types.";
 
+    public string TempFolderSummary => FormatTemporaryFilesSummary(TinyClipsTemporaryFiles.GetSummary());
+
     private string ResolveEffectiveSaveLocation(CaptureType type) => string.IsNullOrWhiteSpace(SaveDirectory)
         ? $"{_storage.OutputDirectory(type)} (default)"
         : SaveDirectory;
+
+    public void OpenTempFolder()
+    {
+        var directory = TinyClipsTemporaryFiles.EnsureDirectoryExists();
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = directory,
+            UseShellExecute = true,
+        });
+    }
+
+    public void PurgeTempFiles()
+    {
+        TinyClipsTemporaryFiles.Purge();
+        OnPropertyChanged(nameof(TempFolderSummary));
+    }
+
+    private static string FormatTemporaryFilesSummary(TemporaryFilesSummary summary)
+    {
+        var fileLabel = summary.FileCount == 1 ? "file" : "files";
+        return $"{summary.FileCount:N0} {fileLabel}, {FormatFileSize(summary.TotalSize)}";
+    }
+
+    private static string FormatFileSize(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB"];
+        var value = (double)bytes;
+        var unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return unitIndex == 0
+            ? $"{value:N0} {units[unitIndex]}"
+            : $"{value:N1} {units[unitIndex]}";
+    }
 
     // General
     [ObservableProperty]

--- a/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
@@ -483,6 +483,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
         _recordingTimeline = null;
         _lastTimelineWebcamFrame = null;
         IsRecording = false;
+        WebcamDiagnostics.EndRecording();
     }
 
     private async Task StartWebcamOverlayAsync(CancellationToken cancellationToken)
@@ -493,7 +494,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
         Interlocked.Exchange(ref _webcamOverlayNullFrames, 0);
         Interlocked.Exchange(ref _webcamNoFrameFrames, 0);
 
-        WebcamDiagnostics.Reset();
+        WebcamDiagnostics.BeginRecording();
         WebcamDiagnostics.Log($"StartWebcamOverlay: WebcamEnabled={_settings.WebcamEnabled} deviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedWebcamId) ? "(default)" : _settings.SelectedWebcamId)}' shape={_settings.WebcamShape} size={_settings.WebcamSizePreset} corner={_settings.WebcamCornerPosition}");
 
         if (!_settings.WebcamEnabled)
@@ -968,6 +969,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
         }
         finally
         {
+            WebcamDiagnostics.EndRecording();
             Interlocked.Exchange(ref _stopping, 0);
             _gate.Release();
         }

--- a/windows/src/TinyClips.Core/Capture/WebcamDiagnostics.cs
+++ b/windows/src/TinyClips.Core/Capture/WebcamDiagnostics.cs
@@ -1,9 +1,11 @@
+using TinyClips.Core.Services;
+
 namespace TinyClips.Core.Capture;
 
 /// <summary>
 /// Lightweight, best-effort file logger for diagnosing webcam capture/overlay failures
 /// in the packaged app, where Debug.WriteLine is invisible. Writes timestamped lines to
-/// <c>%LOCALAPPDATA%\TinyClips\webcam-diagnostics.log</c>. LocalApplicationData is used
+/// <c>%LOCALAPPDATA%\TinyClips\Temp\webcam-diagnostics.log</c>. LocalApplicationData is used
 /// (rather than Pictures) because it is writable without tripping Controlled Folder Access /
 /// Windows Security prompts. All I/O failures are swallowed. The log is truncated at the start
 /// of each recording so it always reflects the latest run.
@@ -20,20 +22,7 @@ public static class WebcamDiagnostics
             return _logPath;
         }
 
-        string directory;
-        try
-        {
-            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            directory = string.IsNullOrWhiteSpace(localAppData)
-                ? Path.GetTempPath()
-                : Path.Combine(localAppData, "TinyClips");
-        }
-        catch
-        {
-            directory = Path.GetTempPath();
-        }
-
-        _logPath = Path.Combine(directory, "webcam-diagnostics.log");
+        _logPath = Path.Combine(TinyClipsTemporaryFiles.EnsureDirectoryExists(), "webcam-diagnostics.log");
         return _logPath;
     }
 

--- a/windows/src/TinyClips.Core/Capture/WebcamDiagnostics.cs
+++ b/windows/src/TinyClips.Core/Capture/WebcamDiagnostics.cs
@@ -14,6 +14,7 @@ public static class WebcamDiagnostics
 {
     private static readonly object Gate = new();
     private static string? _logPath;
+    private static bool _recordingActive;
 
     private static string ResolveLogPath()
     {
@@ -26,11 +27,12 @@ public static class WebcamDiagnostics
         return _logPath;
     }
 
-    /// <summary>Truncates the log and writes a header. Call once per recording start.</summary>
-    public static void Reset()
+    /// <summary>Starts diagnostics for a recording and protects its log from cleanup.</summary>
+    public static void BeginRecording()
     {
         lock (Gate)
         {
+            _recordingActive = true;
             try
             {
                 var path = ResolveLogPath();
@@ -45,6 +47,27 @@ public static class WebcamDiagnostics
             catch
             {
                 // Best-effort only.
+            }
+        }
+    }
+
+    /// <summary>Allows the latest diagnostic log to be cleaned after recording stops.</summary>
+    public static void EndRecording()
+    {
+        lock (Gate)
+        {
+            _recordingActive = false;
+        }
+    }
+
+    /// <summary>Gets the diagnostic file that must not be purged during an active recording.</summary>
+    public static IReadOnlyList<string> ActiveFilePaths
+    {
+        get
+        {
+            lock (Gate)
+            {
+                return _recordingActive ? [ResolveLogPath()] : [];
             }
         }
     }

--- a/windows/src/TinyClips.Core/Services/TinyClipsTemporaryFiles.cs
+++ b/windows/src/TinyClips.Core/Services/TinyClipsTemporaryFiles.cs
@@ -30,14 +30,19 @@ public static class TinyClipsTemporaryFiles
     }
 
     /// <summary>Returns the number and total size of files managed by Tiny Clips.</summary>
-    public static TemporaryFilesSummary GetSummary()
+    public static TemporaryFilesSummary GetSummary() => GetSummary(DirectoryPath);
+
+    /// <summary>Returns the number and total size of files in a temporary directory.</summary>
+    public static TemporaryFilesSummary GetSummary(string directoryPath)
     {
-        if (!Directory.Exists(DirectoryPath))
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath);
+
+        if (!Directory.Exists(directoryPath))
         {
             return new TemporaryFilesSummary(0, 0);
         }
 
-        var files = new DirectoryInfo(DirectoryPath).EnumerateFiles();
+        var files = new DirectoryInfo(directoryPath).EnumerateFiles();
         var fileCount = 0;
         long totalSize = 0;
         foreach (var file in files)
@@ -49,24 +54,51 @@ public static class TinyClipsTemporaryFiles
         return new TemporaryFilesSummary(fileCount, totalSize);
     }
 
-    /// <summary>Deletes all files owned by Tiny Clips in its temporary directory.</summary>
-    public static int Purge()
+    /// <summary>Deletes temporary files that are not actively being used by Tiny Clips.</summary>
+    public static TemporaryFilesPurgeResult Purge(IEnumerable<string>? activeFilePaths = null) =>
+        Purge(DirectoryPath, activeFilePaths);
+
+    /// <summary>Deletes temporary files in a directory, excluding active files.</summary>
+    public static TemporaryFilesPurgeResult Purge(string directoryPath, IEnumerable<string>? activeFilePaths = null)
     {
-        if (!Directory.Exists(DirectoryPath))
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath);
+
+        if (!Directory.Exists(directoryPath))
         {
-            return 0;
+            return new TemporaryFilesPurgeResult(0, 0);
         }
 
-        var removedCount = 0;
-        foreach (var file in new DirectoryInfo(DirectoryPath).EnumerateFiles())
+        var activePaths = activeFilePaths is null
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(activeFilePaths.Select(Path.GetFullPath), StringComparer.OrdinalIgnoreCase);
+        var removedFileCount = 0;
+        var skippedFileCount = 0;
+
+        foreach (var file in new DirectoryInfo(directoryPath).EnumerateFiles())
         {
-            file.Delete();
-            removedCount++;
+            if (activePaths.Contains(file.FullName))
+            {
+                skippedFileCount++;
+                continue;
+            }
+
+            try
+            {
+                file.Delete();
+                removedFileCount++;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                skippedFileCount++;
+            }
         }
 
-        return removedCount;
+        return new TemporaryFilesPurgeResult(removedFileCount, skippedFileCount);
     }
 }
 
 /// <summary>A point-in-time summary of files in the Tiny Clips temporary directory.</summary>
 public readonly record struct TemporaryFilesSummary(int FileCount, long TotalSize);
+
+/// <summary>The outcome of deleting files from the Tiny Clips temporary directory.</summary>
+public readonly record struct TemporaryFilesPurgeResult(int RemovedFileCount, int SkippedFileCount);

--- a/windows/src/TinyClips.Core/Services/TinyClipsTemporaryFiles.cs
+++ b/windows/src/TinyClips.Core/Services/TinyClipsTemporaryFiles.cs
@@ -1,0 +1,72 @@
+namespace TinyClips.Core.Services;
+
+/// <summary>
+/// Manages Tiny Clips-owned temporary files outside the user's capture library.
+/// </summary>
+public static class TinyClipsTemporaryFiles
+{
+    private const string ApplicationFolderName = "TinyClips";
+    private const string TemporaryFolderName = "Temp";
+
+    /// <summary>The directory reserved for temporary Tiny Clips artifacts.</summary>
+    public static string DirectoryPath
+    {
+        get
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var rootDirectory = string.IsNullOrWhiteSpace(localAppData)
+                ? Path.GetTempPath()
+                : localAppData;
+
+            return Path.Combine(rootDirectory, ApplicationFolderName, TemporaryFolderName);
+        }
+    }
+
+    /// <summary>Creates the temporary directory when it does not already exist.</summary>
+    public static string EnsureDirectoryExists()
+    {
+        Directory.CreateDirectory(DirectoryPath);
+        return DirectoryPath;
+    }
+
+    /// <summary>Returns the number and total size of files managed by Tiny Clips.</summary>
+    public static TemporaryFilesSummary GetSummary()
+    {
+        if (!Directory.Exists(DirectoryPath))
+        {
+            return new TemporaryFilesSummary(0, 0);
+        }
+
+        var files = new DirectoryInfo(DirectoryPath).EnumerateFiles();
+        var fileCount = 0;
+        long totalSize = 0;
+        foreach (var file in files)
+        {
+            fileCount++;
+            totalSize += file.Length;
+        }
+
+        return new TemporaryFilesSummary(fileCount, totalSize);
+    }
+
+    /// <summary>Deletes all files owned by Tiny Clips in its temporary directory.</summary>
+    public static int Purge()
+    {
+        if (!Directory.Exists(DirectoryPath))
+        {
+            return 0;
+        }
+
+        var removedCount = 0;
+        foreach (var file in new DirectoryInfo(DirectoryPath).EnumerateFiles())
+        {
+            file.Delete();
+            removedCount++;
+        }
+
+        return removedCount;
+    }
+}
+
+/// <summary>A point-in-time summary of files in the Tiny Clips temporary directory.</summary>
+public readonly record struct TemporaryFilesSummary(int FileCount, long TotalSize);

--- a/windows/tests/TinyClips.Core.Tests/TinyClipsTemporaryFilesTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/TinyClipsTemporaryFilesTests.cs
@@ -1,0 +1,60 @@
+using TinyClips.Core.Services;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class TinyClipsTemporaryFilesTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "TinyClipsTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void GetSummary_ReturnsEmptyForMissingDirectory()
+    {
+        var summary = TinyClipsTemporaryFiles.GetSummary(_directory);
+
+        Assert.Equal(0, summary.FileCount);
+        Assert.Equal(0, summary.TotalSize);
+    }
+
+    [Fact]
+    public void GetSummary_AggregatesFileCountAndSize()
+    {
+        WriteFile("one.tmp", 3);
+        WriteFile("two.tmp", 5);
+
+        var summary = TinyClipsTemporaryFiles.GetSummary(_directory);
+
+        Assert.Equal(2, summary.FileCount);
+        Assert.Equal(8, summary.TotalSize);
+    }
+
+    [Fact]
+    public void Purge_RemovesInactiveFilesAndPreservesActiveFiles()
+    {
+        var inactivePath = WriteFile("inactive.tmp", 3);
+        var activePath = WriteFile("active.tmp", 5);
+
+        var result = TinyClipsTemporaryFiles.Purge(_directory, [activePath]);
+
+        Assert.Equal(1, result.RemovedFileCount);
+        Assert.Equal(1, result.SkippedFileCount);
+        Assert.False(File.Exists(inactivePath));
+        Assert.True(File.Exists(activePath));
+        Assert.Equal(new TemporaryFilesSummary(1, 5), TinyClipsTemporaryFiles.GetSummary(_directory));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private string WriteFile(string fileName, int length)
+    {
+        Directory.CreateDirectory(_directory);
+        var path = Path.Combine(_directory, fileName);
+        File.WriteAllBytes(path, new byte[length]);
+        return path;
+    }
+}


### PR DESCRIPTION
Windows had no way to inspect or clear Tiny Clips-owned temporary files. This adds the Settings > General > Advanced controls needed to view their size, open the folder, and purge them without touching saved captures.

- Adds a dedicated `%LOCALAPPDATA%\TinyClips\Temp` helper with summary and purge support.
- Moves webcam diagnostics into that managed folder.
- Adds an accessible confirmation flow and refreshed summary after purging.

Windows records final MP4 and GIF files directly to their configured output locations; this change manages only the app's dedicated temporary directory.

Closes #180