### PR TITLE
Keep CI checks successful when no platform files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,20 +3,40 @@ name: Build
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'mac/**'
-      - '.github/workflows/build.yml'
   push:
     branches: [main, develop]
-    paths:
-      - 'mac/**'
-      - '.github/workflows/build.yml'
 
 env:
   SCHEME: TinyClips
 
 jobs:
+  changes:
+    name: Detect macOS changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      mac: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.mac }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Filter changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            mac:
+              - 'mac/**'
+              - '.github/workflows/build.yml'
+          base: ${{ github.ref }}
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.mac == 'true' }}
     runs-on: macos-26
 
     steps:
@@ -51,3 +71,13 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
+
+  no-macos-changes:
+    name: Build skipped (no macOS changes)
+    needs: changes
+    if: ${{ needs.changes.outputs.mac != 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report successful skip
+        run: echo "No macOS files changed; skipping the macOS build."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Filter changed files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             mac:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,19 +3,39 @@ name: Windows Build
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'windows/**'
-      - '.github/workflows/windows-build.yml'
   push:
     branches: [main, develop]
-    paths:
-      - 'windows/**'
-      - '.github/workflows/windows-build.yml'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Windows changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      windows: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.windows }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Filter changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            windows:
+              - 'windows/**'
+              - '.github/workflows/windows-build.yml'
+          base: ${{ github.ref }}
+
   build:
     name: Build (Windows, ${{ matrix.platform }})
+    needs: changes
+    if: ${{ needs.changes.outputs.windows == 'true' }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -40,7 +60,8 @@ jobs:
   test:
     name: Run Core Tests
     runs-on: windows-latest
-    needs: build
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.windows == 'true' }}
 
     steps:
       - name: Checkout code
@@ -56,3 +77,13 @@ jobs:
 
       - name: Run tests
         run: dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Release --no-restore
+
+  no-windows-changes:
+    name: Build skipped (no Windows changes)
+    needs: changes
+    if: ${{ needs.changes.outputs.windows != 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report successful skip
+        run: echo "No Windows files changed; skipping the Windows build and tests."

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Filter changed files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
 - macOS capture settings now offer matching before/after picker controls for screenshots, video recordings, and GIF recordings.
+- macOS and Windows CI workflows now always report a successful check when their platform-specific files are unchanged, while skipping the unnecessary build work.
 
 ### Fixed
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.


### PR DESCRIPTION
CI workflows previously used trigger-level path filters, which meant required build checks never appeared on unrelated changes. This keeps the workflows running for every PR and push so branch protection receives a result.

- Detect macOS and Windows changes in lightweight jobs with `dorny/paths-filter`.
- Run the platform build and tests only when its files or workflow definition changed.
- Report an explicit successful skip when no relevant files changed, while preserving full manual-dispatch builds.