### PR TITLE
Add separate macOS save folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
+- macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.
 
 ## v1.5.4-mac - 2026-07-26
 

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -218,9 +218,15 @@ class CaptureSettings: ObservableObject {
     static let shared = CaptureSettings()
 
     @AppStorage("saveDirectory") var saveDirectory: String = NSHomeDirectory() + "/Desktop"
+    @AppStorage("screenshotSaveDirectory") var screenshotSaveDirectory: String = ""
+    @AppStorage("videoGifSaveDirectory") var videoGifSaveDirectory: String = ""
 #if APPSTORE
     @AppStorage("saveDirectoryBookmark") var saveDirectoryBookmark: Data = Data()
     @AppStorage("saveDirectoryDisplayPath") var saveDirectoryDisplayPath: String = ""
+    @AppStorage("screenshotSaveDirectoryBookmark") var screenshotSaveDirectoryBookmark: Data = Data()
+    @AppStorage("screenshotSaveDirectoryDisplayPath") var screenshotSaveDirectoryDisplayPath: String = ""
+    @AppStorage("videoGifSaveDirectoryBookmark") var videoGifSaveDirectoryBookmark: Data = Data()
+    @AppStorage("videoGifSaveDirectoryDisplayPath") var videoGifSaveDirectoryDisplayPath: String = ""
 #endif
     @AppStorage("copyScreenshotToClipboard") var copyScreenshotToClipboard: Bool = true
     @AppStorage("copyVideoToClipboard") var copyVideoToClipboard: Bool = false
@@ -347,9 +353,76 @@ class CaptureSettings: ObservableObject {
     @AppStorage("gifHotKeyCode") var gifHotKeyCode: Int = 26                    // kVK_ANSI_7
     @AppStorage("gifHotKeyModifiers") var gifHotKeyModifiers: Int = 6400
 
+    func resolvedSaveDirectory(for captureType: CaptureType) -> URL {
+        URL(fileURLWithPath: saveDirectoryPath(for: captureType), isDirectory: true)
+    }
+
+    func saveDirectoryPath(for captureType: CaptureType) -> String {
+        switch captureType {
+        case .screenshot:
+            return screenshotSaveDirectory.isEmpty ? saveDirectory : screenshotSaveDirectory
+        case .video, .gif:
+            return videoGifSaveDirectory.isEmpty ? saveDirectory : videoGifSaveDirectory
+        }
+    }
+
+    func isUsingSharedSaveDirectory(for captureType: CaptureType) -> Bool {
 #if APPSTORE
-    var hasCustomSaveDirectory: Bool {
-        !saveDirectoryBookmark.isEmpty
+        switch captureType {
+        case .screenshot:
+            return screenshotSaveDirectoryBookmark.isEmpty
+        case .video, .gif:
+            return videoGifSaveDirectoryBookmark.isEmpty
+        }
+#else
+        switch captureType {
+        case .screenshot:
+            return screenshotSaveDirectory.isEmpty
+        case .video, .gif:
+            return videoGifSaveDirectory.isEmpty
+        }
+#endif
+    }
+
+#if APPSTORE
+    func saveDirectoryBookmark(for captureType: CaptureType) -> Data {
+        switch captureType {
+        case .screenshot:
+            return screenshotSaveDirectoryBookmark
+        case .video, .gif:
+            return videoGifSaveDirectoryBookmark
+        }
+    }
+
+    func saveDirectoryDisplayPath(for captureType: CaptureType) -> String {
+        switch captureType {
+        case .screenshot:
+            return screenshotSaveDirectoryDisplayPath.isEmpty
+                ? saveDirectoryDisplayPath
+                : screenshotSaveDirectoryDisplayPath
+        case .video, .gif:
+            return videoGifSaveDirectoryDisplayPath.isEmpty
+                ? saveDirectoryDisplayPath
+                : videoGifSaveDirectoryDisplayPath
+        }
+    }
+
+    func setSaveDirectoryBookmark(_ bookmark: Data, displayPath: String, for captureType: CaptureType?) {
+        switch captureType {
+        case .screenshot:
+            screenshotSaveDirectoryBookmark = bookmark
+            screenshotSaveDirectoryDisplayPath = displayPath
+        case .video, .gif:
+            videoGifSaveDirectoryBookmark = bookmark
+            videoGifSaveDirectoryDisplayPath = displayPath
+        case nil:
+            saveDirectoryBookmark = bookmark
+            saveDirectoryDisplayPath = displayPath
+        }
+    }
+
+    func resetSaveDirectory(for captureType: CaptureType?) {
+        setSaveDirectoryBookmark(Data(), displayPath: "", for: captureType)
     }
 #endif
 
@@ -462,7 +535,8 @@ class CaptureSettings: ObservableObject {
     func resetToDefaults() {
         // Remove all keys in one pass so only a single objectWillChange fires
         let keys: [String] = [
-            "saveDirectory", "copyToClipboard", "copyScreenshotToClipboard", "copyVideoToClipboard", "copyGifToClipboard",
+            "saveDirectory", "screenshotSaveDirectory", "videoGifSaveDirectory",
+            "copyToClipboard", "copyScreenshotToClipboard", "copyVideoToClipboard", "copyGifToClipboard",
             "showInFinder", "showSaveNotifications", "showInDock",
             "autoUpdateEnabled",
             "fileNameTemplate",
@@ -499,7 +573,11 @@ class CaptureSettings: ObservableObject {
             "appStoreClipCountForReview", "appStoreReviewRequested"
         ]
 #if APPSTORE
-        let masKeys: [String] = ["saveDirectoryBookmark", "saveDirectoryDisplayPath"]
+        let masKeys: [String] = [
+            "saveDirectoryBookmark", "saveDirectoryDisplayPath",
+            "screenshotSaveDirectoryBookmark", "screenshotSaveDirectoryDisplayPath",
+            "videoGifSaveDirectoryBookmark", "videoGifSaveDirectoryDisplayPath"
+        ]
 #else
         let masKeys: [String] = []
 #endif

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -584,6 +584,9 @@ class CaptureSettings: ObservableObject {
         for key in keys + masKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
+#if APPSTORE
+        SaveService.shared.invalidateAllSaveDirectoryBookmarks()
+#endif
         UploadcareCredentialsStore.shared.clearAll()
         Task { @MainActor in
             CaptureAnalyticsStore.shared.clear()

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -172,6 +172,18 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
             keys = [saveDirectoryBookmarkKey]
         }
 
+        invalidateSaveDirectoryBookmarks(for: keys)
+    }
+
+    func invalidateAllSaveDirectoryBookmarks() {
+        invalidateSaveDirectoryBookmarks(for: [
+            saveDirectoryBookmarkKey,
+            screenshotSaveDirectoryBookmarkKey,
+            videoGifSaveDirectoryBookmarkKey
+        ])
+    }
+
+    private func invalidateSaveDirectoryBookmarks(for keys: [String]) {
         bookmarkQueue.sync {
             for key in keys {
                 activeSecurityScopedDirectoryURLs.removeValue(forKey: key)?
@@ -347,13 +359,14 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
                     }
 
                     guard url.startAccessingSecurityScopedResource() else {
+                        clearBookmark(for: key)
                         continue
                     }
 
                     activeSecurityScopedDirectoryURLs[key] = url
                     return url
                 } catch {
-                    UserDefaults.standard.removeObject(forKey: key)
+                    clearBookmark(for: key)
                 }
             }
             return nil
@@ -366,6 +379,22 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
             return [screenshotSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
         case .video, .gif:
             return [videoGifSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
+        }
+    }
+
+    private func clearBookmark(for bookmarkKey: String) {
+        UserDefaults.standard.removeObject(forKey: bookmarkKey)
+        UserDefaults.standard.removeObject(forKey: displayPathKey(for: bookmarkKey))
+    }
+
+    private func displayPathKey(for bookmarkKey: String) -> String {
+        switch bookmarkKey {
+        case screenshotSaveDirectoryBookmarkKey:
+            return "screenshotSaveDirectoryDisplayPath"
+        case videoGifSaveDirectoryBookmarkKey:
+            return "videoGifSaveDirectoryDisplayPath"
+        default:
+            return "saveDirectoryDisplayPath"
         }
     }
 #endif

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -156,8 +156,29 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 
 #if APPSTORE
     private let saveDirectoryBookmarkKey = "saveDirectoryBookmark"
-    private var activeSecurityScopedDirectoryURL: URL?
+    private let screenshotSaveDirectoryBookmarkKey = "screenshotSaveDirectoryBookmark"
+    private let videoGifSaveDirectoryBookmarkKey = "videoGifSaveDirectoryBookmark"
+    private var activeSecurityScopedDirectoryURLs: [String: URL] = [:]
     private let bookmarkQueue = DispatchQueue(label: "com.tinyclips.save-service.bookmark")
+
+    func invalidateSaveDirectoryBookmark(for type: CaptureType?) {
+        let keys: [String]
+        switch type {
+        case .screenshot:
+            keys = [screenshotSaveDirectoryBookmarkKey]
+        case .video, .gif:
+            keys = [videoGifSaveDirectoryBookmarkKey]
+        case nil:
+            keys = [saveDirectoryBookmarkKey]
+        }
+
+        bookmarkQueue.sync {
+            for key in keys {
+                activeSecurityScopedDirectoryURLs.removeValue(forKey: key)?
+                    .stopAccessingSecurityScopedResource()
+            }
+        }
+    }
 #endif
 
     func generateURL(for type: CaptureType) -> URL {
@@ -181,12 +202,11 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
             withIntermediateDirectories: true
         )
 #else
-        let directory = UserDefaults.standard.string(forKey: "saveDirectory")
-            ?? (NSHomeDirectory() + "/Desktop")
+        let directoryURL = CaptureSettings.shared.resolvedSaveDirectory(for: type)
 
         // Ensure directory exists
         try? FileManager.default.createDirectory(
-            atPath: directory,
+            at: directoryURL,
             withIntermediateDirectories: true
         )
 #endif
@@ -202,7 +222,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 #if APPSTORE
         return uniqueURL(in: directoryURL, filename: filename)
 #else
-        return uniqueURL(in: URL(fileURLWithPath: directory), filename: filename)
+        return uniqueURL(in: directoryURL, filename: filename)
 #endif
     }
 
@@ -210,9 +230,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 #if APPSTORE
         return appStoreOutputDirectoryURL(for: type)
 #else
-        let directory = UserDefaults.standard.string(forKey: "saveDirectory")
-            ?? (NSHomeDirectory() + "/Desktop")
-        return URL(fileURLWithPath: directory, isDirectory: true)
+        return CaptureSettings.shared.resolvedSaveDirectory(for: type)
 #endif
     }
 
@@ -283,7 +301,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 
 #if APPSTORE
     private func appStoreOutputDirectoryURL(for type: CaptureType) -> URL {
-        if let customDirectory = customDirectoryURLFromBookmark() {
+        if let customDirectory = customDirectoryURLFromBookmark(for: type) {
             return customDirectory
         }
         return defaultDirectoryURL(for: type)
@@ -303,40 +321,51 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         return baseURL.appendingPathComponent("TinyClips", isDirectory: true)
     }
 
-    private func customDirectoryURLFromBookmark() -> URL? {
+    private func customDirectoryURLFromBookmark(for type: CaptureType) -> URL? {
         bookmarkQueue.sync {
-            if let activeSecurityScopedDirectoryURL {
-                return activeSecurityScopedDirectoryURL
-            }
-
-            guard let bookmarkData = UserDefaults.standard.data(forKey: saveDirectoryBookmarkKey), !bookmarkData.isEmpty else {
-                return nil
-            }
-
-            do {
-                var isStale = false
-                let url = try URL(
-                    resolvingBookmarkData: bookmarkData,
-                    options: [.withSecurityScope],
-                    relativeTo: nil,
-                    bookmarkDataIsStale: &isStale
-                )
-
-                if isStale,
-                   let refreshedBookmark = try? url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil) {
-                    UserDefaults.standard.set(refreshedBookmark, forKey: saveDirectoryBookmarkKey)
+            for key in bookmarkKeys(for: type) {
+                if let activeURL = activeSecurityScopedDirectoryURLs[key] {
+                    return activeURL
                 }
 
-                guard url.startAccessingSecurityScopedResource() else {
-                    return nil
+                guard let bookmarkData = UserDefaults.standard.data(forKey: key), !bookmarkData.isEmpty else {
+                    continue
                 }
 
-                activeSecurityScopedDirectoryURL = url
-                return url
-            } catch {
-                UserDefaults.standard.removeObject(forKey: saveDirectoryBookmarkKey)
-                return nil
+                do {
+                    var isStale = false
+                    let url = try URL(
+                        resolvingBookmarkData: bookmarkData,
+                        options: [.withSecurityScope],
+                        relativeTo: nil,
+                        bookmarkDataIsStale: &isStale
+                    )
+
+                    if isStale,
+                       let refreshedBookmark = try? url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil) {
+                        UserDefaults.standard.set(refreshedBookmark, forKey: key)
+                    }
+
+                    guard url.startAccessingSecurityScopedResource() else {
+                        continue
+                    }
+
+                    activeSecurityScopedDirectoryURLs[key] = url
+                    return url
+                } catch {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
             }
+            return nil
+        }
+    }
+
+    private func bookmarkKeys(for type: CaptureType) -> [String] {
+        switch type {
+        case .screenshot:
+            return [screenshotSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
+        case .video, .gif:
+            return [videoGifSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
         }
     }
 #endif

--- a/mac/TinyClips/Views/ClipsManagerWindow.swift
+++ b/mac/TinyClips/Views/ClipsManagerWindow.swift
@@ -225,10 +225,6 @@ private class ClipsViewModel: ObservableObject {
 
     private var editorWindows: [NSWindow] = []
 
-#if APPSTORE
-    private var activeScopedURL: URL?
-#endif
-
     enum SortOption: String, CaseIterable {
         case newest = "Newest First"
         case oldest = "Oldest First"
@@ -399,44 +395,12 @@ private class ClipsViewModel: ObservableObject {
     }
 
     private func clipDirectories() -> [URL] {
-#if APPSTORE
-        let bookmark = UserDefaults.standard.data(forKey: "saveDirectoryBookmark")
-        if let bookmark, !bookmark.isEmpty,
-           let customURL = resolveBookmark(bookmark) {
-            return [customURL]
-        }
-        var dirs: [URL] = []
-        if let pics = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first {
-            dirs.append(pics.appendingPathComponent("TinyClips"))
-        }
-        if let movies = FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask).first {
-            dirs.append(movies.appendingPathComponent("TinyClips"))
-        }
-        return dirs
-#else
-        let dir = UserDefaults.standard.string(forKey: "saveDirectory") ?? (NSHomeDirectory() + "/Desktop")
-        return [URL(fileURLWithPath: dir)]
-#endif
+        let types: [CaptureType] = [.screenshot, .video, .gif]
+        var seen = Set<String>()
+        return types
+            .map { SaveService.shared.outputDirectoryURL(for: $0) }
+            .filter { seen.insert($0.standardizedFileURL.path).inserted }
     }
-
-#if APPSTORE
-    private func resolveBookmark(_ data: Data) -> URL? {
-        var isStale = false
-        guard let url = try? URL(
-            resolvingBookmarkData: data,
-            options: [.withSecurityScope],
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
-        ), url.startAccessingSecurityScopedResource() else { return nil }
-        activeScopedURL?.stopAccessingSecurityScopedResource()
-        activeScopedURL = url
-        return url
-    }
-
-    deinit {
-        activeScopedURL?.stopAccessingSecurityScopedResource()
-    }
-#endif
 
     private func filesInDirectory(_ dir: URL) -> [URL] {
         let settings = CaptureSettings.shared

--- a/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
@@ -165,7 +165,7 @@ struct GeneralSettingsSection: View {
                 .truncationMode(.middle)
 
             if settings.isUsingSharedSaveDirectory(for: type) {
-                Text("Using shared folder")
+                Text(saveDirectoryHint(for: type))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -174,10 +174,25 @@ struct GeneralSettingsSection: View {
 
     private func saveDirectoryPath(for type: CaptureType) -> String {
 #if APPSTORE
+        if type == .video,
+           settings.isUsingSharedSaveDirectory(for: type),
+           settings.saveDirectoryBookmark.isEmpty {
+            let videoPath = SaveService.shared.outputDirectoryURL(for: .video).path
+            let gifPath = SaveService.shared.outputDirectoryURL(for: .gif).path
+            return "Videos: \(videoPath)  GIFs: \(gifPath)"
+        }
         let path = settings.saveDirectoryDisplayPath(for: type)
         return path.isEmpty ? SaveService.shared.outputDirectoryURL(for: type).path : path
 #else
         return settings.resolvedSaveDirectory(for: type).path
+#endif
+    }
+
+    private func saveDirectoryHint(for type: CaptureType) -> String {
+#if APPSTORE
+        return settings.saveDirectoryBookmark.isEmpty ? "Using default folders" : "Using shared folder"
+#else
+        return "Using shared folder"
 #endif
     }
 

--- a/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
@@ -4,8 +4,8 @@ import SwiftUI
 struct GeneralSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
     @ObservedObject var launchAtLogin: LaunchAtLoginManager
-    let chooseSaveDirectory: () -> Void
-    let resetSaveDirectory: () -> Void
+    let chooseSaveDirectory: (CaptureType?) -> Void
+    let resetSaveDirectory: (CaptureType?) -> Void
     let resetAllSettings: () -> Void
     let showInDockBinding: Binding<Bool>
     @State private var showPurgeConfirmation = false
@@ -28,12 +28,12 @@ struct GeneralSettingsSection: View {
                     Spacer()
 
                     Button("Browse…") {
-                        chooseSaveDirectory()
+                        chooseSaveDirectory(nil)
                     }
 
-                    if settings.hasCustomSaveDirectory {
+                    if !settings.saveDirectoryBookmark.isEmpty {
                         Button("Reset") {
-                            resetSaveDirectory()
+                            resetSaveDirectory(nil)
                         }
                     }
                 }
@@ -43,10 +43,12 @@ struct GeneralSettingsSection: View {
                 TextField("Save to", text: $settings.saveDirectory)
                     .textFieldStyle(.roundedBorder)
                 Button("Browse…") {
-                    chooseSaveDirectory()
+                    chooseSaveDirectory(nil)
                 }
             }
 #endif
+            saveDirectoryRow(title: "Screenshots folder", type: .screenshot)
+            saveDirectoryRow(title: "Videos & GIFs folder", type: .video)
             VStack(alignment: .leading, spacing: 6) {
                 TextField("File name template", text: $settings.fileNameTemplate)
                     .textFieldStyle(.roundedBorder)
@@ -138,6 +140,45 @@ struct GeneralSettingsSection: View {
         .task {
             await loadTemporaryFilesSummary()
         }
+    }
+
+    @ViewBuilder
+    private func saveDirectoryRow(title: String, type: CaptureType) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                Spacer()
+                Button("Choose…") {
+                    chooseSaveDirectory(type)
+                }
+                if !settings.isUsingSharedSaveDirectory(for: type) {
+                    Button("Reset to shared") {
+                        resetSaveDirectory(type)
+                    }
+                }
+            }
+
+            Text(saveDirectoryPath(for: type))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if settings.isUsingSharedSaveDirectory(for: type) {
+                Text("Using shared folder")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func saveDirectoryPath(for type: CaptureType) -> String {
+#if APPSTORE
+        let path = settings.saveDirectoryDisplayPath(for: type)
+        return path.isEmpty ? SaveService.shared.outputDirectoryURL(for: type).path : path
+#else
+        return settings.resolvedSaveDirectory(for: type).path
+#endif
     }
 
     @ViewBuilder

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -174,7 +174,7 @@ struct SettingsView: View {
         settingsWindowManager.selectedTab = nil
     }
 
-    private func chooseSaveDirectory() {
+    private func chooseSaveDirectory(for captureType: CaptureType?) {
         DispatchQueue.main.async {
             let panel = NSOpenPanel()
             panel.canChooseFiles = false
@@ -188,24 +188,40 @@ struct SettingsView: View {
 #if APPSTORE
             do {
                 let bookmark = try url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil)
-                settings.saveDirectoryBookmark = bookmark
-                settings.saveDirectoryDisplayPath = url.path
+                settings.setSaveDirectoryBookmark(bookmark, displayPath: url.path, for: captureType)
+                SaveService.shared.invalidateSaveDirectoryBookmark(for: captureType)
             } catch {
                 SaveService.shared.showError("Could not save folder permission: \(error.localizedDescription)")
             }
 #else
-            settings.saveDirectory = url.path
+            switch captureType {
+            case .screenshot:
+                settings.screenshotSaveDirectory = url.path
+            case .video, .gif:
+                settings.videoGifSaveDirectory = url.path
+            case nil:
+                settings.saveDirectory = url.path
+            }
 #endif
         }
     }
 
 #if APPSTORE
-    private func resetSaveDirectory() {
-        settings.saveDirectoryBookmark = Data()
-        settings.saveDirectoryDisplayPath = ""
+    private func resetSaveDirectory(for captureType: CaptureType?) {
+        settings.resetSaveDirectory(for: captureType)
+        SaveService.shared.invalidateSaveDirectoryBookmark(for: captureType)
     }
 #else
-    private func resetSaveDirectory() {}
+    private func resetSaveDirectory(for captureType: CaptureType?) {
+        switch captureType {
+        case .screenshot:
+            settings.screenshotSaveDirectory = ""
+        case .video, .gif:
+            settings.videoGifSaveDirectory = ""
+        case nil:
+            break
+        }
+    }
 #endif
 
     private func resetAllSettings() {


### PR DESCRIPTION
Users can now organize screenshots separately from videos and GIFs without losing their existing shared save-folder preference.

- Adds per-type folder overrides in General settings, with a reset-to-shared option and visible fallback state.
- Keeps the existing shared directory as the compatibility fallback for upgrades.
- Persists separate App Store security-scoped bookmarks and invalidates active scopes when an override changes or resets.
- Uses effective output folders for saving, menu folder actions, and Clips Manager discovery.

Closes #149