### PR TITLE
Add Narrator capture status announcements

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -7,6 +7,7 @@ own `CHANGELOG.md` at the repository root.
 
 ### Added
 - **Temporary-file controls in Settings → General** — an Advanced card now shows the Tiny Clips temporary-file count and size, opens its dedicated `%LOCALAPPDATA%\TinyClips\Temp` folder, and can purge those files without affecting saved captures.
+- **Narrator capture-status announcements** — Tiny Clips now announces screenshot, video, and GIF save results plus recording start and stop through a tray-lifetime UI Automation notification anchor, even when capture pickers and popups are closed.
 
 ### Changed
 - Screenshot, video, and GIF settings now each provide matching before/after capture-picker controls.

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -54,6 +54,7 @@ public partial class App : Application
     private TargetSelection? _activeRecordingSelection;
     private CaptureType? _activeRecordingType;
     private bool _activeRecordingWasPickerInitiated;
+    private bool _recordingStopAnnounced;
     private CaptureTile? _videoTile;
     private CaptureTile? _gifTile;
     private TrayPopupWindow? _trayPopup;
@@ -609,6 +610,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Capture failed: {ex}");
+            ShowSaveFailureNotification(CaptureOutputDescription(type));
             UpdateRecordingState();
             CloseRecordingRegionIndicator();
             _activeRecordingSelection = null;
@@ -1002,6 +1004,8 @@ public partial class App : Application
 
     private async Task StopActiveRecordingAsync()
     {
+        CaptureType? stoppedType = null;
+
         try
         {
             var video = Services.GetRequiredService<IVideoRecordingService>();
@@ -1009,12 +1013,14 @@ public partial class App : Application
 
             if (video.IsRecording)
             {
+                stoppedType = CaptureType.Video;
                 HideRecordingIndicator();
                 ShowProcessingIndicator(CaptureType.Video, _activeRecordingSelection);
                 await video.StopAsync();
             }
             else if (gif.IsRecording)
             {
+                stoppedType = CaptureType.Gif;
                 HideRecordingIndicator();
                 ShowProcessingIndicator(CaptureType.Gif, _activeRecordingSelection);
                 await gif.StopAsync();
@@ -1027,9 +1033,18 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Failed to stop active recording: {ex}");
+            if (stoppedType is { } type)
+            {
+                ShowSaveFailureNotification(CaptureOutputDescription(type));
+            }
         }
         finally
         {
+            if (stoppedType is { } type && !IsAnyRecordingActive())
+            {
+                AnnounceRecordingStopped(type);
+            }
+
             HideProcessingIndicator();
             UpdateRecordingState();
             CloseRecordingRegionIndicatorIfNotRecording();
@@ -1276,6 +1291,7 @@ public partial class App : Application
 
     private void ActivateRecordingIndicatorForStartedCapture(CaptureType type)
     {
+        _recordingStopAnnounced = false;
         _recordingStartedUtc = DateTime.UtcNow;
         _recordingElapsedBeforePause = TimeSpan.Zero;
         _recordingIndicator?.SetStopEnabled(true);
@@ -1633,16 +1649,24 @@ public partial class App : Application
     private void AnnounceRecordingStarted(CaptureType type) =>
         Announce(
             AutomationNotificationKind.Other,
-            AutomationNotificationProcessing.All,
+            AutomationNotificationProcessing.MostRecent,
             $"{CaptureTypeName(type)} recording started.",
             $"{CaptureTypeName(type)}RecordingStarted");
 
-    private void AnnounceRecordingStopped(CaptureType type) =>
+    private void AnnounceRecordingStopped(CaptureType type)
+    {
+        if (_recordingStopAnnounced)
+        {
+            return;
+        }
+
+        _recordingStopAnnounced = true;
         Announce(
             AutomationNotificationKind.ActionCompleted,
-            AutomationNotificationProcessing.All,
+            AutomationNotificationProcessing.MostRecent,
             $"{CaptureTypeName(type)} recording stopped.",
             $"{CaptureTypeName(type)}RecordingStopped");
+    }
 
     private static void AnnounceCaptureSaved(string path)
     {
@@ -1660,7 +1684,7 @@ public partial class App : Application
         {
             app.Announce(
                 AutomationNotificationKind.ActionCompleted,
-                AutomationNotificationProcessing.All,
+                AutomationNotificationProcessing.MostRecent,
                 message,
                 $"{CaptureTypeName(type)}Saved");
         }
@@ -1676,7 +1700,7 @@ public partial class App : Application
         {
             app.Announce(
                 AutomationNotificationKind.ActionAborted,
-                AutomationNotificationProcessing.All,
+                AutomationNotificationProcessing.ImportantMostRecent,
                 message,
                 "CaptureSaveFailed");
         }
@@ -1720,6 +1744,9 @@ public partial class App : Application
         CaptureType.Video => "Video",
         _ => "Screenshot",
     };
+
+    private static string CaptureOutputDescription(CaptureType type) =>
+        $"the {CaptureTypeName(type).ToLowerInvariant()} capture";
 
     private GlobalHotKeyRegistrationResult RegisterGlobalHotKeys()
     {

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
@@ -56,6 +57,7 @@ public partial class App : Application
     private CaptureTile? _videoTile;
     private CaptureTile? _gifTile;
     private TrayPopupWindow? _trayPopup;
+    private AutomationNotificationAnnouncer? _automationNotificationAnnouncer;
     private const double TrayPopupWidth = 288;
     private const double TrayPopupHeight = 242;
     private GlobalHotKeyManager? _hotKeyManager;
@@ -82,6 +84,7 @@ public partial class App : Application
 
         WireRecordingEvents();
         CreateTrayIcon();
+        CreateAutomationNotificationAnnouncer();
         RegisterGlobalHotKeys();
         ShowOnboardingIfNeeded();
         HandleFileActivation();
@@ -161,6 +164,11 @@ public partial class App : Application
         _taskbarIcon.ForceCreate();
 
         UpdateRecordingState();
+    }
+
+    private void CreateAutomationNotificationAnnouncer()
+    {
+        _automationNotificationAnnouncer ??= new AutomationNotificationAnnouncer();
     }
 
     private void ShowTrayPopup()
@@ -568,7 +576,7 @@ public partial class App : Application
                     }
                     await Services.GetRequiredService<IVideoRecordingService>()
                         .StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes, captureFlowCts.Token);
-                    ActivateRecordingIndicatorForStartedCapture();
+                    ActivateRecordingIndicatorForStartedCapture(CaptureType.Video);
                     UpdateRecordingState();
                     break;
 
@@ -584,7 +592,7 @@ public partial class App : Application
                     }
                     await Services.GetRequiredService<IGifRecordingService>()
                         .StartAsync(selection.Target, selection.Region, captureFlowCts.Token);
-                    ActivateRecordingIndicatorForStartedCapture();
+                    ActivateRecordingIndicatorForStartedCapture(CaptureType.Gif);
                     UpdateRecordingState();
                     break;
             }
@@ -966,14 +974,16 @@ public partial class App : Application
                 return;
             }
 
+            var type = sender is IGifRecordingService
+                ? CaptureType.Gif
+                : CaptureType.Video;
+            AnnounceRecordingStopped(type);
+
             if (string.IsNullOrEmpty(path))
             {
                 return;
             }
 
-            var type = Path.GetExtension(path).Equals(".gif", StringComparison.OrdinalIgnoreCase)
-                ? CaptureType.Gif
-                : CaptureType.Video;
             Services.GetRequiredService<IRecentCaptureService>().Record(path, type);
 
             var settings = Services.GetRequiredService<ICaptureSettings>();
@@ -1121,7 +1131,7 @@ public partial class App : Application
             await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
         }
 
-        ActivateRecordingIndicatorForStartedCapture();
+        ActivateRecordingIndicatorForStartedCapture(type);
         UpdateRecordingState();
     }
 
@@ -1264,7 +1274,7 @@ public partial class App : Application
         }
     }
 
-    private void ActivateRecordingIndicatorForStartedCapture()
+    private void ActivateRecordingIndicatorForStartedCapture(CaptureType type)
     {
         _recordingStartedUtc = DateTime.UtcNow;
         _recordingElapsedBeforePause = TimeSpan.Zero;
@@ -1276,6 +1286,7 @@ public partial class App : Application
             video.CanMuteMicrophone,
             video.IsMicrophoneMuted);
         StartRecordingTimer();
+        AnnounceRecordingStarted(type);
     }
 
     private void StartRecordingTimer()
@@ -1516,6 +1527,8 @@ public partial class App : Application
     /// </summary>
     internal static void ShowSaveNotification(string path)
     {
+        AnnounceCaptureSaved(path);
+
         try
         {
             var settings = Services.GetRequiredService<ICaptureSettings>();
@@ -1599,6 +1612,8 @@ public partial class App : Application
     /// </summary>
     internal static void ShowSaveFailureNotification(string fileName)
     {
+        AnnounceSaveFailure(fileName);
+
         try
         {
             EnsureNotificationsRegistered();
@@ -1614,6 +1629,97 @@ public partial class App : Application
             Debug.WriteLine($"Failed to show save failure notification: {ex}");
         }
     }
+
+    private void AnnounceRecordingStarted(CaptureType type) =>
+        Announce(
+            AutomationNotificationKind.Other,
+            AutomationNotificationProcessing.All,
+            $"{CaptureTypeName(type)} recording started.",
+            $"{CaptureTypeName(type)}RecordingStarted");
+
+    private void AnnounceRecordingStopped(CaptureType type) =>
+        Announce(
+            AutomationNotificationKind.ActionCompleted,
+            AutomationNotificationProcessing.All,
+            $"{CaptureTypeName(type)} recording stopped.",
+            $"{CaptureTypeName(type)}RecordingStopped");
+
+    private static void AnnounceCaptureSaved(string path)
+    {
+        var type = Path.GetExtension(path).Equals(".gif", StringComparison.OrdinalIgnoreCase)
+            ? CaptureType.Gif
+            : Path.GetExtension(path).Equals(".mp4", StringComparison.OrdinalIgnoreCase)
+                ? CaptureType.Video
+                : CaptureType.Screenshot;
+        var fileName = Path.GetFileName(path);
+        var message = string.IsNullOrWhiteSpace(fileName)
+            ? $"{CaptureTypeName(type)} saved."
+            : $"{CaptureTypeName(type)} saved: {fileName}.";
+
+        if (Application.Current is App app)
+        {
+            app.Announce(
+                AutomationNotificationKind.ActionCompleted,
+                AutomationNotificationProcessing.All,
+                message,
+                $"{CaptureTypeName(type)}Saved");
+        }
+    }
+
+    private static void AnnounceSaveFailure(string fileName)
+    {
+        var message = string.IsNullOrWhiteSpace(fileName)
+            ? "Couldn't save file."
+            : $"Couldn't save {fileName}.";
+
+        if (Application.Current is App app)
+        {
+            app.Announce(
+                AutomationNotificationKind.ActionAborted,
+                AutomationNotificationProcessing.All,
+                message,
+                "CaptureSaveFailed");
+        }
+    }
+
+    private void Announce(
+        AutomationNotificationKind kind,
+        AutomationNotificationProcessing processing,
+        string message,
+        string activityId)
+    {
+        if (_automationNotificationAnnouncer is null)
+        {
+            Debug.WriteLine($"Automation announcement unavailable: {message}");
+            return;
+        }
+
+        var dispatcher = _dispatcher;
+        if (dispatcher is null)
+        {
+            Debug.WriteLine($"Automation announcement dispatcher unavailable: {message}");
+            return;
+        }
+
+        if (dispatcher.HasThreadAccess)
+        {
+            _automationNotificationAnnouncer.Announce(kind, processing, message, activityId);
+            return;
+        }
+
+        if (!dispatcher.TryEnqueue(() =>
+                _automationNotificationAnnouncer?.Announce(kind, processing, message, activityId)))
+        {
+            Debug.WriteLine($"Automation announcement dispatch failed: {message}");
+        }
+    }
+
+    private static string CaptureTypeName(CaptureType type) => type switch
+    {
+        CaptureType.Gif => "GIF",
+        CaptureType.Video => "Video",
+        _ => "Screenshot",
+    };
 
     private GlobalHotKeyRegistrationResult RegisterGlobalHotKeys()
     {
@@ -1867,6 +1973,8 @@ public partial class App : Application
         _hotKeyManager = null;
         _taskbarIcon?.Dispose();
         _taskbarIcon = null;
+        _automationNotificationAnnouncer?.Close();
+        _automationNotificationAnnouncer = null;
         _settingsWindow?.Close();
         _guideWindow?.Close();
         _onboardingWindow?.Close();

--- a/windows/src/TinyClips.App/AutomationNotificationAnnouncer.cs
+++ b/windows/src/TinyClips.App/AutomationNotificationAnnouncer.cs
@@ -1,0 +1,51 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Graphics;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Keeps a WinUI Automation peer available for tray-first capture status announcements.
+/// </summary>
+internal sealed class AutomationNotificationAnnouncer : Window
+{
+    private const string AnchorName = "Tiny Clips capture status";
+
+    private readonly TextBlock _anchor;
+
+    public AutomationNotificationAnnouncer()
+    {
+        _anchor = new TextBlock
+        {
+            Width = 1,
+            Height = 1,
+            Opacity = 0,
+            IsHitTestVisible = false,
+        };
+        AutomationProperties.SetName(_anchor, AnchorName);
+        AutomationProperties.SetAutomationId(_anchor, "TinyClipsCaptureStatus");
+        Content = _anchor;
+
+        var presenter = OverlappedPresenter.CreateForContextMenu();
+        AppWindow.SetPresenter(presenter);
+        AppWindow.IsShownInSwitchers = false;
+        AppWindow.Resize(new SizeInt32(1, 1));
+        AppWindow.Move(new PointInt32(-32000, -32000));
+        AppWindow.Show(false);
+    }
+
+    public void Announce(
+        AutomationNotificationKind kind,
+        AutomationNotificationProcessing processing,
+        string message,
+        string activityId)
+    {
+        _anchor.Text = message;
+        var peer = FrameworkElementAutomationPeer.FromElement(_anchor)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(_anchor);
+        peer?.RaiseNotificationEvent(kind, processing, message, activityId);
+    }
+}

--- a/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
@@ -346,14 +346,15 @@ public sealed partial class GifTrimmerWindow : Window
 
         StopPlayback();
         ExportFrameButton.IsEnabled = false;
+        string? outputPath = null;
 
         try
         {
             var storage = App.Services.GetRequiredService<IClipStorageService>();
-            var path = storage.GenerateFilePath(CaptureType.Screenshot, ".png", "(frame)");
-            var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(path)!);
+            outputPath = storage.GenerateFilePath(CaptureType.Screenshot, ".png", "(frame)");
+            var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(outputPath)!);
             var file = await folder.CreateFileAsync(
-                System.IO.Path.GetFileName(path), CreationCollisionOption.GenerateUniqueName);
+                System.IO.Path.GetFileName(outputPath), CreationCollisionOption.GenerateUniqueName);
 
             using (var stream = await file.OpenAsync(FileAccessMode.ReadWrite))
             {
@@ -367,7 +368,7 @@ public sealed partial class GifTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"GIF frame export failed: {ex}");
-            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(_filePath));
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(outputPath ?? "GIF frame export"));
         }
         finally
         {

--- a/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
@@ -367,6 +367,7 @@ public sealed partial class GifTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"GIF frame export failed: {ex}");
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(_filePath));
         }
         finally
         {
@@ -431,6 +432,7 @@ public sealed partial class GifTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"GIF trim failed: {ex}");
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(outputPath ?? _filePath));
             outputPath = null;
         }
         finally

--- a/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
@@ -324,6 +324,7 @@ public sealed partial class VideoTrimmerWindow : Window
 
         BusyBar.Visibility = Visibility.Visible;
         ExportFrameButton.IsEnabled = false;
+        string? outputPath = null;
 
         try
         {
@@ -339,10 +340,10 @@ public sealed partial class VideoTrimmerWindow : Window
             var bitmap = await decoder.GetSoftwareBitmapAsync(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
 
             var storage = App.Services.GetRequiredService<IClipStorageService>();
-            var path = storage.GenerateFilePath(CaptureType.Screenshot, ".png", "(frame)");
-            var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(path)!);
+            outputPath = storage.GenerateFilePath(CaptureType.Screenshot, ".png", "(frame)");
+            var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(outputPath)!);
             var outFile = await folder.CreateFileAsync(
-                System.IO.Path.GetFileName(path), CreationCollisionOption.GenerateUniqueName);
+                System.IO.Path.GetFileName(outputPath), CreationCollisionOption.GenerateUniqueName);
 
             using (var outStream = await outFile.OpenAsync(FileAccessMode.ReadWrite))
             {
@@ -356,7 +357,7 @@ public sealed partial class VideoTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Video frame export failed: {ex}");
-            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(_filePath));
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(outputPath ?? "video frame export"));
         }
         finally
         {

--- a/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
@@ -356,6 +356,7 @@ public sealed partial class VideoTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Video frame export failed: {ex}");
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(_filePath));
         }
         finally
         {
@@ -445,6 +446,7 @@ public sealed partial class VideoTrimmerWindow : Window
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Video trim failed: {ex}");
+            App.ShowSaveFailureNotification(System.IO.Path.GetFileName(outputPath ?? _filePath));
             outputPath = null;
         }
         finally


### PR DESCRIPTION
Capture completion currently relies on visual toasts, leaving tray-first flows without reliable Narrator feedback once transient pickers or popups close.

This adds a dedicated tray-lifetime, off-screen WinUI automation anchor and raises UIA notification events for screenshot, video, and GIF save success/failure plus video/GIF recording start and stop. Save and error handling remains centralized so existing toast, clipboard, and Explorer behavior is unchanged; GIF/video trimmer export failures now also use the shared save-failure notification.

Validation was attempted on macOS. Restore completed, but the Windows App SDK XAML compiler and WindowsDesktop test host require a Windows environment.

Fixes: #198