### PR TITLE
Surface macOS hotkey registration conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.
+- Fixed macOS shortcut changes silently accepting unavailable or conflicting global hotkeys; Settings now validates conflicts and keeps the prior working shortcut when registration fails.
 
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -132,7 +132,12 @@ class CaptureManager: ObservableObject {
     @Published var activeWebcamName: String?
     @Published var microphoneLevel: Double = 0
     @Published var microphoneWarningMessage: String?
-    @Published private(set) var hotKeyRegistrationError: String?
+    @Published private(set) var captureHotKeyRegistrationError: String?
+    @Published private(set) var stopHotKeyRegistrationError: String?
+
+    var hotKeyRegistrationError: String? {
+        captureHotKeyRegistrationError ?? stopHotKeyRegistrationError
+    }
 
     private var videoRecorder: VideoRecorder?
     private var webcamRecorder: WebcamRecorder?
@@ -229,7 +234,7 @@ class CaptureManager: ObservableObject {
                 carbonModifiers: settings.gifHotKeyModifiers
             )
         )
-        hotKeyRegistrationError = result.errorMessage
+        captureHotKeyRegistrationError = result.errorMessage
 
         updateStopHotKeyRegistration()
     }
@@ -260,18 +265,19 @@ class CaptureManager: ObservableObject {
             currentBinding = gif
         }
 
-        guard binding != currentBinding else {
-            hotKeyRegistrationError = nil
-            return nil
-        }
-
         if let validationError = HotKeyBinding.validationError(
             for: binding,
             captureType: captureType,
             captureBindings: [(.screenshot, screenshot), (.video, video), (.gif, gif)]
         ) {
-            hotKeyRegistrationError = validationError
+            captureHotKeyRegistrationError = validationError
             return validationError
+        }
+
+        if binding == currentBinding {
+            let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+            captureHotKeyRegistrationError = result.errorMessage
+            return result.errorMessage
         }
 
         switch captureType {
@@ -285,24 +291,50 @@ class CaptureManager: ObservableObject {
 
         let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
         guard let registrationError = result.errorMessage else {
-            shouldIgnoreNextHotKeySettingsChange = true
-            switch captureType {
-            case .screenshot:
-                settings.screenshotHotKeyCode = binding.keyCode
-                settings.screenshotHotKeyModifiers = binding.carbonModifiers
-            case .video:
-                settings.videoHotKeyCode = binding.keyCode
-                settings.videoHotKeyModifiers = binding.carbonModifiers
-            case .gif:
-                settings.gifHotKeyCode = binding.keyCode
-                settings.gifHotKeyModifiers = binding.carbonModifiers
-            }
-            hotKeyRegistrationError = nil
+            persistCaptureHotKeys(screenshot: screenshot, video: video, gif: gif, settings: settings)
+            captureHotKeyRegistrationError = nil
             return nil
         }
 
-        hotKeyRegistrationError = registrationError
+        captureHotKeyRegistrationError = registrationError
         return registrationError
+    }
+
+    @discardableResult
+    func resetCaptureHotKeysToDefaults() -> String? {
+        let screenshot = HotKeyBinding.defaultScreenshot
+        let video = HotKeyBinding.defaultVideo
+        let gif = HotKeyBinding.defaultGif
+        let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+
+        guard let registrationError = result.errorMessage else {
+            persistCaptureHotKeys(
+                screenshot: screenshot,
+                video: video,
+                gif: gif,
+                settings: CaptureSettings.shared
+            )
+            captureHotKeyRegistrationError = nil
+            return nil
+        }
+
+        captureHotKeyRegistrationError = registrationError
+        return registrationError
+    }
+
+    private func persistCaptureHotKeys(
+        screenshot: HotKeyBinding,
+        video: HotKeyBinding,
+        gif: HotKeyBinding,
+        settings: CaptureSettings
+    ) {
+        shouldIgnoreNextHotKeySettingsChange = true
+        settings.screenshotHotKeyCode = screenshot.keyCode
+        settings.screenshotHotKeyModifiers = screenshot.carbonModifiers
+        settings.videoHotKeyCode = video.keyCode
+        settings.videoHotKeyModifiers = video.carbonModifiers
+        settings.gifHotKeyCode = gif.keyCode
+        settings.gifHotKeyModifiers = gif.carbonModifiers
     }
 
     private func registerCaptureHotKeys(
@@ -338,11 +370,10 @@ class CaptureManager: ObservableObject {
                 guard let self, self.isRecording else { return }
                 self.stopRecording()
             }
-            if let registrationError = result.errorMessage {
-                hotKeyRegistrationError = registrationError
-            }
+            stopHotKeyRegistrationError = result.errorMessage
         } else {
             hotKeyManager.unregisterStopHotKey()
+            stopHotKeyRegistrationError = nil
         }
     }
 

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -132,6 +132,7 @@ class CaptureManager: ObservableObject {
     @Published var activeWebcamName: String?
     @Published var microphoneLevel: Double = 0
     @Published var microphoneWarningMessage: String?
+    @Published private(set) var hotKeyRegistrationError: String?
 
     private var videoRecorder: VideoRecorder?
     private var webcamRecorder: WebcamRecorder?
@@ -176,6 +177,7 @@ class CaptureManager: ObservableObject {
     private var webcamPositionEvents: [BrandingOverlayProcessor.WebcamPositionEvent] = []
     private let hotKeyManager = HotKeyManager()
     private var hotKeySettingsCancellable: AnyCancellable?
+    private var shouldIgnoreNextHotKeySettingsChange = false
 
     init() {
         configureGlobalHotKeys()
@@ -184,7 +186,12 @@ class CaptureManager: ObservableObject {
         hotKeySettingsCancellable = CaptureSettings.shared.objectWillChange
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .sink { [weak self] in
-                self?.configureGlobalHotKeys()
+                guard let self else { return }
+                if self.shouldIgnoreNextHotKeySettingsChange {
+                    self.shouldIgnoreNextHotKeySettingsChange = false
+                    return
+                }
+                self.configureGlobalHotKeys()
             }
 
         DispatchQueue.main.async { [weak self] in
@@ -208,35 +215,131 @@ class CaptureManager: ObservableObject {
 
     private func configureGlobalHotKeys() {
         let settings = CaptureSettings.shared
+        let result = registerCaptureHotKeys(
+            screenshot: HotKeyBinding(
+                keyCode: settings.screenshotHotKeyCode,
+                carbonModifiers: settings.screenshotHotKeyModifiers
+            ),
+            video: HotKeyBinding(
+                keyCode: settings.videoHotKeyCode,
+                carbonModifiers: settings.videoHotKeyModifiers
+            ),
+            gif: HotKeyBinding(
+                keyCode: settings.gifHotKeyCode,
+                carbonModifiers: settings.gifHotKeyModifiers
+            )
+        )
+        hotKeyRegistrationError = result.errorMessage
+
+        updateStopHotKeyRegistration()
+    }
+
+    @discardableResult
+    func applyCaptureHotKey(_ binding: HotKeyBinding, for captureType: CaptureType) -> String? {
+        let settings = CaptureSettings.shared
+        var screenshot = HotKeyBinding(
+            keyCode: settings.screenshotHotKeyCode,
+            carbonModifiers: settings.screenshotHotKeyModifiers
+        )
+        var video = HotKeyBinding(
+            keyCode: settings.videoHotKeyCode,
+            carbonModifiers: settings.videoHotKeyModifiers
+        )
+        var gif = HotKeyBinding(
+            keyCode: settings.gifHotKeyCode,
+            carbonModifiers: settings.gifHotKeyModifiers
+        )
+        let currentBinding: HotKeyBinding
+
+        switch captureType {
+        case .screenshot:
+            currentBinding = screenshot
+        case .video:
+            currentBinding = video
+        case .gif:
+            currentBinding = gif
+        }
+
+        guard binding != currentBinding else {
+            hotKeyRegistrationError = nil
+            return nil
+        }
+
+        if let validationError = HotKeyBinding.validationError(
+            for: binding,
+            captureType: captureType,
+            captureBindings: [(.screenshot, screenshot), (.video, video), (.gif, gif)]
+        ) {
+            hotKeyRegistrationError = validationError
+            return validationError
+        }
+
+        switch captureType {
+        case .screenshot:
+            screenshot = binding
+        case .video:
+            video = binding
+        case .gif:
+            gif = binding
+        }
+
+        let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+        guard let registrationError = result.errorMessage else {
+            shouldIgnoreNextHotKeySettingsChange = true
+            switch captureType {
+            case .screenshot:
+                settings.screenshotHotKeyCode = binding.keyCode
+                settings.screenshotHotKeyModifiers = binding.carbonModifiers
+            case .video:
+                settings.videoHotKeyCode = binding.keyCode
+                settings.videoHotKeyModifiers = binding.carbonModifiers
+            case .gif:
+                settings.gifHotKeyCode = binding.keyCode
+                settings.gifHotKeyModifiers = binding.carbonModifiers
+            }
+            hotKeyRegistrationError = nil
+            return nil
+        }
+
+        hotKeyRegistrationError = registrationError
+        return registrationError
+    }
+
+    private func registerCaptureHotKeys(
+        screenshot: HotKeyBinding,
+        video: HotKeyBinding,
+        gif: HotKeyBinding
+    ) -> HotKeyManager.RegistrationResult {
         hotKeyManager.registerCaptureHotKeys(
-            screenshotKeyCode: UInt32(settings.screenshotHotKeyCode),
-            screenshotModifiers: UInt32(settings.screenshotHotKeyModifiers),
+            screenshotKeyCode: UInt32(screenshot.keyCode),
+            screenshotModifiers: UInt32(screenshot.carbonModifiers),
             onScreenshot: { [weak self] in
                 guard let self, !self.isRecording else { return }
                 self.takeScreenshot()
             },
-            videoKeyCode: UInt32(settings.videoHotKeyCode),
-            videoModifiers: UInt32(settings.videoHotKeyModifiers),
+            videoKeyCode: UInt32(video.keyCode),
+            videoModifiers: UInt32(video.carbonModifiers),
             onRecordVideo: { [weak self] in
                 guard let self, !self.isRecording else { return }
                 self.startVideoRecording()
             },
-            gifKeyCode: UInt32(settings.gifHotKeyCode),
-            gifModifiers: UInt32(settings.gifHotKeyModifiers),
+            gifKeyCode: UInt32(gif.keyCode),
+            gifModifiers: UInt32(gif.carbonModifiers),
             onRecordGif: { [weak self] in
                 guard let self, !self.isRecording else { return }
                 self.startGifRecording()
             }
         )
-
-        updateStopHotKeyRegistration()
     }
 
     private func updateStopHotKeyRegistration() {
         if isRecording {
-            hotKeyManager.registerStopHotKey { [weak self] in
+            let result = hotKeyManager.registerStopHotKey { [weak self] in
                 guard let self, self.isRecording else { return }
                 self.stopRecording()
+            }
+            if let registrationError = result.errorMessage {
+                hotKeyRegistrationError = registrationError
             }
         } else {
             hotKeyManager.unregisterStopHotKey()

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -532,7 +532,7 @@ class CaptureSettings: ObservableObject {
         set { gifMouseClickColorHex = newValue.hexRGBString }
     }
 
-    func resetToDefaults() {
+    func resetToDefaults(preservingHotKeys: Bool = false) {
         // Remove all keys in one pass so only a single objectWillChange fires
         let keys: [String] = [
             "saveDirectory", "screenshotSaveDirectory", "videoGifSaveDirectory",
@@ -567,10 +567,12 @@ class CaptureSettings: ObservableObject {
             "screenshotCountdownEnabled", "screenshotCountdownDuration",
             "hasCompletedOnboarding", "alwaysCaptureMainDisplay", "multiMonitorCaptureMode", "showRegionIndicator",
             "includeTinyClipsInCapture", "showBrandingOverlay",
+            "appStoreClipCountForReview", "appStoreReviewRequested"
+        ]
+        let hotKeyKeys = [
             "screenshotHotKeyCode", "screenshotHotKeyModifiers",
             "videoHotKeyCode", "videoHotKeyModifiers",
-            "gifHotKeyCode", "gifHotKeyModifiers",
-            "appStoreClipCountForReview", "appStoreReviewRequested"
+            "gifHotKeyCode", "gifHotKeyModifiers"
         ]
 #if APPSTORE
         let masKeys: [String] = [
@@ -581,7 +583,7 @@ class CaptureSettings: ObservableObject {
 #else
         let masKeys: [String] = []
 #endif
-        for key in keys + masKeys {
+        for key in keys + (preservingHotKeys ? [] : hotKeyKeys) + masKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
 #if APPSTORE

--- a/mac/TinyClips/Models/HotKeyBinding.swift
+++ b/mac/TinyClips/Models/HotKeyBinding.swift
@@ -18,6 +18,33 @@ struct HotKeyBinding: Equatable {
     static let defaultScreenshot = HotKeyBinding(keyCode: 23, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘5
     static let defaultVideo      = HotKeyBinding(keyCode: 22, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘6
     static let defaultGif        = HotKeyBinding(keyCode: 26, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘7
+    static let stopRecording     = HotKeyBinding(keyCode: kVK_ANSI_Period, carbonModifiers: Int(cmdKey))
+
+    private static let supportedModifierMask = Int(controlKey | optionKey | shiftKey | cmdKey)
+
+    // MARK: - Validation
+
+    static func validationError(
+        for proposedBinding: HotKeyBinding,
+        captureType: CaptureType,
+        captureBindings: [(CaptureType, HotKeyBinding)]
+    ) -> String? {
+        guard proposedBinding.carbonModifiers & supportedModifierMask != 0 else {
+            return "Add at least one modifier key (Control, Option, Shift, or Command)."
+        }
+
+        if proposedBinding == stopRecording {
+            return "That shortcut is reserved for Stop Recording (\(stopRecording.displayString)). Choose a different combination."
+        }
+
+        if let conflictingType = captureBindings.first(where: {
+            $0.0 != captureType && $0.1 == proposedBinding
+        })?.0 {
+            return "That shortcut is already assigned to \(conflictingType.hotKeyDisplayName)."
+        }
+
+        return nil
+    }
 
     // MARK: - Display
 
@@ -136,6 +163,20 @@ struct HotKeyBinding: Equatable {
         case kVK_F11:           return "F11"
         case kVK_F12:           return "F12"
         default:                return nil
+        }
+    }
+
+}
+
+extension CaptureType {
+    var hotKeyDisplayName: String {
+        switch self {
+        case .screenshot:
+            return "Screenshot"
+        case .video:
+            return "Record Video"
+        case .gif:
+            return "Record GIF"
         }
     }
 }

--- a/mac/TinyClips/Services/HotKeyManager.swift
+++ b/mac/TinyClips/Services/HotKeyManager.swift
@@ -10,7 +10,7 @@ final class HotKeyManager {
 
     // MARK: - Types
 
-    private enum HotKeyID: UInt32 {
+    enum HotKeyID: UInt32 {
         case screenshot = 1
         case recordVideo = 2
         case recordGif = 3
@@ -19,6 +19,46 @@ final class HotKeyManager {
 
     private struct RegisteredHotKey {
         let reference: EventHotKeyRef
+        let keyCode: UInt32
+        let modifiers: UInt32
+        let action: () -> Void
+    }
+
+    struct RegistrationFailure {
+        let name: String
+        let status: OSStatus
+    }
+
+    struct RegistrationResult {
+        let failures: [RegistrationFailure]
+        let restorationFailures: [RegistrationFailure]
+
+        static let success = RegistrationResult(failures: [], restorationFailures: [])
+
+        var isSuccess: Bool {
+            failures.isEmpty
+        }
+
+        var errorMessage: String? {
+            guard !failures.isEmpty else { return nil }
+
+            let rejectedNames = failures.map(\.name).joined(separator: ", ")
+            var message = "macOS could not register \(rejectedNames). Another app may already use this shortcut. Choose a different combination."
+
+            if !restorationFailures.isEmpty {
+                let restoredNames = restorationFailures.map(\.name).joined(separator: ", ")
+                message += " The previous shortcut remains in Settings, but macOS could not reactivate \(restoredNames). Close the competing app or restart TinyClips."
+            }
+
+            return message
+        }
+    }
+
+    private struct HotKeyRegistration {
+        let id: HotKeyID
+        let name: String
+        let keyCode: UInt32
+        let modifiers: UInt32
         let action: () -> Void
     }
 
@@ -53,35 +93,45 @@ final class HotKeyManager {
         gifKeyCode: UInt32,
         gifModifiers: UInt32,
         onRecordGif: @escaping () -> Void
-    ) {
-        register(
-            id: .screenshot,
-            keyCode: screenshotKeyCode,
-            modifiers: screenshotModifiers,
-            action: onScreenshot
-        )
-
-        register(
-            id: .recordVideo,
-            keyCode: videoKeyCode,
-            modifiers: videoModifiers,
-            action: onRecordVideo
-        )
-
-        register(
-            id: .recordGif,
-            keyCode: gifKeyCode,
-            modifiers: gifModifiers,
-            action: onRecordGif
+    ) -> RegistrationResult {
+        replace(
+            hotKeys: [
+                HotKeyRegistration(
+                    id: .screenshot,
+                    name: "Screenshot",
+                    keyCode: screenshotKeyCode,
+                    modifiers: screenshotModifiers,
+                    action: onScreenshot
+                ),
+                HotKeyRegistration(
+                    id: .recordVideo,
+                    name: "Record Video",
+                    keyCode: videoKeyCode,
+                    modifiers: videoModifiers,
+                    action: onRecordVideo
+                ),
+                HotKeyRegistration(
+                    id: .recordGif,
+                    name: "Record GIF",
+                    keyCode: gifKeyCode,
+                    modifiers: gifModifiers,
+                    action: onRecordGif
+                )
+            ]
         )
     }
 
-    func registerStopHotKey(onStopRecording: @escaping () -> Void) {
-        register(
-            id: .stopRecording,
-            keyCode: 47, // kVK_ANSI_Period
-            modifiers: UInt32(cmdKey),
-            action: onStopRecording
+    func registerStopHotKey(onStopRecording: @escaping () -> Void) -> RegistrationResult {
+        replace(
+            hotKeys: [
+                HotKeyRegistration(
+                    id: .stopRecording,
+                    name: "Stop Recording",
+                    keyCode: UInt32(HotKeyBinding.stopRecording.keyCode),
+                    modifiers: UInt32(HotKeyBinding.stopRecording.carbonModifiers),
+                    action: onStopRecording
+                )
+            ]
         )
     }
 
@@ -100,24 +150,74 @@ final class HotKeyManager {
 
     // MARK: - Registration
 
-    private func register(id: HotKeyID, keyCode: UInt32, modifiers: UInt32, action: @escaping () -> Void) {
-        unregister(id: id)
+    private func replace(hotKeys: [HotKeyRegistration]) -> RegistrationResult {
+        let ids = hotKeys.map(\.id)
+        let previousHotKeys = ids.compactMap { id in
+            registeredHotKeys[id.rawValue].map {
+                HotKeyRegistration(
+                    id: id,
+                    name: name(for: id),
+                    keyCode: $0.keyCode,
+                    modifiers: $0.modifiers,
+                    action: $0.action
+                )
+            }
+        }
 
+        ids.forEach(unregister)
+
+        let failures = hotKeys.compactMap { hotKey -> RegistrationFailure? in
+            register(hotKey) ? nil : RegistrationFailure(name: hotKey.name, status: lastRegistrationStatus)
+        }
+        guard failures.isEmpty else {
+            ids.forEach(unregister)
+
+            let restorationFailures = previousHotKeys.compactMap { hotKey -> RegistrationFailure? in
+                register(hotKey) ? nil : RegistrationFailure(name: hotKey.name, status: lastRegistrationStatus)
+            }
+            return RegistrationResult(failures: failures, restorationFailures: restorationFailures)
+        }
+
+        return .success
+    }
+
+    private var lastRegistrationStatus: OSStatus = noErr
+
+    private func register(_ hotKey: HotKeyRegistration) -> Bool {
         var hotKeyRef: EventHotKeyRef?
-        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: id.rawValue)
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: hotKey.id.rawValue)
 
-        let status = RegisterEventHotKey(
-            keyCode,
-            modifiers,
+        lastRegistrationStatus = RegisterEventHotKey(
+            hotKey.keyCode,
+            hotKey.modifiers,
             hotKeyID,
             GetApplicationEventTarget(),
             0,
             &hotKeyRef
         )
 
-        guard status == noErr, let hotKeyRef else { return }
+        guard lastRegistrationStatus == noErr, let hotKeyRef else { return false }
 
-        registeredHotKeys[id.rawValue] = RegisteredHotKey(reference: hotKeyRef, action: action)
+        registeredHotKeys[hotKey.id.rawValue] = RegisteredHotKey(
+            reference: hotKeyRef,
+            keyCode: hotKey.keyCode,
+            modifiers: hotKey.modifiers,
+            action: hotKey.action
+        )
+        return true
+    }
+
+    private func name(for id: HotKeyID) -> String {
+        switch id {
+        case .screenshot:
+            return "Screenshot"
+        case .recordVideo:
+            return "Record Video"
+        case .recordGif:
+            return "Record GIF"
+        case .stopRecording:
+            return "Stop Recording"
+        }
     }
 
     private func unregister(id: HotKeyID) {

--- a/mac/TinyClips/TinyClipsApp.swift
+++ b/mac/TinyClips/TinyClipsApp.swift
@@ -49,7 +49,7 @@ struct TinyClipsApp: App {
         }
 
         Window("Tiny Clips Settings", id: "settings-window") {
-            SettingsView()
+            SettingsView(captureManager: captureManager)
         }
         .defaultSize(width: 720, height: 460)
         .commands {

--- a/mac/TinyClips/Views/Settings/ShortcutsSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/ShortcutsSettingsSection.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct ShortcutsSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
+    @ObservedObject var captureManager: CaptureManager
+
+    @State private var shortcutError: String?
 
     var body: some View {
         Section("Global Keyboard Shortcuts") {
@@ -9,27 +12,39 @@ struct ShortcutsSettingsSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            if let shortcutError {
+                Label(shortcutError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Shortcut error: \(shortcutError)")
+            } else if let registrationError = captureManager.hotKeyRegistrationError {
+                Label(registrationError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Shortcut error: \(registrationError)")
+            }
+
             ShortcutRecorderField(
                 label: "Screenshot",
-                keyCode: $settings.screenshotHotKeyCode,
-                carbonModifiers: $settings.screenshotHotKeyModifiers,
-                defaultBinding: .defaultScreenshot
+                binding: screenshotBinding,
+                defaultBinding: .defaultScreenshot,
+                onBindingRecorded: { apply($0, for: .screenshot) }
             )
             .accessibilityLabel("Screenshot keyboard shortcut")
 
             ShortcutRecorderField(
                 label: "Record Video",
-                keyCode: $settings.videoHotKeyCode,
-                carbonModifiers: $settings.videoHotKeyModifiers,
-                defaultBinding: .defaultVideo
+                binding: videoBinding,
+                defaultBinding: .defaultVideo,
+                onBindingRecorded: { apply($0, for: .video) }
             )
             .accessibilityLabel("Record Video keyboard shortcut")
 
             ShortcutRecorderField(
                 label: "Record GIF",
-                keyCode: $settings.gifHotKeyCode,
-                carbonModifiers: $settings.gifHotKeyModifiers,
-                defaultBinding: .defaultGif
+                binding: gifBinding,
+                defaultBinding: .defaultGif,
+                onBindingRecorded: { apply($0, for: .gif) }
             )
             .accessibilityLabel("Record GIF keyboard shortcut")
         }
@@ -56,5 +71,30 @@ struct ShortcutsSettingsSection: View {
                 .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
                 .foregroundStyle(.secondary)
         }
+    }
+
+    private var screenshotBinding: HotKeyBinding {
+        HotKeyBinding(
+            keyCode: settings.screenshotHotKeyCode,
+            carbonModifiers: settings.screenshotHotKeyModifiers
+        )
+    }
+
+    private var videoBinding: HotKeyBinding {
+        HotKeyBinding(
+            keyCode: settings.videoHotKeyCode,
+            carbonModifiers: settings.videoHotKeyModifiers
+        )
+    }
+
+    private var gifBinding: HotKeyBinding {
+        HotKeyBinding(
+            keyCode: settings.gifHotKeyCode,
+            carbonModifiers: settings.gifHotKeyModifiers
+        )
+    }
+
+    private func apply(_ binding: HotKeyBinding, for captureType: CaptureType) {
+        shortcutError = captureManager.applyCaptureHotKey(binding, for: captureType)
     }
 }

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -235,9 +235,14 @@ struct SettingsView: View {
             alert.addButton(withTitle: "Cancel")
 
             guard alert.runModal() == .alertFirstButtonReturn else { return }
-            settings.resetToDefaults()
+            let hotKeyResetError = captureManager.resetCaptureHotKeysToDefaults()
+            settings.resetToDefaults(preservingHotKeys: true)
             sparkleController.resetPreferencesToDefaults()
             applyDockVisibility(settings.showInDock)
+
+            if let hotKeyResetError {
+                SaveService.shared.showError(hotKeyResetError)
+            }
         }
     }
 

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -40,6 +40,7 @@ enum SettingsTab: String, CaseIterable {
 }
 
 struct SettingsView: View {
+    @ObservedObject var captureManager: CaptureManager
     @ObservedObject private var settings = CaptureSettings.shared
     @ObservedObject private var captureAnalytics = CaptureAnalyticsStore.shared
     @ObservedObject private var sparkleController = SparkleController.shared
@@ -98,7 +99,7 @@ struct SettingsView: View {
                 case .branding:
                     BrandingSettingsSection(settings: settings)
                 case .shortcuts:
-                    ShortcutsSettingsSection(settings: settings)
+                    ShortcutsSettingsSection(settings: settings, captureManager: captureManager)
                 case .pro:
 #if APPSTORE
                     ProSettingsSection()

--- a/mac/TinyClips/Views/ShortcutRecorderField.swift
+++ b/mac/TinyClips/Views/ShortcutRecorderField.swift
@@ -8,19 +8,15 @@ import Carbon.HIToolbox
 /// record a new one by clicking "Record" and pressing any key combo.
 struct ShortcutRecorderField: View {
     let label: String
-    @Binding var keyCode: Int
-    @Binding var carbonModifiers: Int
+    let binding: HotKeyBinding
     let defaultBinding: HotKeyBinding
+    let onBindingRecorded: (HotKeyBinding) -> Void
 
     @State private var isRecording = false
     @State private var eventMonitor: Any?
 
-    private var current: HotKeyBinding {
-        HotKeyBinding(keyCode: keyCode, carbonModifiers: carbonModifiers)
-    }
-
     private var isCustom: Bool {
-        current != defaultBinding
+        binding != defaultBinding
     }
 
     var body: some View {
@@ -45,13 +41,13 @@ struct ShortcutRecorderField: View {
                 .accessibilityHint("Cancels recording and keeps the current shortcut.")
                 .help("Cancel shortcut recording.")
             } else {
-                Text(current.displayString)
+                Text(binding.displayString)
                     .font(.system(.body, design: .monospaced))
                     .frame(minWidth: 80, alignment: .center)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
-                    .accessibilityLabel("Current shortcut: \(current.displayString)")
+                    .accessibilityLabel("Current shortcut: \(binding.displayString)")
 
                 Button("Record") {
                     startRecording()
@@ -62,8 +58,7 @@ struct ShortcutRecorderField: View {
 
                 if isCustom {
                     Button("Reset") {
-                        keyCode = defaultBinding.keyCode
-                        carbonModifiers = defaultBinding.carbonModifiers
+                        onBindingRecorded(defaultBinding)
                     }
                     .buttonStyle(.bordered)
                     .accessibilityHint("Resets this shortcut to its default value.")
@@ -105,9 +100,12 @@ struct ShortcutRecorderField: View {
                 return nil
             }
 
-            // Commit new shortcut
-            keyCode = code
-            carbonModifiers = HotKeyBinding.carbonModifiers(from: flags)
+            onBindingRecorded(
+                HotKeyBinding(
+                    keyCode: code,
+                    carbonModifiers: HotKeyBinding.carbonModifiers(from: flags)
+                )
+            )
             stopRecording()
             return nil
         }


### PR DESCRIPTION
macOS shortcut edits could appear to save even when Carbon rejected their global registration, leaving an inactive binding without feedback.

This change validates modifier requirements, duplicate capture bindings, and the reserved Cmd+. stop shortcut before persistence. It registers replacements transactionally, restores the prior working binding when Carbon rejects a candidate, and shows an accessible inline Settings error for rejected registrations.

Both TinyClips and TinyClipsMAS build successfully without signing.

Fixes: #152