### PR TITLE
Add screenshot export frame controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.
+- macOS screenshot editor exports now offer Original, 1:1, 4:3, 16:9, 3:4, and 9:16 frames plus horizontal and vertical alignment, with image pixels and annotations preserved without stretching.
 
 ## v1.5.4-mac - 2026-07-26
 

--- a/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorCanvas.swift
@@ -8,10 +8,16 @@ struct ScreenshotEditorCanvasView: View {
     let containerSize: CGSize
 
     var body: some View {
-        let imageSize = viewModel.displaySize(in: containerSize)
+        let exportLayout = viewModel.displayLayout(in: containerSize)
+        let imageSize = exportLayout.imageRect.size
+        let frameSize = exportLayout.frameSize
+        let frameOrigin = CGPoint(
+            x: (containerSize.width - frameSize.width) / 2,
+            y: (containerSize.height - frameSize.height) / 2
+        )
         let origin = CGPoint(
-            x: (containerSize.width - imageSize.width) / 2,
-            y: (containerSize.height - imageSize.height) / 2
+            x: frameOrigin.x + exportLayout.imageRect.minX,
+            y: frameOrigin.y + exportLayout.imageRect.minY
         )
         let imageCornerRadius = min(
             viewModel.canvasCornerRadius,
@@ -23,13 +29,10 @@ struct ScreenshotEditorCanvasView: View {
             Color(nsColor: .controlBackgroundColor)
 
             if let image = viewModel.originalImage {
-                let backgroundWidth = imageSize.width + (viewModel.canvasPadding * 2)
-                let backgroundHeight = imageSize.height + (viewModel.canvasPadding * 2)
-
                 if viewModel.backgroundStyle == .solid {
                     Rectangle()
                         .fill(viewModel.backgroundColor)
-                        .frame(width: backgroundWidth, height: backgroundHeight)
+                        .frame(width: frameSize.width, height: frameSize.height)
                         .position(x: containerSize.width / 2, y: containerSize.height / 2)
                 } else if viewModel.backgroundStyle == .gradient {
                     Rectangle()
@@ -40,13 +43,14 @@ struct ScreenshotEditorCanvasView: View {
                                 endPoint: .bottomTrailing
                             )
                         )
-                        .frame(width: backgroundWidth, height: backgroundHeight)
+                        .frame(width: frameSize.width, height: frameSize.height)
                         .position(x: containerSize.width / 2, y: containerSize.height / 2)
                 } else if viewModel.backgroundStyle == .wallpaper, let wallpaperImage = viewModel.wallpaperImage {
                     Image(nsImage: wallpaperImage)
                         .resizable()
                         .scaledToFill()
-                        .frame(width: backgroundWidth, height: backgroundHeight)
+                        .frame(width: frameSize.width, height: frameSize.height)
+                        .clipped()
                         .position(x: containerSize.width / 2, y: containerSize.height / 2)
                 }
 
@@ -90,7 +94,7 @@ struct ScreenshotEditorCanvasView: View {
                 .frame(width: imageSize.width, height: imageSize.height, alignment: .topLeading)
                 .clipShape(RoundedRectangle(cornerRadius: imageCornerRadius))
                 .shadow(color: .black.opacity(0.25), radius: viewModel.canvasShadowRadius)
-                .position(x: containerSize.width / 2, y: containerSize.height / 2)
+                .position(x: origin.x + imageSize.width / 2, y: origin.y + imageSize.height / 2)
 
                 Canvas { context, size in
                     // Draw crop overlay
@@ -222,7 +226,7 @@ struct ScreenshotEditorCanvasView: View {
                     .accessibilityHint(viewModel.selectedTool == .move
                         ? "Select an annotation, drag inside it to move, or drag a corner handle to resize."
                         : "Use the selected tool to edit the screenshot.")
-                    .position(x: containerSize.width / 2, y: containerSize.height / 2)
+                    .position(x: origin.x + imageSize.width / 2, y: origin.y + imageSize.height / 2)
             }
         }
     }

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -157,6 +157,127 @@ enum ExportBackgroundStyle: String, CaseIterable, Identifiable {
     }
 }
 
+enum ExportFramePreset: String, CaseIterable, Identifiable {
+    case original
+    case square
+    case landscapeFourByThree
+    case landscapeSixteenByNine
+    case portraitThreeByFour
+    case portraitNineBySixteen
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .original: return "Original"
+        case .square: return "1:1"
+        case .landscapeFourByThree: return "4:3"
+        case .landscapeSixteenByNine: return "16:9"
+        case .portraitThreeByFour: return "3:4"
+        case .portraitNineBySixteen: return "9:16"
+        }
+    }
+
+    var aspectRatio: CGFloat? {
+        switch self {
+        case .original: return nil
+        case .square: return 1
+        case .landscapeFourByThree: return 4.0 / 3.0
+        case .landscapeSixteenByNine: return 16.0 / 9.0
+        case .portraitThreeByFour: return 3.0 / 4.0
+        case .portraitNineBySixteen: return 9.0 / 16.0
+        }
+    }
+}
+
+enum ExportHorizontalAlignment: String, CaseIterable, Identifiable {
+    case leading
+    case center
+    case trailing
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .leading: return "Left"
+        case .center: return "Center"
+        case .trailing: return "Right"
+        }
+    }
+
+    var placementFactor: CGFloat {
+        switch self {
+        case .leading: return 0
+        case .center: return 0.5
+        case .trailing: return 1
+        }
+    }
+}
+
+enum ExportVerticalAlignment: String, CaseIterable, Identifiable {
+    case top
+    case center
+    case bottom
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .top: return "Top"
+        case .center: return "Center"
+        case .bottom: return "Bottom"
+        }
+    }
+
+    var placementFactor: CGFloat {
+        switch self {
+        case .top: return 0
+        case .center: return 0.5
+        case .bottom: return 1
+        }
+    }
+}
+
+struct ExportFrameLayout {
+    let frameSize: CGSize
+    let imageRect: CGRect
+
+    static func make(
+        imageSize: CGSize,
+        padding: CGFloat,
+        preset: ExportFramePreset,
+        horizontalAlignment: ExportHorizontalAlignment,
+        verticalAlignment: ExportVerticalAlignment
+    ) -> Self {
+        let safePadding = max(0, padding)
+        let baseSize = CGSize(
+            width: imageSize.width + (safePadding * 2),
+            height: imageSize.height + (safePadding * 2)
+        )
+
+        var frameSize = baseSize
+        if let targetRatio = preset.aspectRatio, baseSize.width > 0, baseSize.height > 0 {
+            if baseSize.width / baseSize.height < targetRatio {
+                frameSize.width = ceil(baseSize.height * targetRatio)
+            } else if baseSize.width / baseSize.height > targetRatio {
+                frameSize.height = ceil(baseSize.width / targetRatio)
+            }
+        }
+
+        let extraHorizontalSpace = max(0, frameSize.width - baseSize.width)
+        let extraVerticalSpace = max(0, frameSize.height - baseSize.height)
+        return Self(
+            frameSize: frameSize,
+            imageRect: CGRect(
+                x: safePadding + (extraHorizontalSpace * horizontalAlignment.placementFactor),
+                y: safePadding + (extraVerticalSpace * verticalAlignment.placementFactor),
+                width: imageSize.width,
+                height: imageSize.height
+            )
+        )
+    }
+}
+
 struct ExportBackgroundPreset: Identifiable {
     let id: String
     let label: String

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -55,6 +55,9 @@ class ScreenshotEditorViewModel: ObservableObject {
     @Published var canvasPadding: CGFloat = 0
     @Published var canvasCornerRadius: CGFloat = 0
     @Published var canvasShadowRadius: CGFloat = 0
+    @Published var exportFramePreset: ExportFramePreset = .original
+    @Published var horizontalExportAlignment: ExportHorizontalAlignment = .center
+    @Published var verticalExportAlignment: ExportVerticalAlignment = .center
 
     private var pencilPoints: [CGPoint] = []
     private var imagePixelSize: CGSize = .zero
@@ -79,6 +82,9 @@ class ScreenshotEditorViewModel: ObservableObject {
     private var initialCanvasPadding: CGFloat
     private var initialCanvasCornerRadius: CGFloat
     private var initialCanvasShadowRadius: CGFloat
+    private var initialExportFramePreset: ExportFramePreset
+    private var initialHorizontalExportAlignment: ExportHorizontalAlignment
+    private var initialVerticalExportAlignment: ExportVerticalAlignment
     private var hasPendingChanges = false
 
     init(url: URL) {
@@ -102,6 +108,9 @@ class ScreenshotEditorViewModel: ObservableObject {
         self.initialCanvasPadding = 0
         self.initialCanvasCornerRadius = 0
         self.initialCanvasShadowRadius = 0
+        self.initialExportFramePreset = .original
+        self.initialHorizontalExportAlignment = .center
+        self.initialVerticalExportAlignment = .center
     }
 
     // Convert point in overlay-local space to 0..1 normalized coordinate
@@ -157,26 +166,46 @@ class ScreenshotEditorViewModel: ObservableObject {
         )
     }
 
-    // Calculate display size maintaining aspect ratio, capped at native pixel size
-    func displaySize(in containerSize: CGSize) -> CGSize {
+    func displayLayout(in containerSize: CGSize) -> ExportFrameLayout {
         guard let image = originalImage, image.size.width > 0, image.size.height > 0 else {
-            return .zero
+            return ExportFrameLayout.make(
+                imageSize: .zero,
+                padding: canvasPadding,
+                preset: exportFramePreset,
+                horizontalAlignment: horizontalExportAlignment,
+                verticalAlignment: verticalExportAlignment
+            )
         }
         let imageAspect = image.size.width / image.size.height
         let effectivePadding = max(0, canvasPadding)
-        let availableWidth = max(1, containerSize.width - (effectivePadding * 2))
-        let availableHeight = max(1, containerSize.height - (effectivePadding * 2))
+        let screenScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        let nativeWidth = imagePixelSize.width / screenScale
+        let nativeHeight = imagePixelSize.height / screenScale
+        let frameAspect = exportFramePreset.aspectRatio ?? ((nativeWidth + effectivePadding * 2) / (nativeHeight + effectivePadding * 2))
+        let maxFrameWidth = max(1, containerSize.width * 0.95)
+        let maxFrameHeight = max(1, containerSize.height * 0.95)
+        let frameWidth = min(maxFrameWidth, maxFrameHeight * frameAspect)
+        let frameHeight = frameWidth / frameAspect
+        let availableWidth = max(1, frameWidth - (effectivePadding * 2))
+        let availableHeight = max(1, frameHeight - (effectivePadding * 2))
 
         // Cap at native pixel dimensions to prevent upscaling blur on Retina
-        let screenScale = NSScreen.main?.backingScaleFactor ?? 2.0
-        let maxWidth = min(availableWidth * 0.95, imagePixelSize.width / screenScale)
-        let maxHeight = min(availableHeight * 0.95, imagePixelSize.height / screenScale)
-
+        let maxWidth = min(availableWidth, nativeWidth)
+        let maxHeight = min(availableHeight, nativeHeight)
+        let imageSize: CGSize
         if maxWidth / maxHeight < imageAspect {
-            return CGSize(width: maxWidth, height: maxWidth / imageAspect)
+            imageSize = CGSize(width: maxWidth, height: maxWidth / imageAspect)
         } else {
-            return CGSize(width: maxHeight * imageAspect, height: maxHeight)
+            imageSize = CGSize(width: maxHeight * imageAspect, height: maxHeight)
         }
+
+        return ExportFrameLayout.make(
+            imageSize: imageSize,
+            padding: effectivePadding,
+            preset: exportFramePreset,
+            horizontalAlignment: horizontalExportAlignment,
+            verticalAlignment: verticalExportAlignment
+        )
     }
 
     /// Returns the text size for an image rendered at `renderedImageWidth`.
@@ -345,7 +374,10 @@ class ScreenshotEditorViewModel: ObservableObject {
 
         if abs(canvasPadding - initialCanvasPadding) > 0.0001 ||
             abs(canvasCornerRadius - initialCanvasCornerRadius) > 0.0001 ||
-            abs(canvasShadowRadius - initialCanvasShadowRadius) > 0.0001 {
+            abs(canvasShadowRadius - initialCanvasShadowRadius) > 0.0001 ||
+            exportFramePreset != initialExportFramePreset ||
+            horizontalExportAlignment != initialHorizontalExportAlignment ||
+            verticalExportAlignment != initialVerticalExportAlignment {
             return true
         }
 
@@ -801,6 +833,9 @@ class ScreenshotEditorViewModel: ObservableObject {
         initialCanvasPadding = canvasPadding
         initialCanvasCornerRadius = canvasCornerRadius
         initialCanvasShadowRadius = canvasShadowRadius
+        initialExportFramePreset = exportFramePreset
+        initialHorizontalExportAlignment = horizontalExportAlignment
+        initialVerticalExportAlignment = verticalExportAlignment
     }
 
     private func canvasState() -> EditorCanvasState {
@@ -925,11 +960,13 @@ class ScreenshotEditorViewModel: ObservableObject {
             cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
         }
 
-        let exportPadding = max(0, Int(canvasPadding))
-        return CGSize(
-            width: Int(cropPixelRect.width) + (exportPadding * 2),
-            height: Int(cropPixelRect.height) + (exportPadding * 2)
-        )
+        return ExportFrameLayout.make(
+            imageSize: cropPixelRect.size,
+            padding: canvasPadding,
+            preset: exportFramePreset,
+            horizontalAlignment: horizontalExportAlignment,
+            verticalAlignment: verticalExportAlignment
+        ).frameSize
     }
 
     private func originalLinePoints() -> LinePoints {
@@ -1158,9 +1195,15 @@ class ScreenshotEditorViewModel: ObservableObject {
             cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
         }
 
-        let exportPadding = max(0, Int(canvasPadding))
-        let outputW = Int(cropPixelRect.width) + (exportPadding * 2)
-        let outputH = Int(cropPixelRect.height) + (exportPadding * 2)
+        let layout = ExportFrameLayout.make(
+            imageSize: cropPixelRect.size,
+            padding: canvasPadding,
+            preset: exportFramePreset,
+            horizontalAlignment: horizontalExportAlignment,
+            verticalAlignment: verticalExportAlignment
+        )
+        let outputW = Int(layout.frameSize.width)
+        let outputH = Int(layout.frameSize.height)
         guard outputW > 0 && outputH > 0 else { return nil }
 
         guard let result = NSBitmapImageRep(
@@ -1202,12 +1245,7 @@ class ScreenshotEditorViewModel: ObservableObject {
             }
         }
 
-        let imageRect = CGRect(
-            x: exportPadding,
-            y: exportPadding,
-            width: Int(cropPixelRect.width),
-            height: Int(cropPixelRect.height)
-        )
+        let imageRect = layout.imageRect
         let imageCornerRadius = max(0, min(canvasCornerRadius, min(imageRect.width, imageRect.height) / 2))
         let imageClipPath = CGPath(
             roundedRect: imageRect,
@@ -1256,7 +1294,8 @@ class ScreenshotEditorViewModel: ObservableObject {
                 cropOrigin: cropPixelRect.origin,
                 outputSize: CGSize(width: outputW, height: outputH),
                 fullSize: imagePixelSize,
-                contentOffset: CGPoint(x: exportPadding, y: exportPadding),
+                contentOffset: imageRect.origin,
+                imageHeight: imageRect.height,
                 sourceCGImage: sourceCGImage
             )
         }
@@ -1270,8 +1309,8 @@ class ScreenshotEditorViewModel: ObservableObject {
         return result
     }
 
-    private func drawAnnotationCG(_ annotation: ScreenshotAnnotation, in ctx: CGContext, cropOrigin: CGPoint, outputSize: CGSize, fullSize: CGSize, contentOffset: CGPoint, sourceCGImage: CGImage? = nil) {
-        let imageOutputHeight = outputSize.height - (contentOffset.y * 2)
+    private func drawAnnotationCG(_ annotation: ScreenshotAnnotation, in ctx: CGContext, cropOrigin: CGPoint, outputSize: CGSize, fullSize: CGSize, contentOffset: CGPoint, imageHeight: CGFloat, sourceCGImage: CGImage? = nil) {
+        let imageOutputHeight = imageHeight
         // Convert normalized rect to pixel coords relative to crop
         let pixelRect = CGRect(
             x: (annotation.rect.origin.x * fullSize.width) - cropOrigin.x + contentOffset.x,

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -167,7 +167,7 @@ class ScreenshotEditorViewModel: ObservableObject {
     }
 
     func displayLayout(in containerSize: CGSize) -> ExportFrameLayout {
-        guard let image = originalImage, image.size.width > 0, image.size.height > 0 else {
+        guard originalImage != nil, imagePixelSize.width > 0, imagePixelSize.height > 0 else {
             return ExportFrameLayout.make(
                 imageSize: .zero,
                 padding: canvasPadding,
@@ -176,36 +176,43 @@ class ScreenshotEditorViewModel: ObservableObject {
                 verticalAlignment: verticalExportAlignment
             )
         }
-        let imageAspect = image.size.width / image.size.height
-        let effectivePadding = max(0, canvasPadding)
-        let screenScale = NSScreen.main?.backingScaleFactor ?? 2.0
-        let nativeWidth = imagePixelSize.width / screenScale
-        let nativeHeight = imagePixelSize.height / screenScale
-        let frameAspect = exportFramePreset.aspectRatio ?? ((nativeWidth + effectivePadding * 2) / (nativeHeight + effectivePadding * 2))
-        let maxFrameWidth = max(1, containerSize.width * 0.95)
-        let maxFrameHeight = max(1, containerSize.height * 0.95)
-        let frameWidth = min(maxFrameWidth, maxFrameHeight * frameAspect)
-        let frameHeight = frameWidth / frameAspect
-        let availableWidth = max(1, frameWidth - (effectivePadding * 2))
-        let availableHeight = max(1, frameHeight - (effectivePadding * 2))
 
-        // Cap at native pixel dimensions to prevent upscaling blur on Retina
-        let maxWidth = min(availableWidth, nativeWidth)
-        let maxHeight = min(availableHeight, nativeHeight)
-        let imageSize: CGSize
-        if maxWidth / maxHeight < imageAspect {
-            imageSize = CGSize(width: maxWidth, height: maxWidth / imageAspect)
-        } else {
-            imageSize = CGSize(width: maxHeight * imageAspect, height: maxHeight)
-        }
-
-        return ExportFrameLayout.make(
-            imageSize: imageSize,
-            padding: effectivePadding,
+        let pixelLayout = ExportFrameLayout.make(
+            imageSize: imagePixelSize,
+            padding: canvasPadding,
             preset: exportFramePreset,
             horizontalAlignment: horizontalExportAlignment,
             verticalAlignment: verticalExportAlignment
         )
+        let screenScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        let maxFrameWidth = max(1, containerSize.width * 0.95)
+        let maxFrameHeight = max(1, containerSize.height * 0.95)
+        let displayScale = min(
+            1 / screenScale,
+            maxFrameWidth / pixelLayout.frameSize.width,
+            maxFrameHeight / pixelLayout.frameSize.height
+        )
+
+        return ExportFrameLayout.make(
+            imageSize: CGSize(
+                width: imagePixelSize.width * displayScale,
+                height: imagePixelSize.height * displayScale
+            ),
+            padding: canvasPadding * displayScale,
+            preset: exportFramePreset,
+            horizontalAlignment: horizontalExportAlignment,
+            verticalAlignment: verticalExportAlignment
+        )
+    }
+
+    var hasHorizontalExportFrameSpace: Bool {
+        let layout = exportLayout(for: exportImageSize)
+        return layout.frameSize.width > exportImageSize.width + max(0, canvasPadding) * 2
+    }
+
+    var hasVerticalExportFrameSpace: Bool {
+        let layout = exportLayout(for: exportImageSize)
+        return layout.frameSize.height > exportImageSize.height + max(0, canvasPadding) * 2
     }
 
     /// Returns the text size for an image rendered at `renderedImageWidth`.
@@ -960,13 +967,7 @@ class ScreenshotEditorViewModel: ObservableObject {
             cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
         }
 
-        return ExportFrameLayout.make(
-            imageSize: cropPixelRect.size,
-            padding: canvasPadding,
-            preset: exportFramePreset,
-            horizontalAlignment: horizontalExportAlignment,
-            verticalAlignment: verticalExportAlignment
-        ).frameSize
+        return exportLayout(for: cropPixelRect.size).frameSize
     }
 
     private func originalLinePoints() -> LinePoints {
@@ -1195,13 +1196,7 @@ class ScreenshotEditorViewModel: ObservableObject {
             cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
         }
 
-        let layout = ExportFrameLayout.make(
-            imageSize: cropPixelRect.size,
-            padding: canvasPadding,
-            preset: exportFramePreset,
-            horizontalAlignment: horizontalExportAlignment,
-            verticalAlignment: verticalExportAlignment
-        )
+        let layout = exportLayout(for: cropPixelRect.size)
         let outputW = Int(layout.frameSize.width)
         let outputH = Int(layout.frameSize.height)
         guard outputW > 0 && outputH > 0 else { return nil }
@@ -1245,7 +1240,12 @@ class ScreenshotEditorViewModel: ObservableObject {
             }
         }
 
-        let imageRect = layout.imageRect
+        let imageRect = CGRect(
+            x: layout.imageRect.minX,
+            y: CGFloat(outputH) - layout.imageRect.maxY,
+            width: layout.imageRect.width,
+            height: layout.imageRect.height
+        )
         let imageCornerRadius = max(0, min(canvasCornerRadius, min(imageRect.width, imageRect.height) / 2))
         let imageClipPath = CGPath(
             roundedRect: imageRect,
@@ -1332,6 +1332,7 @@ class ScreenshotEditorViewModel: ObservableObject {
                 ctx.setFillColor(fillCGColor)
                 ctx.fill(pixelRect)
             }
+
             ctx.stroke(pixelRect)
 
         case .circle:
@@ -1492,6 +1493,25 @@ class ScreenshotEditorViewModel: ObservableObject {
         case .crop, .move:
             break
         }
+    }
+
+    private var exportImageSize: CGSize {
+        guard imagePixelSize.width > 0, imagePixelSize.height > 0 else { return .zero }
+        guard let crop = cropRect else { return imagePixelSize }
+        return CGSize(
+            width: crop.width * imagePixelSize.width,
+            height: crop.height * imagePixelSize.height
+        )
+    }
+
+    private func exportLayout(for imageSize: CGSize) -> ExportFrameLayout {
+        ExportFrameLayout.make(
+            imageSize: imageSize,
+            padding: canvasPadding,
+            preset: exportFramePreset,
+            horizontalAlignment: horizontalExportAlignment,
+            verticalAlignment: verticalExportAlignment
+        )
     }
 
     private func exportStrokeWidth(baseWidth: CGFloat, outputWidth: CGFloat) -> CGFloat {

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -487,6 +487,30 @@ struct ScreenshotEditorView: View {
                 Slider(value: $viewModel.canvasPadding, in: 0...160, step: 2)
             }
 
+            Picker("Frame", selection: $viewModel.exportFramePreset) {
+                ForEach(ExportFramePreset.allCases) { preset in
+                    Text(preset.label).tag(preset)
+                }
+            }
+            .accessibilityHint("Sets the export frame without stretching the screenshot.")
+
+            HStack(spacing: 8) {
+                Picker("Horizontal", selection: $viewModel.horizontalExportAlignment) {
+                    ForEach(ExportHorizontalAlignment.allCases) { alignment in
+                        Text(alignment.label).tag(alignment)
+                    }
+                }
+                .disabled(viewModel.exportFramePreset == .original)
+
+                Picker("Vertical", selection: $viewModel.verticalExportAlignment) {
+                    ForEach(ExportVerticalAlignment.allCases) { alignment in
+                        Text(alignment.label).tag(alignment)
+                    }
+                }
+                .disabled(viewModel.exportFramePreset == .original)
+            }
+            .accessibilityElement(children: .contain)
+
             VStack(alignment: .leading, spacing: 4) {
                 Text("Image corners: \(Int(viewModel.canvasCornerRadius)) px")
                     .font(.caption)

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -500,14 +500,14 @@ struct ScreenshotEditorView: View {
                         Text(alignment.label).tag(alignment)
                     }
                 }
-                .disabled(viewModel.exportFramePreset == .original)
+                .disabled(!viewModel.hasHorizontalExportFrameSpace)
 
                 Picker("Vertical", selection: $viewModel.verticalExportAlignment) {
                     ForEach(ExportVerticalAlignment.allCases) { alignment in
                         Text(alignment.label).tag(alignment)
                     }
                 }
-                .disabled(viewModel.exportFramePreset == .original)
+                .disabled(!viewModel.hasVerticalExportFrameSpace)
             }
             .accessibilityElement(children: .contain)
 

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -8,6 +8,7 @@ own `CHANGELOG.md` at the repository root.
 ### Added
 - **Temporary-file controls in Settings → General** — an Advanced card now shows the Tiny Clips temporary-file count and size, opens its dedicated `%LOCALAPPDATA%\TinyClips\Temp` folder, and can purge those files without affecting saved captures.
 - **Narrator capture-status announcements** — Tiny Clips now announces screenshot, video, and GIF save results plus recording start and stop through a tray-lifetime UI Automation notification anchor, even when capture pickers and popups are closed.
+- **Flexible screenshot export frames** — the screenshot editor now offers Original, 1:1, 4:3, 16:9, 3:4, and 9:16 frames plus horizontal and vertical image alignment, without stretching annotated content.
 
 ### Changed
 - Screenshot, video, and GIF settings now each provide matching before/after capture-picker controls.

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorCanvas.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorCanvas.xaml.cs
@@ -255,16 +255,18 @@ public sealed partial class EditorCanvas : UserControl
         double imgW = _controller.Bitmap.PixelWidth;
         double imgH = _controller.Bitmap.PixelHeight;
         var (scale, imageOffX, imageOffY) = HostLayout();
-        var pad = _controller.CanvasPadding * scale;
+        var frame = _controller.GetExportFrameLayout();
+        var frameOffX = imageOffX - frame.ImageBounds.X * scale;
+        var frameOffY = imageOffY - frame.ImageBounds.Y * scale;
 
         var showBackground = _controller.BgStyle != ExportBackgroundStyle.Transparent;
         CanvasBackground.Visibility = showBackground ? Visibility.Visible : Visibility.Collapsed;
         if (showBackground)
         {
-            Canvas.SetLeft(CanvasBackground, imageOffX - pad);
-            Canvas.SetTop(CanvasBackground, imageOffY - pad);
-            CanvasBackground.Width = imgW * scale + pad * 2;
-            CanvasBackground.Height = imgH * scale + pad * 2;
+            Canvas.SetLeft(CanvasBackground, frameOffX);
+            Canvas.SetTop(CanvasBackground, frameOffY);
+            CanvasBackground.Width = frame.FrameSize.Width * scale;
+            CanvasBackground.Height = frame.FrameSize.Height * scale;
             CanvasBackground.Background = MakeBackgroundBrush();
         }
 

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorController.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorController.cs
@@ -129,6 +129,12 @@ internal sealed class EditorController : IDisposable
 
     public double CanvasShadow { get; private set; }
 
+    public ExportFramePreset FramePreset { get; private set; } = ExportFramePreset.Original;
+
+    public ExportHorizontalAlignment HorizontalExportAlignment { get; private set; } = ExportHorizontalAlignment.Center;
+
+    public ExportVerticalAlignment VerticalExportAlignment { get; private set; } = ExportVerticalAlignment.Center;
+
     // -- Events -------------------------------------------------------------------------------
 
     /// <summary>The loaded bitmap changed (initial load, crop, or reset). Full relayout/redraw.</summary>
@@ -434,6 +440,37 @@ internal sealed class EditorController : IDisposable
         BackgroundChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    public void SetExportFramePreset(ExportFramePreset preset)
+    {
+        FramePreset = preset;
+        BackgroundChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void SetHorizontalExportAlignment(ExportHorizontalAlignment alignment)
+    {
+        HorizontalExportAlignment = alignment;
+        BackgroundChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void SetVerticalExportAlignment(ExportVerticalAlignment alignment)
+    {
+        VerticalExportAlignment = alignment;
+        BackgroundChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public ExportFrameLayout GetExportFrameLayout()
+    {
+        var imageWidth = _bitmap?.PixelWidth ?? 0;
+        var imageHeight = _bitmap?.PixelHeight ?? 0;
+        return ExportFrameLayout.Create(
+            imageWidth,
+            imageHeight,
+            CanvasPadding,
+            FramePreset,
+            HorizontalExportAlignment,
+            VerticalExportAlignment);
+    }
+
     // -- Coordinate mapping (pure; parameterized by the current host size) ------------------
 
     public (double Scale, double OffsetX, double OffsetY) ImageLayout(double hostW, double hostH)
@@ -445,17 +482,14 @@ internal sealed class EditorController : IDisposable
             return (1, 0, 0);
         }
 
-        // The composite (background frame) is the image plus padding on every side.
-        var pad = CanvasPadding;
-        var compW = imgW + pad * 2;
-        var compH = imgH + pad * 2;
-        var scale = Math.Min(hostW / compW, hostH / compH);
-        var frameOffsetX = (hostW - compW * scale) / 2.0;
-        var frameOffsetY = (hostH - compH * scale) / 2.0;
+        var frame = GetExportFrameLayout();
+        var scale = Math.Min(hostW / frame.FrameSize.Width, hostH / frame.FrameSize.Height);
+        var frameOffsetX = (hostW - frame.FrameSize.Width * scale) / 2.0;
+        var frameOffsetY = (hostH - frame.FrameSize.Height * scale) / 2.0;
         // Offsets returned are the image card's top-left (inside the padded frame),
         // so annotation pixel<->canvas mapping stays aligned with the screenshot.
-        var offsetX = frameOffsetX + pad * scale;
-        var offsetY = frameOffsetY + pad * scale;
+        var offsetX = frameOffsetX + frame.ImageBounds.X * scale;
+        var offsetY = frameOffsetY + frame.ImageBounds.Y * scale;
         return (scale, offsetX, offsetY);
     }
 
@@ -917,7 +951,8 @@ internal sealed class EditorController : IDisposable
         var hasBackground = BgStyle != ExportBackgroundStyle.Transparent
             || CanvasPadding > 0
             || CanvasCornerRadius > 0
-            || CanvasShadow > 0;
+            || CanvasShadow > 0
+            || FramePreset != ExportFramePreset.Original;
 
         // Simple path: no background/padding/corners/shadow, or caller opted out (crop pre-bake).
         if (!includeBackground || !hasBackground)
@@ -946,10 +981,10 @@ internal sealed class EditorController : IDisposable
         }
 
         // Composited path: padded background frame, rounded screenshot card, optional shadow.
-        var pad = (float)Math.Round(CanvasPadding);
+        var frame = GetExportFrameLayout();
         var corner = (float)CanvasCornerRadius;
-        var outW = imgW + pad * 2;
-        var outH = imgH + pad * 2;
+        var outW = (float)frame.FrameSize.Width;
+        var outH = (float)frame.FrameSize.Height;
 
         using var target = new CanvasRenderTarget(device, outW, outH, 96);
         using (var ds = target.CreateDrawingSession())
@@ -971,7 +1006,14 @@ internal sealed class EditorController : IDisposable
                 ds.FillRectangle(fullRect, brush);
             }
 
-            using var cardGeo = CanvasGeometry.CreateRoundedRectangle(device, pad, pad, imgW, imgH, corner, corner);
+            using var cardGeo = CanvasGeometry.CreateRoundedRectangle(
+                device,
+                (float)frame.ImageBounds.X,
+                (float)frame.ImageBounds.Y,
+                imgW,
+                imgH,
+                corner,
+                corner);
 
             if (CanvasShadow > 0)
             {
@@ -992,7 +1034,7 @@ internal sealed class EditorController : IDisposable
 
             using (ds.CreateLayer(1f, cardGeo))
             {
-                ds.Transform = Matrix3x2.CreateTranslation(pad, pad);
+                ds.Transform = Matrix3x2.CreateTranslation((float)frame.ImageBounds.X, (float)frame.ImageBounds.Y);
                 ds.DrawImage(source);
                 // Same single stable-order pass as the simple path above (kept in sync
                 // deliberately — see the comment there).

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorController.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorController.cs
@@ -471,6 +471,34 @@ internal sealed class EditorController : IDisposable
             VerticalExportAlignment);
     }
 
+    public bool HasHorizontalExportFrameSpace
+    {
+        get
+        {
+            if (_bitmap is null)
+            {
+                return false;
+            }
+
+            var layout = GetExportFrameLayout();
+            return layout.FrameSize.Width > _bitmap.PixelWidth + Math.Max(0, CanvasPadding) * 2;
+        }
+    }
+
+    public bool HasVerticalExportFrameSpace
+    {
+        get
+        {
+            if (_bitmap is null)
+            {
+                return false;
+            }
+
+            var layout = GetExportFrameLayout();
+            return layout.FrameSize.Height > _bitmap.PixelHeight + Math.Max(0, CanvasPadding) * 2;
+        }
+    }
+
     // -- Coordinate mapping (pure; parameterized by the current host size) ------------------
 
     public (double Scale, double OffsetX, double OffsetY) ImageLayout(double hostW, double hostH)

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml
@@ -232,6 +232,39 @@
                             Minimum="0"
                             StepFrequency="2"
                             ValueChanged="OnPaddingChanged" />
+                        <ComboBox
+                            x:Name="ExportFrameCombo"
+                            AutomationProperties.AutomationId="EditorExportFrameCombo"
+                            AutomationProperties.Name="Export frame"
+                            Header="Frame"
+                            SelectionChanged="OnExportFrameChanged">
+                            <ComboBoxItem Content="Original" />
+                            <ComboBoxItem Content="1:1" />
+                            <ComboBoxItem Content="4:3" />
+                            <ComboBoxItem Content="16:9" />
+                            <ComboBoxItem Content="3:4" />
+                            <ComboBoxItem Content="9:16" />
+                        </ComboBox>
+                        <ComboBox
+                            x:Name="HorizontalAlignmentCombo"
+                            AutomationProperties.AutomationId="EditorHorizontalAlignmentCombo"
+                            AutomationProperties.Name="Horizontal image alignment"
+                            Header="Horizontal alignment"
+                            SelectionChanged="OnHorizontalAlignmentChanged">
+                            <ComboBoxItem Content="Left" />
+                            <ComboBoxItem Content="Center" />
+                            <ComboBoxItem Content="Right" />
+                        </ComboBox>
+                        <ComboBox
+                            x:Name="VerticalAlignmentCombo"
+                            AutomationProperties.AutomationId="EditorVerticalAlignmentCombo"
+                            AutomationProperties.Name="Vertical image alignment"
+                            Header="Vertical alignment"
+                            SelectionChanged="OnVerticalAlignmentChanged">
+                            <ComboBoxItem Content="Top" />
+                            <ComboBoxItem Content="Center" />
+                            <ComboBoxItem Content="Bottom" />
+                        </ComboBox>
                         <Slider
                             x:Name="CornerSlider"
                             AutomationProperties.AutomationId="EditorCornerSlider"

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml.cs
@@ -39,6 +39,8 @@ public sealed partial class EditorInspector : UserControl
         InitializeBackgroundControls();
 
         controller.ToolChanged += (_, tool) => ShowForTool(tool);
+        controller.BackgroundChanged += (_, _) => UpdateExportFrameControls();
+        controller.ImageChanged += (_, _) => UpdateExportFrameControls();
         controller.SelectionChanged += (_, ann) =>
         {
             // Matches the original behavior: deselecting (clicking empty space with the Select
@@ -514,8 +516,7 @@ public sealed partial class EditorInspector : UserControl
 
     private void UpdateExportFrameControls()
     {
-        var hasAdditionalFrameSpace = _controller.FramePreset != ExportFramePreset.Original;
-        HorizontalAlignmentCombo.IsEnabled = hasAdditionalFrameSpace;
-        VerticalAlignmentCombo.IsEnabled = hasAdditionalFrameSpace;
+        HorizontalAlignmentCombo.IsEnabled = _controller.HasHorizontalExportFrameSpace;
+        VerticalAlignmentCombo.IsEnabled = _controller.HasVerticalExportFrameSpace;
     }
 }

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorInspector.xaml.cs
@@ -101,8 +101,12 @@ public sealed partial class EditorInspector : UserControl
         PaddingSlider.Value = _controller.CanvasPadding;
         CornerSlider.Value = _controller.CanvasCornerRadius;
         ShadowSlider.Value = _controller.CanvasShadow;
+        ExportFrameCombo.SelectedIndex = (int)_controller.FramePreset;
+        HorizontalAlignmentCombo.SelectedIndex = (int)_controller.HorizontalExportAlignment;
+        VerticalAlignmentCombo.SelectedIndex = (int)_controller.VerticalExportAlignment;
         UpdateSliderHeaders();
         UpdateBackgroundStyleUi();
+        UpdateExportFrameControls();
 
         _bgInitializing = false;
     }
@@ -452,6 +456,33 @@ public sealed partial class EditorInspector : UserControl
         UpdateSliderHeaders();
     }
 
+    private void OnExportFrameChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_bgInitializing)
+        {
+            return;
+        }
+
+        _controller.SetExportFramePreset((ExportFramePreset)ExportFrameCombo.SelectedIndex);
+        UpdateExportFrameControls();
+    }
+
+    private void OnHorizontalAlignmentChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_bgInitializing)
+        {
+            _controller.SetHorizontalExportAlignment((ExportHorizontalAlignment)HorizontalAlignmentCombo.SelectedIndex);
+        }
+    }
+
+    private void OnVerticalAlignmentChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_bgInitializing)
+        {
+            _controller.SetVerticalExportAlignment((ExportVerticalAlignment)VerticalAlignmentCombo.SelectedIndex);
+        }
+    }
+
     private void OnCornerChanged(object sender, RangeBaseValueChangedEventArgs e)
     {
         if (_bgInitializing)
@@ -479,5 +510,12 @@ public sealed partial class EditorInspector : UserControl
         PaddingSlider.Header = $"Padding — {(int)_controller.CanvasPadding} px";
         CornerSlider.Header = $"Image corners — {(int)_controller.CanvasCornerRadius} px";
         ShadowSlider.Header = $"Shadow — {(int)_controller.CanvasShadow}";
+    }
+
+    private void UpdateExportFrameControls()
+    {
+        var hasAdditionalFrameSpace = _controller.FramePreset != ExportFramePreset.Original;
+        HorizontalAlignmentCombo.IsEnabled = hasAdditionalFrameSpace;
+        VerticalAlignmentCombo.IsEnabled = hasAdditionalFrameSpace;
     }
 }

--- a/windows/src/TinyClips.App/ScreenshotEditor/EditorModels.cs
+++ b/windows/src/TinyClips.App/ScreenshotEditor/EditorModels.cs
@@ -62,6 +62,91 @@ internal enum ExportBackgroundStyle
     Gradient,
 }
 
+internal enum ExportFramePreset
+{
+    Original,
+    Square,
+    LandscapeFourByThree,
+    LandscapeSixteenByNine,
+    PortraitThreeByFour,
+    PortraitNineBySixteen,
+}
+
+internal enum ExportHorizontalAlignment
+{
+    Left,
+    Center,
+    Right,
+}
+
+internal enum ExportVerticalAlignment
+{
+    Top,
+    Center,
+    Bottom,
+}
+
+internal readonly record struct ExportFrameLayout(Size FrameSize, Rect ImageBounds)
+{
+    public static ExportFrameLayout Create(
+        double imageWidth,
+        double imageHeight,
+        double padding,
+        ExportFramePreset preset,
+        ExportHorizontalAlignment horizontalAlignment,
+        ExportVerticalAlignment verticalAlignment)
+    {
+        var safePadding = Math.Max(0, padding);
+        var baseWidth = imageWidth + safePadding * 2;
+        var baseHeight = imageHeight + safePadding * 2;
+        var frameWidth = baseWidth;
+        var frameHeight = baseHeight;
+        var targetRatio = preset switch
+        {
+            ExportFramePreset.Square => 1.0,
+            ExportFramePreset.LandscapeFourByThree => 4.0 / 3.0,
+            ExportFramePreset.LandscapeSixteenByNine => 16.0 / 9.0,
+            ExportFramePreset.PortraitThreeByFour => 3.0 / 4.0,
+            ExportFramePreset.PortraitNineBySixteen => 9.0 / 16.0,
+            _ => 0.0,
+        };
+
+        if (targetRatio > 0 && baseWidth > 0 && baseHeight > 0)
+        {
+            if (baseWidth / baseHeight < targetRatio)
+            {
+                frameWidth = Math.Ceiling(baseHeight * targetRatio);
+            }
+            else if (baseWidth / baseHeight > targetRatio)
+            {
+                frameHeight = Math.Ceiling(baseWidth / targetRatio);
+            }
+        }
+
+        var horizontalFactor = horizontalAlignment switch
+        {
+            ExportHorizontalAlignment.Left => 0.0,
+            ExportHorizontalAlignment.Right => 1.0,
+            _ => 0.5,
+        };
+        var verticalFactor = verticalAlignment switch
+        {
+            ExportVerticalAlignment.Top => 0.0,
+            ExportVerticalAlignment.Bottom => 1.0,
+            _ => 0.5,
+        };
+        var extraHorizontalSpace = Math.Max(0, frameWidth - baseWidth);
+        var extraVerticalSpace = Math.Max(0, frameHeight - baseHeight);
+        return new ExportFrameLayout(
+            new Size(frameWidth, frameHeight),
+            new Rect(
+                safePadding + extraHorizontalSpace * horizontalFactor,
+                safePadding + extraVerticalSpace * verticalFactor,
+                imageWidth,
+                imageHeight));
+    }
+}
+
 /// <summary>
 /// One annotation in image-pixel coordinates. Mutable in place so the editor canvas can retain a
 /// live visual per instance and update it during drags instead of rebuilding the overlay.


### PR DESCRIPTION
## Summary
- add shared export-frame concepts to both macOS and Windows screenshot editors
- provide Original, 1:1, 4:3, 16:9, 3:4, and 9:16 presets with horizontal and vertical image alignment
- use the same geometry for each editor preview and export while preserving padding, backgrounds, corners, shadows, annotations, and Original behavior

Closes #130
Closes #131

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Windows restore succeeds with `EnableWindowsTargeting=true`; app build is blocked on this macOS host because the Windows App SDK XAML compiler is a Windows executable. Core test binaries build, but the WindowsDesktop test host cannot run on macOS.