### PR TITLE
Add Windows accessibility release gate

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -8,6 +8,7 @@ own `CHANGELOG.md` at the repository root.
 ### Added
 - **Temporary-file controls in Settings → General** — an Advanced card now shows the Tiny Clips temporary-file count and size, opens its dedicated `%LOCALAPPDATA%\TinyClips\Temp` folder, and can purge those files without affecting saved captures.
 - **Narrator capture-status announcements** — Tiny Clips now announces screenshot, video, and GIF save results plus recording start and stop through a tray-lifetime UI Automation notification anchor, even when capture pickers and popups are closed.
+- **Windows accessibility release gate** — releases now require a documented keyboard-only and Narrator pass across the tray, settings, capture flow, indicators, editor, trimmers, onboarding, and guide. The shared trim range is now keyboard-operable.
 
 ### Changed
 - Screenshot, video, and GIF settings now each provide matching before/after capture-picker controls.

--- a/windows/README.md
+++ b/windows/README.md
@@ -103,6 +103,13 @@ WASAPI capture, and audio back-pressure), see [`docs/audio-video-sync.md`](docs/
 `.github/workflows/windows-build.yml` builds `x64` + `ARM64` and runs the Core tests on
 `windows-latest`. It is path-filtered to `windows/**`, so it only runs when Windows code changes.
 
+## Accessibility release gate
+
+Before shipping a Windows release, complete the manual [accessibility release-gate matrix](docs/accessibility-release-gate.md)
+against the packaged candidate. It covers keyboard-only and Narrator behavior for the tray,
+settings, capture flows, indicators, editor, trimmers, onboarding, and guide. A build or static
+automation review does not replace the documented hands-on results.
+
 ## Distribution
 
 - **Direct (available now):** signed MSIX distributed via **winget** — install with

--- a/windows/docs/accessibility-release-gate.md
+++ b/windows/docs/accessibility-release-gate.md
@@ -1,0 +1,67 @@
+# Windows accessibility release gate
+
+Every Windows release must complete this matrix on the packaged build that will ship. It is a
+manual release gate: source review and automated builds cannot establish Narrator speech, focus
+order, or the usability of a keyboard-only flow.
+
+## Running the gate
+
+1. Install the signed release candidate MSIX on a supported Windows 11 machine and record the
+   app version, package architecture, Windows build, display scale, and Narrator voice.
+2. Run each applicable row with a keyboard only, then repeat it with Narrator running.
+3. Record **Pass**, **Fail**, or **Not applicable** for both columns in the release evidence. A
+   failure is release-blocking until it is resolved or an explicit waiver is approved.
+4. Re-run every affected row after changing the corresponding flow. Run the tray and capture
+   completion rows for every release because Tiny Clips starts tray-first.
+
+Do not mark a row as passed based solely on automation metadata or a successful build. The
+operator must verify that focus is visible, follows a sensible order, and returns to a usable
+surface after dismissing a popup or completing a flow. All icon-only and custom controls must
+have an accessible name, current state/value, and a keyboard alternative.
+
+## Release matrix
+
+| ID | Surface | Keyboard acceptance | Narrator acceptance | Initial status |
+| --- | --- | --- | --- | --- |
+| A11Y-01 | Tray popup | Open from the notification area; traverse every command; activate Screenshot, Video, GIF, Settings, Guide, recent captures, folders, and Exit; dismiss without trapping focus. | Announces each command, its shortcut/state where present, and the popup context. | Pending hands-on validation |
+| A11Y-02 | Capture completion notifications | Complete screenshot, video, and GIF captures with the picker and tray popup closed. | Confirms recording start/stop and successful or failed save once through the tray-lifetime notification anchor introduced by #198. | Pending hands-on validation |
+| A11Y-03 | Settings | Navigate every navigation item and each settings section with Tab, arrow keys, Space, Enter, and Escape; edit a hotkey and confirm focus returns sensibly. | Announces navigation selection, labels, values, toggle states, validation messages, and dialog buttons. | Pending hands-on validation |
+| A11Y-04 | Capture picker | Use Tab/Shift+Tab, Enter, Escape, and R/S/W; open and change Countdown and the video time-limit flyouts. | Announces Region, Screen, Window, countdown, time-limit current values, and Cancel. | Pending hands-on validation |
+| A11Y-05 | Screen picker | Select a display with keyboard navigation and cancel without starting a capture. | Announces the picker, each display name, primary-display state, resolution, and Cancel. | Pending hands-on validation |
+| A11Y-06 | Window picker | Select a listed window with keyboard navigation and cancel without starting a capture. | Announces the picker, each available window title, and Cancel. | Pending hands-on validation |
+| A11Y-07 | Region selector and outline | Confirm Esc always cancels and focus does not become trapped; verify the pointer-only selection path remains understandable with the instruction overlay. | Announces the region-selection instruction and cancellation path; document any keyboard-only limitation as a blocker or approved exception. | Pending hands-on validation |
+| A11Y-08 | Countdown and region indicator | Start then cancel a countdown, including a region capture. | Announces each countdown value without duplicate or stale speech and does not expose the decorative region outline as actionable content. | Pending hands-on validation |
+| A11Y-09 | Recording and processing indicators | Tab through pause/resume, audio mute, restart, discard, and stop; verify disabled and hidden controls are skipped; complete video and GIF processing. | Announces elapsed/paused state, audio mute state, button names, and processing context. | Pending hands-on validation |
+| A11Y-10 | Screenshot editor | Reach every output action, tool, inspector control, color picker, canvas action, and close path by keyboard. | Announces tool selection, editable values, color names, selected annotation guidance, and output actions. | Pending hands-on validation |
+| A11Y-11 | Video trimmer | Reach preview controls, trim range, speed, remove-audio, export, save, and cancel. On the trim range, use Left/Right to seek, Ctrl+Left/Right to adjust the start, Shift+Left/Right to adjust the end, Page Up/Down to move the range, and Home/End to seek. | Announces video preview, trim range help, controls, checked state, labels, and busy state. | Pending hands-on validation |
+| A11Y-12 | GIF trimmer | Reach frame stepper, trim range, playback, speed, export, save, and cancel. Exercise the same trim-range keyboard commands as A11Y-11. | Announces current frame, trim range help, playback state, controls, labels, and busy state. | Pending hands-on validation |
+| A11Y-13 | Onboarding | Complete, go back, and skip each step with keyboard only. | Announces the current step content, controls, and the changing Next/Get started action. | Pending hands-on validation |
+| A11Y-14 | Guide | Read every section and shortcut with keyboard scrolling; close the window without trapping focus. | Announces guide headings, rows, shortcut labels, and scrollable content in a useful order. | Pending hands-on validation |
+
+## Evidence template
+
+Copy this block into the release issue or pull request and replace every pending value:
+
+```text
+Windows version/build:
+Tiny Clips version/package architecture:
+Narrator voice:
+Display scale(s):
+
+A11Y-01 keyboard:     Narrator:
+A11Y-02 keyboard:     Narrator:
+A11Y-03 keyboard:     Narrator:
+A11Y-04 keyboard:     Narrator:
+A11Y-05 keyboard:     Narrator:
+A11Y-06 keyboard:     Narrator:
+A11Y-07 keyboard:     Narrator:
+A11Y-08 keyboard:     Narrator:
+A11Y-09 keyboard:     Narrator:
+A11Y-10 keyboard:     Narrator:
+A11Y-11 keyboard:     Narrator:
+A11Y-12 keyboard:     Narrator:
+A11Y-13 keyboard:     Narrator:
+A11Y-14 keyboard:     Narrator:
+
+Waivers or linked blocking issues:
+```

--- a/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/GifTrimmerWindow.xaml.cs
@@ -87,6 +87,7 @@ public sealed partial class GifTrimmerWindow : Window
             _ready = true;
             TrimBar.StartFraction = 0;
             TrimBar.EndFraction = 1;
+            TrimBar.KeyboardStep = LastFrame == 0 ? 1 : 1.0 / LastFrame;
             UpdateLabels();
             SetCurrent(0);
         }

--- a/windows/src/TinyClips.App/TrimBar.xaml
+++ b/windows/src/TinyClips.App/TrimBar.xaml
@@ -5,8 +5,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    AutomationProperties.HelpText="Use Left and Right Arrow to seek. Use Control plus Left or Right Arrow to adjust the start. Use Shift plus Left or Right Arrow to adjust the end. Use Page Up or Page Down to move the selected range. Use Home or End to seek to the beginning or end."
     Height="44"
+    IsTabStop="True"
     MinWidth="80"
+    UseSystemFocusVisuals="True"
     Background="Transparent"
     mc:Ignorable="d">
 

--- a/windows/src/TinyClips.App/TrimBar.xaml.cs
+++ b/windows/src/TinyClips.App/TrimBar.xaml.cs
@@ -14,7 +14,7 @@ namespace TinyClips.App;
 /// </summary>
 /// <remarks>
 /// The control raises <see cref="StartFractionChanged"/>, <see cref="EndFractionChanged"/> and
-/// <see cref="SeekRequested"/> only in response to user pointer input. Assigning the matching
+/// <see cref="SeekRequested"/> only in response to direct user input. Assigning the matching
 /// properties (e.g. from the host while clamping) re-lays out without re-raising events, so there
 /// is no feedback loop. User input supports both pointer gestures and keyboard commands.
 /// </remarks>

--- a/windows/src/TinyClips.App/TrimBar.xaml.cs
+++ b/windows/src/TinyClips.App/TrimBar.xaml.cs
@@ -2,6 +2,8 @@ using System;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
 
 namespace TinyClips.App;
 
@@ -14,7 +16,7 @@ namespace TinyClips.App;
 /// The control raises <see cref="StartFractionChanged"/>, <see cref="EndFractionChanged"/> and
 /// <see cref="SeekRequested"/> only in response to user pointer input. Assigning the matching
 /// properties (e.g. from the host while clamping) re-lays out without re-raising events, so there
-/// is no feedback loop.
+/// is no feedback loop. User input supports both pointer gestures and keyboard commands.
 /// </remarks>
 public sealed partial class TrimBar : UserControl
 {
@@ -30,6 +32,8 @@ public sealed partial class TrimBar : UserControl
     private const double HandleWidth = 14.0;
     private const double TrackHeight = 36.0;
     private const double HandleGrab = 12.0;
+    private const double KeyboardStep = 0.01;
+    private const double KeyboardRangeStep = 0.1;
 
     private static readonly InputSystemCursor SizeCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
     private static readonly InputSystemCursor MoveCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeAll);
@@ -54,20 +58,21 @@ public sealed partial class TrimBar : UserControl
         PointerReleased += OnPointerReleased;
         PointerCaptureLost += OnPointerCaptureLost;
         PointerExited += OnPointerExited;
+        KeyDown += OnKeyDown;
         SizeChanged += (_, _) => LayoutParts();
     }
 
-    /// <summary>Raised while the user drags the start handle. Carries the new start fraction.</summary>
+    /// <summary>Raised when the user changes the start handle. Carries the new start fraction.</summary>
     public event EventHandler<double>? StartFractionChanged;
 
-    /// <summary>Raised while the user drags the end handle. Carries the new end fraction.</summary>
+    /// <summary>Raised when the user changes the end handle. Carries the new end fraction.</summary>
     public event EventHandler<double>? EndFractionChanged;
 
-    /// <summary>Raised while the user scrubs the track body. Carries the requested playhead fraction.</summary>
+    /// <summary>Raised when the user requests a playhead position. Carries the requested fraction.</summary>
     public event EventHandler<double>? SeekRequested;
 
     /// <summary>
-    /// Raised while the user drags the selected region as a whole. Carries the new start and end
+    /// Raised when the user moves the selected region as a whole. Carries the new start and end
     /// fractions (the selection width is preserved).
     /// </summary>
     public event EventHandler<(double Start, double End)>? RangeChanged;
@@ -153,6 +158,8 @@ public sealed partial class TrimBar : UserControl
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        Focus(FocusState.Pointer);
+
         var x = e.GetCurrentPoint(this).Position.X;
         var half = HandleWidth / 2.0;
         var usable = Usable;
@@ -241,6 +248,65 @@ public sealed partial class TrimBar : UserControl
             ProtectedCursor = ArrowCursor;
         }
     }
+
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        var control = IsKeyDown(VirtualKey.Control);
+        var shift = IsKeyDown(VirtualKey.Shift);
+
+        switch (e.Key)
+        {
+            case VirtualKey.Left:
+                ApplyKeyboardArrow(-KeyboardStep, control, shift);
+                break;
+            case VirtualKey.Right:
+                ApplyKeyboardArrow(KeyboardStep, control, shift);
+                break;
+            case VirtualKey.PageUp:
+                MoveRange(KeyboardRangeStep);
+                break;
+            case VirtualKey.PageDown:
+                MoveRange(-KeyboardRangeStep);
+                break;
+            case VirtualKey.Home:
+                SeekRequested?.Invoke(this, 0);
+                break;
+            case VirtualKey.End:
+                SeekRequested?.Invoke(this, 1);
+                break;
+            default:
+                return;
+        }
+
+        e.Handled = true;
+    }
+
+    private void ApplyKeyboardArrow(double delta, bool control, bool shift)
+    {
+        if (control)
+        {
+            StartFractionChanged?.Invoke(this, Clamp01(_start + delta));
+            return;
+        }
+
+        if (shift)
+        {
+            EndFractionChanged?.Invoke(this, Clamp01(_end + delta));
+            return;
+        }
+
+        SeekRequested?.Invoke(this, Clamp01(_play + delta));
+    }
+
+    private void MoveRange(double delta)
+    {
+        var width = _end - _start;
+        var start = Math.Clamp(_start + delta, 0, 1 - width);
+        RangeChanged?.Invoke(this, (start, start + width));
+    }
+
+    private static bool IsKeyDown(VirtualKey key) =>
+        InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(CoreVirtualKeyStates.Down);
 
     private void UpdateHoverCursor(double x)
     {

--- a/windows/src/TinyClips.App/TrimBar.xaml.cs
+++ b/windows/src/TinyClips.App/TrimBar.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Windows.System;
@@ -32,7 +34,6 @@ public sealed partial class TrimBar : UserControl
     private const double HandleWidth = 14.0;
     private const double TrackHeight = 36.0;
     private const double HandleGrab = 12.0;
-    private const double KeyboardStep = 0.01;
     private const double KeyboardRangeStep = 0.1;
 
     private static readonly InputSystemCursor SizeCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
@@ -43,6 +44,7 @@ public sealed partial class TrimBar : UserControl
     private double _start;
     private double _end = 1.0;
     private double _play;
+    private string _automationName = string.Empty;
 
     // Anchors captured at the start of a range drag so the selection moves rigidly with the cursor.
     private double _rangeGrabFraction;
@@ -60,6 +62,7 @@ public sealed partial class TrimBar : UserControl
         PointerExited += OnPointerExited;
         KeyDown += OnKeyDown;
         SizeChanged += (_, _) => LayoutParts();
+        UpdateAutomationName();
     }
 
     /// <summary>Raised when the user changes the start handle. Carries the new start fraction.</summary>
@@ -77,6 +80,12 @@ public sealed partial class TrimBar : UserControl
     /// </summary>
     public event EventHandler<(double Start, double End)>? RangeChanged;
 
+    /// <summary>
+    /// Gets or sets the fraction changed by each arrow-key press. Hosts set this to their
+    /// smallest meaningful unit, such as one frame for GIFs.
+    /// </summary>
+    public double KeyboardStep { get; set; } = 0.01;
+
     public double StartFraction
     {
         get => _start;
@@ -84,6 +93,7 @@ public sealed partial class TrimBar : UserControl
         {
             _start = Clamp01(value);
             LayoutParts();
+            UpdateAutomationName();
         }
     }
 
@@ -94,6 +104,7 @@ public sealed partial class TrimBar : UserControl
         {
             _end = Clamp01(value);
             LayoutParts();
+            UpdateAutomationName();
         }
     }
 
@@ -104,6 +115,7 @@ public sealed partial class TrimBar : UserControl
         {
             _play = Clamp01(value);
             LayoutParts();
+            UpdateAutomationName();
         }
     }
 
@@ -253,20 +265,22 @@ public sealed partial class TrimBar : UserControl
     {
         var control = IsKeyDown(VirtualKey.Control);
         var shift = IsKeyDown(VirtualKey.Shift);
+        var previousAutomationName = _automationName;
+        var step = Math.Clamp(KeyboardStep, double.Epsilon, 1);
 
         switch (e.Key)
         {
             case VirtualKey.Left:
-                ApplyKeyboardArrow(-KeyboardStep, control, shift);
+                ApplyKeyboardArrow(-step, control, shift);
                 break;
             case VirtualKey.Right:
-                ApplyKeyboardArrow(KeyboardStep, control, shift);
+                ApplyKeyboardArrow(step, control, shift);
                 break;
             case VirtualKey.PageUp:
-                MoveRange(KeyboardRangeStep);
+                MoveRange(Math.Max(KeyboardRangeStep, step));
                 break;
             case VirtualKey.PageDown:
-                MoveRange(-KeyboardRangeStep);
+                MoveRange(-Math.Max(KeyboardRangeStep, step));
                 break;
             case VirtualKey.Home:
                 SeekRequested?.Invoke(this, 0);
@@ -278,6 +292,7 @@ public sealed partial class TrimBar : UserControl
                 return;
         }
 
+        UpdateAutomationName(previousAutomationName);
         e.Handled = true;
     }
 
@@ -307,6 +322,24 @@ public sealed partial class TrimBar : UserControl
 
     private static bool IsKeyDown(VirtualKey key) =>
         InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(CoreVirtualKeyStates.Down);
+
+    private void UpdateAutomationName(string? previousName = null)
+    {
+        var name = $"Trim range. Start {FormatFraction(_start)}, end {FormatFraction(_end)}, current {FormatFraction(_play)}.";
+        var oldName = previousName ?? _automationName;
+        _automationName = name;
+        AutomationProperties.SetName(this, name);
+
+        if (previousName is not null && !string.Equals(oldName, name, StringComparison.Ordinal))
+        {
+            var peer = FrameworkElementAutomationPeer.FromElement(this)
+                ?? FrameworkElementAutomationPeer.CreatePeerForElement(this);
+            peer?.RaisePropertyChangedEvent(AutomationElementIdentifiers.NameProperty, oldName, name);
+        }
+    }
+
+    private static string FormatFraction(double fraction) =>
+        $"{Math.Round(Clamp01(fraction) * 100):0}%";
 
     private void UpdateHoverCursor(double x)
     {

--- a/windows/src/TinyClips.App/TrimBar.xaml.cs
+++ b/windows/src/TinyClips.App/TrimBar.xaml.cs
@@ -170,7 +170,7 @@ public sealed partial class TrimBar : UserControl
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        Focus(FocusState.Pointer);
+        Focus(Microsoft.UI.Xaml.FocusState.Pointer);
 
         var x = e.GetCurrentPoint(this).Position.X;
         var half = HandleWidth / 2.0;

--- a/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
@@ -78,6 +78,7 @@ public sealed partial class VideoTrimmerWindow : Window
             TrimBar.StartFraction = 0;
             TrimBar.EndFraction = 1;
             TrimBar.PlayheadFraction = 0;
+            TrimBar.KeyboardStep = Math.Min(1, FrameStep.TotalSeconds / _duration.TotalSeconds);
             UpdateLabels();
             UpdatePositionLabel(TimeSpan.Zero);
         }


### PR DESCRIPTION
Windows releases need repeatable keyboard and Narrator evidence rather than relying on a static accessibility review. This adds a maintained release matrix for the tray-first capture experience while preserving #198's tray-lifetime completion announcements.

- Documents required keyboard-only and Narrator checks for the tray, settings, pickers, countdown and indicators, editor, trimmers, onboarding, and guide.
- Links the gate from the Windows release documentation and records it in the changelog.
- Makes the shared video/GIF trim range focusable and keyboard-operable, including visible system focus styling and documented commands.

All A11Y-01 through A11Y-14 Narrator results remain intentionally pending hands-on Windows validation. The full WinUI build and WindowsDesktop test host cannot run on this macOS host; the Core project builds with cross-targeting enabled.

Fixes: #79