### PR TITLE
Add Uploadcare uploads for Windows

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Uploadcare cloud uploads** — Settings → Uploadcare now stores the public key and upload preferences locally while keeping the optional signing secret only in Windows Credential Locker. Tiny Clips can upload finalized screenshots, videos, GIFs, and exported frames automatically, optionally copy the delivery URL, and lets the Clips Library upload a capture manually with Copy URL and Open URL actions.
 - **Clips Library** — A dedicated media library window (accessible from the tray popup) that lets users browse saved screenshots, videos, and GIFs without opening File Explorer. Each clip shows a thumbnail, filename, timestamp, and file size. Per-clip actions: Reveal in Explorer, Open in editor/trimmer, Copy to clipboard, and Delete with confirmation. Supports filter by capture type (All / Screenshots / Videos / GIFs), sort by newest or oldest first, and a grid/list view toggle. Window state (view mode, filter, sort) persists across sessions.
 - **Temporary-file controls in Settings → General** — an Advanced card now shows the Tiny Clips temporary-file count and size, opens its dedicated `%LOCALAPPDATA%\TinyClips\Temp` folder, and can purge those files without affecting saved captures.
 - **Narrator capture-status announcements** — Tiny Clips now announces screenshot, video, and GIF save results plus recording start and stop through a tray-lifetime UI Automation notification anchor, even when capture pickers and popups are closed.

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -75,6 +75,7 @@ public partial class App : Application
         InitializeComponent();
         Services = new ServiceCollection()
             .AddTinyClipsCore()
+            .AddSingleton<IUploadcareCredentialStore, WindowsCredentialStore>()
             .AddSingleton<IMediaDevicePermissionService, MediaDevicePermissionService>()
             .BuildServiceProvider();
 
@@ -1547,6 +1548,7 @@ public partial class App : Application
     internal static void ShowSaveNotification(string path)
     {
         AnnounceCaptureSaved(path);
+        (Current as App)?.QueueAutoUpload(path);
 
         try
         {
@@ -1570,6 +1572,44 @@ public partial class App : Application
         }
     }
 
+    private void QueueAutoUpload(string path)
+    {
+        var settings = Services.GetRequiredService<ICaptureSettings>();
+        if (!settings.UploadcareEnabled ||
+            !settings.UploadcareAutoUpload ||
+            string.IsNullOrWhiteSpace(settings.UploadcarePublicKey))
+        {
+            return;
+        }
+
+        _ = UploadSavedClipAsync(path);
+    }
+
+    private async Task UploadSavedClipAsync(string path)
+    {
+        try
+        {
+            var result = await Services.GetRequiredService<IUploadcareUploadService>().UploadAsync(path);
+            var settings = Services.GetRequiredService<ICaptureSettings>();
+            if (settings.UploadcareCopyUrl)
+            {
+                try
+                {
+                    await ClipboardService.CopyTextAsync(result.DeliveryUri.AbsoluteUri);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Upload URL clipboard copy failed: {ex}");
+                    ShowClipboardFailureNotification(Path.GetFileName(path));
+                }
+            }
+        }
+        catch (UploadcareUploadException)
+        {
+            ShowUploadFailureNotification(Path.GetFileName(path));
+        }
+    }
+
     internal static void ShowClipboardFailureNotification(string fileName)
     {
         try
@@ -1581,6 +1621,24 @@ public partial class App : Application
                 .BuildNotification();
 
             AppNotificationManager.Default.Show(notification);
+        }
+
+        internal static void ShowUploadFailureNotification(string fileName)
+        {
+            try
+            {
+                EnsureNotificationsRegistered();
+                var notification = new AppNotificationBuilder()
+                    .AddText("Couldn't upload to Uploadcare")
+                    .AddText(fileName)
+                    .BuildNotification();
+
+                AppNotificationManager.Default.Show(notification);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to show upload failure notification: {ex}");
+            }
         }
         catch (Exception ex)
         {

--- a/windows/src/TinyClips.App/ClipsManagerWindow.xaml
+++ b/windows/src/TinyClips.App/ClipsManagerWindow.xaml
@@ -73,6 +73,14 @@
                     GroupName="TypeFilter" />
             </StackPanel>
 
+            <TextBlock
+                x:Name="UploadStatusText"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                TextTrimming="CharacterEllipsis"
+                Visibility="Collapsed" />
+
             <!--  Sort  -->
             <ComboBox
                 x:Name="SortCombo"
@@ -234,6 +242,8 @@
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <Button
                                         Grid.Column="0"
@@ -273,6 +283,42 @@
                                         HorizontalAlignment="Stretch"
                                         HorizontalContentAlignment="Center"
                                         Padding="4,6"
+                                        AutomationProperties.Name="Upload to Uploadcare"
+                                        Click="OnUploadClicked"
+                                        Tag="{x:Bind Path}"
+                                        ToolTipService.ToolTip="Upload to Uploadcare"
+                                        Visibility="{x:Bind UploadAvailable, Mode=OneWay}">
+                                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="13" Glyph="&#xE898;" />
+                                    </Button>
+                                    <Button
+                                        Grid.Column="3"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Padding="4,6"
+                                        AutomationProperties.Name="Copy Uploadcare URL"
+                                        Click="OnCopyUploadUrlClicked"
+                                        Tag="{x:Bind Path}"
+                                        ToolTipService.ToolTip="Copy Uploadcare URL"
+                                        Visibility="{x:Bind UploadedUrlAvailable, Mode=OneWay}">
+                                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="13" Glyph="&#xE8C8;" />
+                                    </Button>
+                                    <Button
+                                        Grid.Column="4"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Padding="4,6"
+                                        AutomationProperties.Name="Open Uploadcare URL"
+                                        Click="OnOpenUploadUrlClicked"
+                                        Tag="{x:Bind Path}"
+                                        ToolTipService.ToolTip="Open Uploadcare URL"
+                                        Visibility="{x:Bind UploadedUrlAvailable, Mode=OneWay}">
+                                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="13" Glyph="&#xE71B;" />
+                                    </Button>
+                                    <Button
+                                        Grid.Column="5"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Padding="4,6"
                                         AutomationProperties.Name="Delete"
                                         Click="OnDeleteClicked"
                                         Tag="{x:Bind Path}"
@@ -301,6 +347,8 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
@@ -372,6 +420,39 @@
                             </Button>
                             <Button
                                 Grid.Column="5"
+                                Width="32"
+                                Padding="0"
+                                AutomationProperties.Name="Upload to Uploadcare"
+                                Click="OnUploadClicked"
+                                Tag="{x:Bind Path}"
+                                ToolTipService.ToolTip="Upload to Uploadcare"
+                                Visibility="{x:Bind UploadAvailable, Mode=OneWay}">
+                                <FontIcon FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE898;" />
+                            </Button>
+                            <Button
+                                Grid.Column="5"
+                                Width="32"
+                                Padding="0"
+                                AutomationProperties.Name="Copy Uploadcare URL"
+                                Click="OnCopyUploadUrlClicked"
+                                Tag="{x:Bind Path}"
+                                ToolTipService.ToolTip="Copy Uploadcare URL"
+                                Visibility="{x:Bind UploadedUrlAvailable, Mode=OneWay}">
+                                <FontIcon FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE8C8;" />
+                            </Button>
+                            <Button
+                                Grid.Column="6"
+                                Width="32"
+                                Padding="0"
+                                AutomationProperties.Name="Open Uploadcare URL"
+                                Click="OnOpenUploadUrlClicked"
+                                Tag="{x:Bind Path}"
+                                ToolTipService.ToolTip="Open Uploadcare URL"
+                                Visibility="{x:Bind UploadedUrlAvailable, Mode=OneWay}">
+                                <FontIcon FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;" />
+                            </Button>
+                            <Button
+                                Grid.Column="7"
                                 Width="32"
                                 Padding="0"
                                 AutomationProperties.Name="Delete"

--- a/windows/src/TinyClips.App/ClipsManagerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/ClipsManagerWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -16,7 +17,7 @@ namespace TinyClips.App;
 /// <summary>
 /// View model for a single clip entry shown in the library grid or list.
 /// </summary>
-public sealed class ClipItemViewModel
+public sealed partial class ClipItemViewModel : ObservableObject
 {
     public required string Path { get; init; }
     public required CaptureType Type { get; init; }
@@ -29,6 +30,19 @@ public sealed class ClipItemViewModel
     public BitmapImage? Thumbnail { get; init; }
     public Visibility HasThumbnail => Thumbnail is not null ? Visibility.Visible : Visibility.Collapsed;
     public Visibility NoThumbnail => Thumbnail is null ? Visibility.Visible : Visibility.Collapsed;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UploadAvailable))]
+    [NotifyPropertyChangedFor(nameof(UploadedUrlAvailable))]
+    private string? _uploadedUrl;
+
+    public Visibility UploadAvailable => string.IsNullOrWhiteSpace(UploadedUrl)
+        ? Visibility.Visible
+        : Visibility.Collapsed;
+
+    public Visibility UploadedUrlAvailable => string.IsNullOrWhiteSpace(UploadedUrl)
+        ? Visibility.Collapsed
+        : Visibility.Visible;
 
     public static async Task<ClipItemViewModel> FromAsync(ClipEntry entry)
     {
@@ -114,6 +128,7 @@ public sealed partial class ClipsManagerWindow : Window
     private const string SettingsKeySort     = "clipsManagerSort";
 
     private readonly IClipLibraryService _library;
+    private readonly IUploadcareUploadService _uploadcare;
     private readonly ISettingsService _settings;
 
     private readonly ObservableCollection<ClipItemViewModel> _visibleClips = [];
@@ -124,6 +139,7 @@ public sealed partial class ClipsManagerWindow : Window
     public ClipsManagerWindow()
     {
         _library  = App.Services.GetRequiredService<IClipLibraryService>();
+        _uploadcare = App.Services.GetRequiredService<IUploadcareUploadService>();
         _settings = App.Services.GetRequiredService<ISettingsService>();
 
         InitializeComponent();
@@ -311,6 +327,82 @@ public sealed partial class ClipsManagerWindow : Window
         }
     }
 
+    private async void OnUploadClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: string path } button)
+        {
+            return;
+        }
+
+        var item = _allClips.FirstOrDefault(c => string.Equals(c.Path, path, StringComparison.OrdinalIgnoreCase));
+        if (item is null)
+        {
+            return;
+        }
+
+        button.IsEnabled = false;
+        SetUploadStatus("Uploading capture...");
+        try
+        {
+            var result = await _uploadcare.UploadAsync(path);
+            item.UploadedUrl = result.DeliveryUri.AbsoluteUri;
+            SetUploadStatus("Uploaded to Uploadcare. Use Copy URL or Open URL to access it.");
+        }
+        catch (UploadcareUploadException ex)
+        {
+            SetUploadStatus(ex.Message);
+        }
+        finally
+        {
+            button.IsEnabled = true;
+        }
+    }
+
+    private async void OnCopyUploadUrlClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { Tag: string path })
+        {
+            return;
+        }
+
+        var item = _allClips.FirstOrDefault(c => string.Equals(c.Path, path, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrWhiteSpace(item?.UploadedUrl))
+        {
+            return;
+        }
+
+        try
+        {
+            await ClipboardService.CopyTextAsync(item.UploadedUrl);
+            SetUploadStatus("Upload URL copied to the clipboard.");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ClipsManagerWindow: upload URL clipboard copy failed: {ex}");
+            App.ShowClipboardFailureNotification(System.IO.Path.GetFileName(path));
+        }
+    }
+
+    private async void OnOpenUploadUrlClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { Tag: string path })
+        {
+            return;
+        }
+
+        var item = _allClips.FirstOrDefault(c => string.Equals(c.Path, path, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrWhiteSpace(item?.UploadedUrl) ||
+            !Uri.TryCreate(item.UploadedUrl, UriKind.Absolute, out var uri))
+        {
+            return;
+        }
+
+        if (!await Windows.System.Launcher.LaunchUriAsync(uri))
+        {
+            SetUploadStatus("Windows couldn't open the Uploadcare URL.");
+        }
+    }
+
     private async void OnDeleteClicked(object sender, RoutedEventArgs e)
     {
         if (sender is not FrameworkElement { Tag: string path }) return;
@@ -388,6 +480,12 @@ public sealed partial class ClipsManagerWindow : Window
                    : "All";
         _settings.Set(SettingsKeyFilter, filter);
         _settings.Set(SettingsKeySort, SortCombo.SelectedIndex);
+    }
+
+    private void SetUploadStatus(string status)
+    {
+        UploadStatusText.Text = status;
+        UploadStatusText.Visibility = Visibility.Visible;
     }
 
     // -----------------------------------------------------------------------

--- a/windows/src/TinyClips.App/Settings/Sections/UploadcareSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/UploadcareSettingsSection.xaml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="TinyClips.App.Settings.Sections.UploadcareSettingsSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="8">
+        <TextBlock
+            Margin="4,8,0,4"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Uploadcare" />
+
+        <TextBlock
+            Margin="4,4,0,0"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="Cloud uploads" />
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Enable Uploadcare" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Upload saved captures to your Uploadcare project." />
+                </StackPanel>
+                <ToggleSwitch
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="UploadcareEnabledToggle"
+                    AutomationProperties.Name="Enable Uploadcare uploads"
+                    IsOn="{x:Bind ViewModel.UploadcareEnabled, Mode=TwoWay}" />
+            </Grid>
+        </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="8">
+                <StackPanel>
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Public key" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Required for uploads. This key is saved with your non-secret Tiny Clips settings." />
+                </StackPanel>
+                <TextBox
+                    AutomationProperties.AutomationId="UploadcarePublicKeyTextBox"
+                    AutomationProperties.Name="Uploadcare public key"
+                    PlaceholderText="demopublickey"
+                    Text="{x:Bind ViewModel.UploadcarePublicKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+        </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="8">
+                <StackPanel>
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Secret key (optional)" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Used only to sign Uploadcare requests. It is stored in Windows Credential Locker, never in Tiny Clips settings." />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.UploadcareSecretKeyStatus, Mode=OneWay}" />
+                </StackPanel>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <PasswordBox
+                        x:Name="SecretKeyBox"
+                        AutomationProperties.AutomationId="UploadcareSecretKeyPasswordBox"
+                        AutomationProperties.Name="Uploadcare secret key"
+                        PasswordRevealMode="Peek"
+                        PlaceholderText="Enter a new secret key" />
+                    <Button
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="SaveUploadcareSecretKeyButton"
+                        Click="OnSaveSecretKey"
+                        Content="Save securely" />
+                    <Button
+                        Grid.Column="2"
+                        AutomationProperties.AutomationId="ClearUploadcareSecretKeyButton"
+                        Click="OnClearSecretKey"
+                        Content="Clear" />
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <TextBlock
+            Margin="4,16,0,0"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            Text="After saving a capture" />
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Upload automatically" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Upload after Tiny Clips successfully finishes saving a screenshot, video, or GIF." />
+                </StackPanel>
+                <ToggleSwitch
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="UploadcareAutoUploadToggle"
+                    AutomationProperties.Name="Upload automatically after saving"
+                    IsOn="{x:Bind ViewModel.UploadcareAutoUpload, Mode=TwoWay}" />
+            </Grid>
+        </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Copy uploaded URL" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Copy the Uploadcare delivery URL when an automatic upload succeeds." />
+                </StackPanel>
+                <ToggleSwitch
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="UploadcareCopyUrlToggle"
+                    AutomationProperties.Name="Copy uploaded URL"
+                    IsOn="{x:Bind ViewModel.UploadcareCopyUrl, Mode=TwoWay}" />
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/windows/src/TinyClips.App/Settings/Sections/UploadcareSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/UploadcareSettingsSection.xaml.cs
@@ -1,0 +1,32 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace TinyClips.App.Settings.Sections;
+
+public sealed partial class UploadcareSettingsSection : UserControl
+{
+    private readonly IDisposable _realizationScope;
+
+    public SettingsViewModel ViewModel { get; }
+
+    public UploadcareSettingsSection(SettingsViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        _realizationScope = viewModel.BeginSectionRealization();
+        InitializeComponent();
+        SectionLifecycle.HookFirstLoad(this, viewModel, _realizationScope);
+    }
+
+    private void OnSaveSecretKey(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(SecretKeyBox.Password))
+        {
+            return;
+        }
+
+        ViewModel.SaveUploadcareSecretKey(SecretKeyBox.Password);
+        SecretKeyBox.Password = string.Empty;
+    }
+
+    private void OnClearSecretKey(object sender, RoutedEventArgs e) => ViewModel.ClearUploadcareSecretKey();
+}

--- a/windows/src/TinyClips.App/Settings/SettingsSectionKind.cs
+++ b/windows/src/TinyClips.App/Settings/SettingsSectionKind.cs
@@ -9,6 +9,7 @@ namespace TinyClips.App.Settings;
 public enum SettingsSectionKind
 {
     General,
+    Uploadcare,
     Analytics,
     Screenshot,
     Video,

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -32,6 +32,7 @@ public sealed partial class SettingsViewModel : ObservableObject
     private readonly IWebcamDeviceEnumerator _webcamDevices;
     private readonly IClipStorageService _storage;
     private readonly IClipAnalyticsService _analytics;
+    private readonly IUploadcareCredentialStore _uploadcareCredentials;
     private readonly DispatcherQueue? _dispatcherQueue;
     private bool _loading;
     private string _savedMicrophoneId = string.Empty;
@@ -71,7 +72,8 @@ public sealed partial class SettingsViewModel : ObservableObject
         IAudioDeviceService audioDevices,
         IWebcamDeviceEnumerator webcamDevices,
         IClipStorageService storage,
-        IClipAnalyticsService analytics)
+        IClipAnalyticsService analytics,
+        IUploadcareCredentialStore uploadcareCredentials)
     {
         _settings = settings;
         _hotKeys = hotKeys;
@@ -80,6 +82,7 @@ public sealed partial class SettingsViewModel : ObservableObject
         _webcamDevices = webcamDevices;
         _storage = storage;
         _analytics = analytics;
+        _uploadcareCredentials = uploadcareCredentials;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         Load();
 
@@ -223,6 +226,27 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _showSaveNotifications;
+
+    // Uploadcare
+    [ObservableProperty]
+    private bool _uploadcareEnabled;
+
+    [ObservableProperty]
+    private string _uploadcarePublicKey = string.Empty;
+
+    [ObservableProperty]
+    private bool _uploadcareAutoUpload;
+
+    [ObservableProperty]
+    private bool _uploadcareCopyUrl;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UploadcareSecretKeyStatus))]
+    private bool _hasUploadcareSecretKey;
+
+    public string UploadcareSecretKeyStatus => HasUploadcareSecretKey
+        ? "A secret key is stored securely in Windows Credential Locker."
+        : "No secret key is stored. It is only required for signed Uploadcare uploads.";
 
     [ObservableProperty]
     private bool _launchAtLogin;
@@ -611,6 +635,11 @@ public sealed partial class SettingsViewModel : ObservableObject
                 : _settings.FileNameTemplate;
             ShowInExplorer = _settings.ShowInExplorer;
             ShowSaveNotifications = _settings.ShowSaveNotifications;
+            UploadcareEnabled = _settings.UploadcareEnabled;
+            UploadcarePublicKey = _settings.UploadcarePublicKey;
+            UploadcareAutoUpload = _settings.UploadcareAutoUpload;
+            UploadcareCopyUrl = _settings.UploadcareCopyUrl;
+            HasUploadcareSecretKey = _uploadcareCredentials.HasSecretKey();
             LaunchAtLogin = _settings.LaunchAtLogin;
             CopyScreenshotToClipboard = _settings.CopyScreenshotToClipboard;
             CopyVideoToClipboard = _settings.CopyVideoToClipboard;
@@ -878,6 +907,26 @@ public sealed partial class SettingsViewModel : ObservableObject
     partial void OnShowInExplorerChanged(bool value) => Persist(() => _settings.ShowInExplorer = value);
 
     partial void OnShowSaveNotificationsChanged(bool value) => Persist(() => _settings.ShowSaveNotifications = value);
+
+    partial void OnUploadcareEnabledChanged(bool value) => Persist(() => _settings.UploadcareEnabled = value);
+
+    partial void OnUploadcarePublicKeyChanged(string value) => Persist(() => _settings.UploadcarePublicKey = value);
+
+    partial void OnUploadcareAutoUploadChanged(bool value) => Persist(() => _settings.UploadcareAutoUpload = value);
+
+    partial void OnUploadcareCopyUrlChanged(bool value) => Persist(() => _settings.UploadcareCopyUrl = value);
+
+    public void SaveUploadcareSecretKey(string secretKey)
+    {
+        _uploadcareCredentials.SaveSecretKey(secretKey);
+        HasUploadcareSecretKey = true;
+    }
+
+    public void ClearUploadcareSecretKey()
+    {
+        _uploadcareCredentials.RemoveSecretKey();
+        HasUploadcareSecretKey = false;
+    }
 
     partial void OnLaunchAtLoginChanged(bool value)
     {

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -46,6 +46,11 @@
                     Icon="Setting"
                     Tag="General" />
                 <NavigationViewItem
+                    AutomationProperties.AutomationId="UploadcareNavigationItem"
+                    Content="Uploadcare"
+                    Icon="CloudUpload"
+                    Tag="Uploadcare" />
+                <NavigationViewItem
                     AutomationProperties.AutomationId="AnalyticsNavigationItem"
                     Content="Analytics"
                     Icon="CalendarWeek"

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -35,7 +35,8 @@ public sealed partial class SettingsWindow : Window
             App.Services.GetRequiredService<IAudioDeviceService>(),
             App.Services.GetRequiredService<IWebcamDeviceEnumerator>(),
             App.Services.GetRequiredService<IClipStorageService>(),
-            App.Services.GetRequiredService<IClipAnalyticsService>());
+            App.Services.GetRequiredService<IClipAnalyticsService>(),
+            App.Services.GetRequiredService<IUploadcareCredentialStore>());
 
         InitializeComponent();
 
@@ -98,6 +99,7 @@ public sealed partial class SettingsWindow : Window
         UserControl section = kind switch
         {
             SettingsSectionKind.General => CreateGeneralSection(),
+            SettingsSectionKind.Uploadcare => new UploadcareSettingsSection(ViewModel),
             SettingsSectionKind.Analytics => new AnalyticsSettingsSection(
                 ViewModel,
                 WinRT.Interop.WindowNative.GetWindowHandle(this)),

--- a/windows/src/TinyClips.App/WindowsCredentialStore.cs
+++ b/windows/src/TinyClips.App/WindowsCredentialStore.cs
@@ -1,0 +1,50 @@
+using Windows.Security.Credentials;
+using TinyClips.Core.Services;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Stores the optional Uploadcare signing key in the Windows Credential Locker, never in app settings.
+/// </summary>
+public sealed class WindowsCredentialStore : IUploadcareCredentialStore
+{
+    private const string ResourceName = "TinyClips.Uploadcare";
+    private const string UserName = "secret-key";
+    private readonly PasswordVault _vault = new();
+
+    public string? GetSecretKey()
+    {
+        var credential = FindCredential();
+        if (credential is null)
+        {
+            return null;
+        }
+
+        credential.RetrievePassword();
+        return credential.Password;
+    }
+
+    public void SaveSecretKey(string secretKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretKey);
+        RemoveSecretKey();
+        _vault.Add(new PasswordCredential(ResourceName, UserName, secretKey));
+    }
+
+    public void RemoveSecretKey()
+    {
+        foreach (var credential in FindCredentials())
+        {
+            _vault.Remove(credential);
+        }
+    }
+
+    public bool HasSecretKey() => FindCredential() is not null;
+
+    private PasswordCredential? FindCredential() => FindCredentials().FirstOrDefault();
+
+    private IEnumerable<PasswordCredential> FindCredentials() =>
+        _vault.RetrieveAll().Where(credential =>
+            string.Equals(credential.Resource, ResourceName, StringComparison.Ordinal) &&
+            string.Equals(credential.UserName, UserName, StringComparison.Ordinal));
+}

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -55,6 +55,30 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("showSaveNotifications", value);
     }
 
+    public bool UploadcareEnabled
+    {
+        get => _settings.Get("uploadcareEnabled", false);
+        set => _settings.Set("uploadcareEnabled", value);
+    }
+
+    public string UploadcarePublicKey
+    {
+        get => _settings.Get("uploadcarePublicKey", string.Empty);
+        set => _settings.Set("uploadcarePublicKey", value);
+    }
+
+    public bool UploadcareAutoUpload
+    {
+        get => _settings.Get("uploadcareAutoUpload", false);
+        set => _settings.Set("uploadcareAutoUpload", value);
+    }
+
+    public bool UploadcareCopyUrl
+    {
+        get => _settings.Get("uploadcareCopyUrl", false);
+        set => _settings.Set("uploadcareCopyUrl", value);
+    }
+
     public bool LaunchAtLogin
     {
         get => _settings.Get("launchAtLogin", false);
@@ -594,6 +618,10 @@ public sealed class CaptureSettings : ICaptureSettings
         ShowRegionIndicator = true;
         IncludeTinyClipsInCapture = false;
         ShowBrandingOverlay = false;
+        UploadcareEnabled = false;
+        UploadcarePublicKey = string.Empty;
+        UploadcareAutoUpload = false;
+        UploadcareCopyUrl = false;
         _analytics?.Clear();
         ScreenshotHotKeyCode = 53;
         ScreenshotHotKeyModifiers = 6;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -66,6 +66,10 @@ public interface ICaptureSettings
     bool ShowRegionIndicator { get; set; }
     bool IncludeTinyClipsInCapture { get; set; }
     bool ShowBrandingOverlay { get; set; }
+    bool UploadcareEnabled { get; set; }
+    string UploadcarePublicKey { get; set; }
+    bool UploadcareAutoUpload { get; set; }
+    bool UploadcareCopyUrl { get; set; }
     int ScreenshotHotKeyCode { get; set; }
     int ScreenshotHotKeyModifiers { get; set; }
     int VideoHotKeyCode { get; set; }

--- a/windows/src/TinyClips.Core/Services/IUploadcareCredentialStore.cs
+++ b/windows/src/TinyClips.Core/Services/IUploadcareCredentialStore.cs
@@ -1,0 +1,15 @@
+namespace TinyClips.Core.Services;
+
+/// <summary>
+/// Provides the Uploadcare secret key from platform secure credential storage.
+/// </summary>
+public interface IUploadcareCredentialStore
+{
+    string? GetSecretKey();
+
+    void SaveSecretKey(string secretKey);
+
+    void RemoveSecretKey();
+
+    bool HasSecretKey();
+}

--- a/windows/src/TinyClips.Core/Services/IUploadcareUploadService.cs
+++ b/windows/src/TinyClips.Core/Services/IUploadcareUploadService.cs
@@ -1,0 +1,6 @@
+namespace TinyClips.Core.Services;
+
+public interface IUploadcareUploadService
+{
+    Task<UploadcareUploadResult> UploadAsync(string filePath, CancellationToken cancellationToken = default);
+}

--- a/windows/src/TinyClips.Core/Services/ServiceCollectionExtensions.cs
+++ b/windows/src/TinyClips.Core/Services/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IRecentCaptureService, RecentCaptureService>();
         services.AddSingleton<IClipLibraryService, ClipLibraryService>();
+        services.AddSingleton<IUploadcareUploadService, UploadcareUploadService>();
         services.AddSingleton<IAppUpdateService, GitHubReleaseUpdateService>();
         services.AddSingleton<IHotKeyService, HotKeyService>();
         services.AddSingleton<ILaunchAtLoginService, LaunchAtLoginService>();

--- a/windows/src/TinyClips.Core/Services/UploadcareUploadException.cs
+++ b/windows/src/TinyClips.Core/Services/UploadcareUploadException.cs
@@ -1,0 +1,14 @@
+namespace TinyClips.Core.Services;
+
+public sealed class UploadcareUploadException : Exception
+{
+    public UploadcareUploadException(string message)
+        : base(message)
+    {
+    }
+
+    public UploadcareUploadException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/windows/src/TinyClips.Core/Services/UploadcareUploadResult.cs
+++ b/windows/src/TinyClips.Core/Services/UploadcareUploadResult.cs
@@ -1,0 +1,3 @@
+namespace TinyClips.Core.Services;
+
+public sealed record UploadcareUploadResult(string FileId, Uri DeliveryUri);

--- a/windows/src/TinyClips.Core/Services/UploadcareUploadService.cs
+++ b/windows/src/TinyClips.Core/Services/UploadcareUploadService.cs
@@ -1,0 +1,340 @@
+using System.Net.Http.Headers;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace TinyClips.Core.Services;
+
+/// <summary>
+/// Streams Tiny Clips files to Uploadcare's direct or multipart upload APIs.
+/// </summary>
+public sealed class UploadcareUploadService : IUploadcareUploadService
+{
+    private const long DefaultDirectUploadLimitBytes = 100L * 1024 * 1024;
+    private const int MultipartPartSizeBytes = 8 * 1024 * 1024;
+    private static readonly Uri BaseUploadUri = new("https://upload.uploadcare.com/base/");
+    private static readonly Uri MultipartStartUri = new("https://upload.uploadcare.com/multipart/start/");
+    private static readonly Uri MultipartCompleteUri = new("https://upload.uploadcare.com/multipart/complete/");
+
+    private readonly HttpClient _httpClient;
+    private readonly ICaptureSettings _settings;
+    private readonly IUploadcareCredentialStore _credentials;
+    private readonly long _directUploadLimitBytes;
+
+    public UploadcareUploadService(
+        HttpClient httpClient,
+        ICaptureSettings settings,
+        IUploadcareCredentialStore credentials,
+        long directUploadLimitBytes = DefaultDirectUploadLimitBytes)
+    {
+        if (directUploadLimitBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(directUploadLimitBytes));
+        }
+
+        _httpClient = httpClient;
+        _settings = settings;
+        _credentials = credentials;
+        _directUploadLimitBytes = directUploadLimitBytes;
+    }
+
+    public async Task<UploadcareUploadResult> UploadAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var publicKey = _settings.UploadcarePublicKey.Trim();
+        if (string.IsNullOrWhiteSpace(publicKey))
+        {
+            throw new UploadcareUploadException("Enter an Uploadcare public key before uploading.");
+        }
+
+        var file = new FileInfo(filePath);
+        if (!file.Exists)
+        {
+            throw new UploadcareUploadException("The capture is no longer available to upload.");
+        }
+
+        if (file.Length == 0)
+        {
+            throw new UploadcareUploadException("Empty files cannot be uploaded.");
+        }
+
+        var signing = CreateSigningParameters(_credentials.GetSecretKey());
+        try
+        {
+            return file.Length < _directUploadLimitBytes
+                ? await UploadDirectAsync(file, publicKey, signing, cancellationToken)
+                : await UploadMultipartAsync(file, publicKey, signing, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (UploadcareUploadException)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new UploadcareUploadException(
+                "Uploadcare could not be reached. Check your connection and try again.",
+                ex);
+        }
+        catch (IOException ex)
+        {
+            throw new UploadcareUploadException("The capture could not be read for upload.", ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new UploadcareUploadException("Tiny Clips cannot read this capture for upload.", ex);
+        }
+        catch (JsonException ex)
+        {
+            throw new UploadcareUploadException("Uploadcare returned an unexpected response.", ex);
+        }
+    }
+
+    private async Task<UploadcareUploadResult> UploadDirectAsync(
+        FileInfo file,
+        string publicKey,
+        SigningParameters? signing,
+        CancellationToken cancellationToken)
+    {
+        using var content = CreateFormContent(publicKey, signing);
+        await using var stream = new FileStream(
+            file.FullName,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81_920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(GetContentType(file.Extension));
+        content.Add(fileContent, "file", file.Name);
+
+        using var response = await _httpClient.PostAsync(BaseUploadUri, content, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        var fileId = ReadDirectUploadFileId(responseBody);
+        return CreateResult(fileId);
+    }
+
+    private async Task<UploadcareUploadResult> UploadMultipartAsync(
+        FileInfo file,
+        string publicKey,
+        SigningParameters? signing,
+        CancellationToken cancellationToken)
+    {
+        using var startContent = CreateFormContent(publicKey, signing);
+        startContent.Add(new StringContent(file.Name), "filename");
+        startContent.Add(new StringContent(file.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)), "size");
+        startContent.Add(new StringContent(MultipartPartSizeBytes.ToString(System.Globalization.CultureInfo.InvariantCulture)), "part_size");
+        startContent.Add(new StringContent(GetContentType(file.Extension)), "content_type");
+
+        using var startResponse = await _httpClient.PostAsync(MultipartStartUri, startContent, cancellationToken);
+        await EnsureSuccessAsync(startResponse, cancellationToken);
+        var startBody = await startResponse.Content.ReadAsStringAsync(cancellationToken);
+        var upload = ReadMultipartStart(startBody);
+        var expectedPartCount = (file.Length + MultipartPartSizeBytes - 1) / MultipartPartSizeBytes;
+        if (upload.Parts.Count != expectedPartCount)
+        {
+            throw new UploadcareUploadException("Uploadcare returned an invalid multipart upload session.");
+        }
+
+        for (var index = 0; index < upload.Parts.Count; index++)
+        {
+            var offset = index * (long)MultipartPartSizeBytes;
+            var length = Math.Min(MultipartPartSizeBytes, file.Length - offset);
+            using var partContent = new FileRangeContent(file.FullName, offset, length);
+            using var request = new HttpRequestMessage(HttpMethod.Put, upload.Parts[index])
+            {
+                Content = partContent,
+            };
+            using var partResponse = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            await EnsureSuccessAsync(partResponse, cancellationToken);
+        }
+
+        using var completeContent = new MultipartFormDataContent();
+        completeContent.Add(new StringContent(publicKey), "UPLOADCARE_PUB_KEY");
+        completeContent.Add(new StringContent(upload.FileId), "uuid");
+        using var completeResponse = await _httpClient.PostAsync(MultipartCompleteUri, completeContent, cancellationToken);
+        await EnsureSuccessAsync(completeResponse, cancellationToken);
+        var completeBody = await completeResponse.Content.ReadAsStringAsync(cancellationToken);
+        var fileId = ReadMultipartCompleteFileId(completeBody);
+        return CreateResult(fileId);
+    }
+
+    private static MultipartFormDataContent CreateFormContent(string publicKey, SigningParameters? signing)
+    {
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(publicKey), "UPLOADCARE_PUB_KEY");
+        content.Add(new StringContent("auto"), "UPLOADCARE_STORE");
+        if (signing is { } parameters)
+        {
+            content.Add(new StringContent(parameters.Signature), "signature");
+            content.Add(new StringContent(parameters.Expire), "expire");
+        }
+
+        return content;
+    }
+
+    private static SigningParameters? CreateSigningParameters(string? secretKey)
+    {
+        if (string.IsNullOrWhiteSpace(secretKey))
+        {
+            return null;
+        }
+
+        var expire = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds()
+            .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secretKey));
+        var signature = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(expire))).ToLowerInvariant();
+        return new SigningParameters(signature, expire);
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        await response.Content.LoadIntoBufferAsync(cancellationToken);
+        throw new UploadcareUploadException(
+            $"Uploadcare rejected the upload ({(int)response.StatusCode} {response.ReasonPhrase}).");
+    }
+
+    private static MultipartStart ReadMultipartStart(string responseBody)
+    {
+        using var document = JsonDocument.Parse(responseBody);
+        var root = document.RootElement;
+        var fileId = ReadFileId(root, "uuid");
+        if (!root.TryGetProperty("parts", out var partsElement) ||
+            partsElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new UploadcareUploadException("Uploadcare returned an invalid multipart upload session.");
+        }
+
+        var parts = partsElement.EnumerateArray()
+            .Select(part => part.GetString())
+            .Where(part => Uri.TryCreate(part, UriKind.Absolute, out _))
+            .Cast<string>()
+            .ToList();
+        if (parts.Count == 0)
+        {
+            throw new UploadcareUploadException("Uploadcare returned an invalid multipart upload session.");
+        }
+
+        return new MultipartStart(fileId, parts);
+    }
+
+    private static string ReadDirectUploadFileId(string responseBody)
+    {
+        using var document = JsonDocument.Parse(responseBody);
+        foreach (var property in document.RootElement.EnumerateObject())
+        {
+            if (property.Value.ValueKind == JsonValueKind.String &&
+                IsFileId(property.Value.GetString()))
+            {
+                return property.Value.GetString()!;
+            }
+        }
+
+        throw new UploadcareUploadException("Uploadcare returned an invalid file identifier.");
+    }
+
+    private static string ReadMultipartCompleteFileId(string responseBody)
+    {
+        using var document = JsonDocument.Parse(responseBody);
+        return ReadFileId(document.RootElement, "uuid");
+    }
+
+    private static string ReadFileId(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.String &&
+            IsFileId(property.GetString()))
+        {
+            return property.GetString()!;
+        }
+
+        throw new UploadcareUploadException("Uploadcare returned an invalid file identifier.");
+    }
+
+    private static bool IsFileId(string? value) => Guid.TryParse(value, out _);
+
+    private static UploadcareUploadResult CreateResult(string fileId) =>
+        new(fileId, new Uri($"https://ucarecdn.com/{fileId}/", UriKind.Absolute));
+
+    private static string GetContentType(string extension) => extension.ToLowerInvariant() switch
+    {
+        ".png" => "image/png",
+        ".jpg" or ".jpeg" => "image/jpeg",
+        ".gif" => "image/gif",
+        ".mp4" => "video/mp4",
+        ".webp" => "image/webp",
+        _ => "application/octet-stream",
+    };
+
+    private sealed record SigningParameters(string Signature, string Expire);
+
+    private sealed record MultipartStart(string FileId, IReadOnlyList<string> Parts);
+
+    private sealed class FileRangeContent : HttpContent
+    {
+        private readonly string _path;
+        private readonly long _offset;
+        private readonly long _length;
+
+        public FileRangeContent(string path, long offset, long length)
+        {
+            _path = path;
+            _offset = offset;
+            _length = length;
+            Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _length;
+            return true;
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            await SerializeRangeAsync(stream, CancellationToken.None);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
+            SerializeRangeAsync(stream, cancellationToken);
+
+        private async Task SerializeRangeAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            await using var source = new FileStream(
+                _path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 81_920,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            source.Seek(_offset, SeekOrigin.Begin);
+            var remaining = _length;
+            var buffer = new byte[Math.Min(81_920, (int)Math.Min(remaining, 81_920))];
+            while (remaining > 0)
+            {
+                var read = await source.ReadAsync(buffer.AsMemory(0, (int)Math.Min(buffer.Length, remaining)), cancellationToken);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException("The capture changed while it was being uploaded.");
+                }
+
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                remaining -= read;
+            }
+        }
+    }
+}

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -23,6 +23,10 @@ public sealed class CaptureSettingsTests
         Assert.Equal(WebcamCornerPosition.BottomRight, settings.WebcamCornerPosition);
         Assert.Null(settings.WebcamCornerRadius);
         Assert.Equal(MultiMonitorCaptureMode.Picker, settings.MultiMonitorCaptureMode);
+        Assert.False(settings.UploadcareEnabled);
+        Assert.Equal(string.Empty, settings.UploadcarePublicKey);
+        Assert.False(settings.UploadcareAutoUpload);
+        Assert.False(settings.UploadcareCopyUrl);
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Screenshot));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Video));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Gif));
@@ -44,6 +48,10 @@ public sealed class CaptureSettingsTests
         settings.WebcamSizePreset = WebcamSizePreset.Large;
         settings.WebcamCornerPosition = WebcamCornerPosition.TopLeft;
         settings.WebcamCornerRadius = 16.0;
+        settings.UploadcareEnabled = true;
+        settings.UploadcarePublicKey = "public-key";
+        settings.UploadcareAutoUpload = true;
+        settings.UploadcareCopyUrl = true;
 
         Assert.False(settings.CopyScreenshotToClipboard);
         Assert.Equal(24.5, settings.GifFrameRate);
@@ -56,6 +64,10 @@ public sealed class CaptureSettingsTests
         Assert.Equal(WebcamSizePreset.Large, settings.WebcamSizePreset);
         Assert.Equal(WebcamCornerPosition.TopLeft, settings.WebcamCornerPosition);
         Assert.Equal(16.0, settings.WebcamCornerRadius);
+        Assert.True(settings.UploadcareEnabled);
+        Assert.Equal("public-key", settings.UploadcarePublicKey);
+        Assert.True(settings.UploadcareAutoUpload);
+        Assert.True(settings.UploadcareCopyUrl);
     }
 
     [Fact]

--- a/windows/tests/TinyClips.Core.Tests/UploadcareUploadServiceTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/UploadcareUploadServiceTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Text;
+using TinyClips.Core.Models;
+using TinyClips.Core.Services;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class UploadcareUploadServiceTests : IDisposable
+{
+    private readonly string _temporaryDirectory = Path.Combine(Path.GetTempPath(), $"TinyClips.Tests.{Guid.NewGuid():N}");
+
+    public UploadcareUploadServiceTests() => Directory.CreateDirectory(_temporaryDirectory);
+
+    [Fact]
+    public async Task UploadAsync_StreamsDirectUpload_AndDoesNotSendSecretKey()
+    {
+        var path = WriteFile("capture.png", "capture bytes");
+        var handler = new RecordingHandler(request =>
+        {
+            Assert.Equal("https://upload.uploadcare.com/base/", request.RequestUri!.ToString());
+            return JsonResponse("""{"capture.png":"22222222-2222-2222-2222-222222222222"}""");
+        });
+        using var client = new HttpClient(handler);
+        var service = CreateService(client, publicKey: "public-key", secretKey: "secret-key");
+
+        var result = await service.UploadAsync(path);
+
+        Assert.Equal("22222222-2222-2222-2222-222222222222", result.FileId);
+        Assert.Equal("https://ucarecdn.com/22222222-2222-2222-2222-222222222222/", result.DeliveryUri.AbsoluteUri);
+        var body = Assert.Single(handler.RequestBodies);
+        Assert.Contains("UPLOADCARE_PUB_KEY", body, StringComparison.Ordinal);
+        Assert.Contains("public-key", body, StringComparison.Ordinal);
+        Assert.Contains("signature", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-key", body, StringComparison.Ordinal);
+        Assert.Contains("capture bytes", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UploadAsync_UsesMultipartForFilesAtConfiguredLimit()
+    {
+        var path = WriteFileWithLength("capture.mp4", 8L * 1024 * 1024 + 1);
+        var requestPaths = new List<string>();
+        var handler = new RecordingHandler(request =>
+        {
+            requestPaths.Add(request.RequestUri!.AbsolutePath);
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/multipart/start/" => JsonResponse(
+                    """{"uuid":"33333333-3333-3333-3333-333333333333","parts":["https://parts.example/one","https://parts.example/two"]}"""),
+                "/one" or "/two" => new HttpResponseMessage(HttpStatusCode.OK),
+                "/multipart/complete/" => JsonResponse("""{"uuid":"33333333-3333-3333-3333-333333333333"}"""),
+                _ => throw new InvalidOperationException($"Unexpected request: {request.RequestUri}"),
+            };
+        });
+        using var client = new HttpClient(handler);
+        var service = CreateService(client, publicKey: "public-key", directUploadLimitBytes: 1);
+
+        var result = await service.UploadAsync(path);
+
+        Assert.Equal("33333333-3333-3333-3333-333333333333", result.FileId);
+        Assert.Equal(
+            new[] { "/multipart/start/", "/one", "/two", "/multipart/complete/" },
+            requestPaths);
+    }
+
+    [Fact]
+    public async Task UploadAsync_RejectsMissingPublicKeyBeforeMakingRequest()
+    {
+        var handler = new RecordingHandler(_ => throw new InvalidOperationException("No request expected."));
+        using var client = new HttpClient(handler);
+        var service = CreateService(client, publicKey: string.Empty);
+
+        var exception = await Assert.ThrowsAsync<UploadcareUploadException>(
+            () => service.UploadAsync(WriteFile("capture.gif", "file")));
+
+        Assert.Equal("Enter an Uploadcare public key before uploading.", exception.Message);
+        Assert.Empty(handler.RequestBodies);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_temporaryDirectory, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private UploadcareUploadService CreateService(
+        HttpClient client,
+        string publicKey,
+        string? secretKey = null,
+        long directUploadLimitBytes = 100L * 1024 * 1024)
+    {
+        var settings = new CaptureSettings(new TestSettingsService())
+        {
+            UploadcarePublicKey = publicKey,
+        };
+        return new UploadcareUploadService(
+            client,
+            settings,
+            new TestCredentialStore(secretKey),
+            directUploadLimitBytes);
+    }
+
+    private string WriteFile(string fileName, string contents)
+    {
+        var path = Path.Combine(_temporaryDirectory, fileName);
+        File.WriteAllText(path, contents, Encoding.UTF8);
+        return path;
+    }
+
+    private string WriteFileWithLength(string fileName, long length)
+    {
+        var path = Path.Combine(_temporaryDirectory, fileName);
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write);
+        stream.SetLength(length);
+        return path;
+    }
+
+    private static HttpResponseMessage JsonResponse(string content) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null && request.RequestUri?.AbsolutePath == "/base/")
+            {
+                RequestBodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            }
+
+            return responseFactory(request);
+        }
+    }
+
+    private sealed class TestCredentialStore(string? secretKey) : IUploadcareCredentialStore
+    {
+        private string? _secretKey = secretKey;
+
+        public string? GetSecretKey() => _secretKey;
+
+        public void SaveSecretKey(string secretKey) => _secretKey = secretKey;
+
+        public void RemoveSecretKey() => _secretKey = null;
+
+        public bool HasSecretKey() => !string.IsNullOrWhiteSpace(_secretKey);
+    }
+
+    private sealed class TestSettingsService : ISettingsService
+    {
+        private readonly Dictionary<string, object> _values = new(StringComparer.Ordinal);
+
+        public AppTheme Theme { get; set; }
+
+        public string SaveDirectory { get; set; } = string.Empty;
+
+        public T Get<T>(string key, T defaultValue) =>
+            _values.TryGetValue(key, out var value) && value is T typedValue ? typedValue : defaultValue;
+
+        public void Set<T>(string key, T value) => _values[key] = value!;
+    }
+}


### PR DESCRIPTION
## Summary
- add secure Uploadcare configuration and Windows Credential Locker secret storage
- stream direct and multipart uploads with automatic final-save uploads
- add Clips Library upload, copy URL, and open URL actions

Closes #148