### PR TITLE
Handle unexpected ScreenCaptureKit stream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.
 - Fixed macOS shortcut changes silently accepting unavailable or conflicting global hotkeys; Settings now validates conflicts and keeps the prior working shortcut when registration fails.
+- Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.

--- a/mac/TinyClips/Capture/GifWriter.swift
+++ b/mac/TinyClips/Capture/GifWriter.swift
@@ -10,8 +10,10 @@ class GifWriter: NSObject, @unchecked Sendable {
     private var frameDelay: Double = 0.1
     private var maxWidth: CGFloat = 640
     private var isPaused = false
+    private var didReportStreamFailure = false
     private let processingQueue = DispatchQueue(label: "com.tinyclips.gif-processing")
     private let ciContext = CIContext()
+    var onStreamFailure: ((Error) -> Void)?
 
     func start(target: CaptureTarget) async throws {
         debugLifecycle("start requested")
@@ -29,11 +31,12 @@ class GifWriter: NSObject, @unchecked Sendable {
         config.queueDepth = 5
 
         frames = []
+        didReportStreamFailure = false
 
-        let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: processingQueue)
-        try await stream.startCapture()
         self.stream = stream
+        try await stream.startCapture()
         debugLifecycle("stream started")
     }
 
@@ -65,6 +68,18 @@ class GifWriter: NSObject, @unchecked Sendable {
         return GifCaptureData(frames: capturedFrames, frameDelay: frameDelay, maxWidth: maxWidth)
     }
 
+    func finishAfterStreamFailure() throws -> GifCaptureData {
+        debugLifecycle("finalizing after stream failure")
+        stream = nil
+
+        let capturedFrames = processingQueue.sync { self.frames }
+        guard !capturedFrames.isEmpty else {
+            throw CaptureError.noFrames
+        }
+
+        return GifCaptureData(frames: capturedFrames, frameDelay: frameDelay, maxWidth: maxWidth)
+    }
+
     func pause() {
         processingQueue.async {
             self.isPaused = true
@@ -83,6 +98,7 @@ class GifWriter: NSObject, @unchecked Sendable {
         processingQueue.sync {
             frames.removeAll()
             isPaused = false
+            didReportStreamFailure = false
         }
     }
 
@@ -151,7 +167,7 @@ class GifWriter: NSObject, @unchecked Sendable {
     }
 }
 
-extension GifWriter: SCStreamOutput {
+extension GifWriter: SCStreamOutput, SCStreamDelegate {
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .screen, sampleBuffer.isValid else { return }
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
@@ -161,5 +177,14 @@ extension GifWriter: SCStreamOutput {
 
         guard !isPaused else { return }
         frames.append(cgImage)
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        processingQueue.async { [weak self] in
+            guard let self, self.stream === stream, !self.didReportStreamFailure else { return }
+            self.didReportStreamFailure = true
+            self.debugLifecycle("stream stopped unexpectedly: \(error.localizedDescription)")
+            self.onStreamFailure?(error)
+        }
     }
 }

--- a/mac/TinyClips/Capture/GifWriter.swift
+++ b/mac/TinyClips/Capture/GifWriter.swift
@@ -36,7 +36,12 @@ class GifWriter: NSObject, @unchecked Sendable {
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: processingQueue)
         self.stream = stream
-        try await stream.startCapture()
+        do {
+            try await stream.startCapture()
+        } catch {
+            self.stream = nil
+            throw error
+        }
         debugLifecycle("stream started")
     }
 

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -319,6 +319,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     private var selectedMicrophoneID = ""
     private var outputURL: URL?
     private var recordingStartedAtUptime: TimeInterval?
+    private var didReportStreamFailure = false
     /// Presentation timestamp (host-clock based) of the first screen frame written.
     /// Used to align the separately-recorded webcam track to the audio timeline.
     private(set) var firstScreenSampleTime: CMTime?
@@ -328,6 +329,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     var onMicrophoneWarning: ((String?) -> Void)?
     var onMicrophoneDeviceName: ((String) -> Void)?
     var onMicrophoneError: ((String) -> Void)?
+    var onStreamFailure: ((Error) -> Void)?
 
     var isMicrophoneCaptureActive: Bool {
         microphoneSession != nil && recordMicrophone
@@ -420,16 +422,17 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         self.writer = writer
         self.videoInput = videoInput
         self.hasStartedWriting = false
+        self.didReportStreamFailure = false
 
         do {
-            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            let stream = SCStream(filter: filter, configuration: config, delegate: self)
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: writingQueue)
             if recordSystemAudio {
                 try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: writingQueue)
             }
+            self.stream = stream
             try await stream.startCapture()
             recordingStartedAtUptime = ProcessInfo.processInfo.systemUptime
-            self.stream = stream
             debugLifecycle("stream started")
 
             if recordMicrophone {
@@ -603,11 +606,31 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         stream = nil
         debugLifecycle("stream stopped")
 
+        return try await finishWriting(removeOutputIfEmpty: false)
+    }
+
+    func finishAfterStreamFailure() async throws -> URL {
+        defer { recordingStartedAtUptime = nil }
+        debugLifecycle("finalizing after stream failure")
+
+        stopMicrophoneCapture()
+        stream = nil
+
+        return try await finishWriting(removeOutputIfEmpty: true)
+    }
+
+    private func finishWriting(removeOutputIfEmpty: Bool) async throws -> URL {
         guard let writer, let videoInput, let outputURL else {
             throw CaptureError.saveFailed
         }
 
         guard hasStartedWriting else {
+            writingQueue.sync {
+                writer.cancelWriting()
+            }
+            if removeOutputIfEmpty {
+                try? FileManager.default.removeItem(at: outputURL)
+            }
             throw CaptureError.noFrames
         }
 
@@ -720,6 +743,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         }
         outputURL = nil
         recordingStartedAtUptime = nil
+        didReportStreamFailure = false
     }
 
     private func debugLifecycle(_ message: String) {
@@ -745,7 +769,7 @@ private final class MicrophoneOutputDelegate: NSObject, AVCaptureAudioDataOutput
     }
 }
 
-extension VideoRecorder: SCStreamOutput {
+extension VideoRecorder: SCStreamOutput, SCStreamDelegate {
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard sampleBuffer.isValid else { return }
         guard let writer else { return }
@@ -822,5 +846,14 @@ extension VideoRecorder: SCStreamOutput {
             sampleBufferOut: &adjusted
         )
         return copyStatus == noErr ? adjusted : sampleBuffer
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        writingQueue.async { [weak self] in
+            guard let self, self.stream === stream, !self.didReportStreamFailure else { return }
+            self.didReportStreamFailure = true
+            self.debugLifecycle("stream stopped unexpectedly: \(error.localizedDescription)")
+            self.onStreamFailure?(error)
+        }
     }
 }

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -709,6 +709,9 @@ class CaptureManager: ObservableObject {
                         recordMicrophone: microphone,
                         selectedMicrophoneID: selectedMicrophoneID
                     )
+                    guard self.activeRecordingSessionID == sessionID else {
+                        return
+                    }
                     self.debugRecordingLifecycle("Video session \(sessionID) started")
                     self.recordingSystemAudioEnabled = recorder.isSystemAudioCaptureActive
                     self.recordingMicrophoneEnabled = recorder.isMicrophoneCaptureActive
@@ -719,6 +722,10 @@ class CaptureManager: ObservableObject {
                                 outputURL: webcamOutputURL,
                                 selectedWebcamID: webcamSelection.deviceID
                             )
+                            guard self.activeRecordingSessionID == sessionID else {
+                                await webcamRecorder.cancel()
+                                return
+                            }
                             self.webcamRecorder = webcamRecorder
                             self.showWebcamPreview(
                                 session: webcamRecorder.previewSession,
@@ -727,6 +734,9 @@ class CaptureManager: ObservableObject {
                             )
                             self.debugRecordingLifecycle("Webcam session started at \(webcamOutputURL.path)")
                         } catch {
+                            guard self.activeRecordingSessionID == sessionID else {
+                                return
+                            }
                             self.webcamRecorder = nil
                             self.activeWebcamName = nil
                             self.activeWebcamOverlaySelection = nil
@@ -735,6 +745,9 @@ class CaptureManager: ObservableObject {
                         }
                     }
 
+                    guard self.activeRecordingSessionID == sessionID else {
+                        return
+                    }
                     self.showStopPanel()
                     self.scheduleVideoAutoStopIfNeeded(timeLimitMinutes: timeLimitMinutes, sessionID: sessionID)
                 } catch {
@@ -821,6 +834,9 @@ class CaptureManager: ObservableObject {
                     self.startMouseClickMonitoringIfNeeded(for: .gif, region: target.region)
 
                     try await writer.start(target: target)
+                    guard self.activeRecordingSessionID == sessionID else {
+                        return
+                    }
                     self.debugRecordingLifecycle("GIF session \(sessionID) started")
                     self.showStopPanel()
                 } catch {
@@ -1056,6 +1072,8 @@ class CaptureManager: ObservableObject {
 
         var savedVideoURL: URL?
         var savedWebcamURL: URL?
+        var partialOutputSaveError: String?
+        var noPartialFramesWereCaptured = false
 
         if let recorder = webcamRecorderAtStop {
             do {
@@ -1083,6 +1101,10 @@ class CaptureManager: ObservableObject {
             } catch {
                 if streamFailureMessage == nil {
                     SaveService.shared.showError("Video save failed: \(error.localizedDescription)")
+                } else if let captureError = error as? CaptureError, case .noFrames = captureError {
+                    noPartialFramesWereCaptured = true
+                } else {
+                    partialOutputSaveError = error.localizedDescription
                 }
             }
 
@@ -1189,6 +1211,19 @@ class CaptureManager: ObservableObject {
                 videoRecorder = nil
             } else {
                 debugRecordingLifecycle("Skipped clearing stale video recorder reference")
+            }
+        }
+
+        if streamFailureMessage != nil,
+           let currentURL = savedVideoURL,
+           currentURL.deletingLastPathComponent().standardizedFileURL == TinyClipsTemporaryFiles.directoryURL.standardizedFileURL {
+            let recoveryURL = SaveService.shared.generateURL(for: .video)
+            do {
+                try FileManager.default.moveItem(at: currentURL, to: recoveryURL)
+                savedVideoURL = recoveryURL
+            } catch {
+                savedVideoURL = nil
+                partialOutputSaveError = error.localizedDescription
             }
         }
 
@@ -1352,6 +1387,10 @@ class CaptureManager: ObservableObject {
             } catch {
                 if streamFailureMessage == nil {
                     SaveService.shared.showError("GIF save failed: \(error.localizedDescription)")
+                } else if let captureError = error as? CaptureError, case .noFrames = captureError {
+                    noPartialFramesWereCaptured = true
+                } else {
+                    partialOutputSaveError = error.localizedDescription
                 }
             }
             if gifWriter === writer {
@@ -1394,9 +1433,16 @@ class CaptureManager: ObservableObject {
 
         if let streamFailureMessage {
             let didSavePartialOutput = savedVideoURL != nil || savedGifURL != nil
-            let partialOutputMessage = didSavePartialOutput
-                ? "A partial recording was saved."
-                : "No captured frames could be saved."
+            let partialOutputMessage: String
+            if didSavePartialOutput {
+                partialOutputMessage = "A partial recording was saved."
+            } else if let partialOutputSaveError {
+                partialOutputMessage = "Tiny Clips could not save the partial recording: \(partialOutputSaveError)"
+            } else if noPartialFramesWereCaptured {
+                partialOutputMessage = "No captured frames could be saved."
+            } else {
+                partialOutputMessage = "No partial recording could be saved."
+            }
             SaveService.shared.showError(
                 "Screen capture stopped unexpectedly. \(partialOutputMessage) Check Screen Recording permission in System Settings, then start a new recording. Details: \(streamFailureMessage)"
             )

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -632,6 +632,16 @@ class CaptureManager: ObservableObject {
                     let sessionID = self.nextRecordingSessionID()
                     self.activeRecordingSessionID = sessionID
                     self.debugRecordingLifecycle("Starting video session \(sessionID)")
+                    recorder.onStreamFailure = { [weak self] error in
+                        let message = error.localizedDescription
+                        Task { @MainActor [weak self] in
+                            self?.handleStreamFailure(
+                                for: sessionID,
+                                type: .video,
+                                message: message
+                            )
+                        }
+                    }
                     recorder.onMicrophoneLevel = { [weak self] level in
                         DispatchQueue.main.async {
                             self?.microphoneLevel = level
@@ -792,6 +802,16 @@ class CaptureManager: ObservableObject {
                     let sessionID = self.nextRecordingSessionID()
                     self.activeRecordingSessionID = sessionID
                     self.debugRecordingLifecycle("Starting GIF session \(sessionID)")
+                    writer.onStreamFailure = { [weak self] error in
+                        let message = error.localizedDescription
+                        Task { @MainActor [weak self] in
+                            self?.handleStreamFailure(
+                                for: sessionID,
+                                type: .gif,
+                                message: message
+                            )
+                        }
+                    }
                     self.gifWriter = writer
                     self.activeRecordingRegion = target.region
                     self.isRecording = true
@@ -827,6 +847,10 @@ class CaptureManager: ObservableObject {
     }
 
     func stopRecording() {
+        stopRecording(streamFailureMessage: nil)
+    }
+
+    private func stopRecording(streamFailureMessage: String?) {
         // Tear down all recording UI synchronously so the user sees an
         // immediate response (menu bar icon flips, stop panel, webcam preview,
         // and region indicator disappear, stop hotkey unregisters) regardless of
@@ -849,13 +873,30 @@ class CaptureManager: ObservableObject {
         let stoppingSessionID = activeRecordingSessionID
         activeRecordingSessionID = nil
         finalizingSessionID = stoppingSessionID
-        debugRecordingLifecycle("Stopping session \(stoppingSessionID.map(String.init) ?? "unknown")")
+        if let streamFailureMessage {
+            debugRecordingLifecycle("Stopping session \(stoppingSessionID.map(String.init) ?? "unknown") after stream failure: \(streamFailureMessage)")
+        } else {
+            debugRecordingLifecycle("Stopping session \(stoppingSessionID.map(String.init) ?? "unknown")")
+        }
 
         let task = Task<Void, Never> { [weak self] in
             guard let self else { return }
-            await self.stopRecordingFlow(stoppingSessionID: stoppingSessionID)
+            await self.stopRecordingFlow(
+                stoppingSessionID: stoppingSessionID,
+                streamFailureMessage: streamFailureMessage
+            )
         }
         stopRecordingTask = task
+    }
+
+    private func handleStreamFailure(for sessionID: UInt64, type: CaptureType, message: String) {
+        guard activeRecordingSessionID == sessionID, !isStoppingRecording, finalizingSessionID != sessionID else {
+            debugRecordingLifecycle("Ignored stale \(type.label.lowercased()) stream failure for session \(sessionID)")
+            return
+        }
+
+        debugRecordingLifecycle("\(type.label) stream failed for session \(sessionID): \(message)")
+        stopRecording(streamFailureMessage: message)
     }
 
     func togglePauseRecording() {
@@ -953,7 +994,7 @@ class CaptureManager: ObservableObject {
         await writer?.cancel()
     }
 
-    private func stopRecordingFlow(stoppingSessionID: UInt64?) async {
+    private func stopRecordingFlow(stoppingSessionID: UInt64?, streamFailureMessage: String? = nil) async {
         defer {
             isStoppingRecording = false
             if finalizingSessionID == stoppingSessionID {
@@ -1001,9 +1042,9 @@ class CaptureManager: ObservableObject {
         // Snapshot video settings before any suspension so that overlay output URL
         // selection and downstream trimmer/save decisions stay consistent even if
         // the user changes preferences while export is in progress.
-        let videoShowTrimmer = CaptureSettings.shared.showTrimmer
-        let videoShouldSaveImmediately = !videoShowTrimmer || CaptureSettings.shared.saveImmediatelyVideo
-        let shouldReturnToPickerAfterRecording = self.shouldReturnToPickerAfterRecording
+        let videoShowTrimmer = streamFailureMessage == nil && CaptureSettings.shared.showTrimmer
+        let videoShouldSaveImmediately = streamFailureMessage != nil || !videoShowTrimmer || CaptureSettings.shared.saveImmediatelyVideo
+        let shouldReturnToPickerAfterRecording = streamFailureMessage == nil && self.shouldReturnToPickerAfterRecording
         let videoOverlayStyle = CaptureSettings.shared.mouseClickOverlayStyle(for: .video)
         let showBrandingOverlay = CaptureSettings.shared.showBrandingOverlay
         let webcamShapeSetting = CaptureSettings.shared.webcamShape
@@ -1033,10 +1074,16 @@ class CaptureManager: ObservableObject {
         if let recorder = videoRecorderAtStop {
             do {
                 updateProcessingProgress(0.15, status: "Exporting video...")
-                savedVideoURL = try await recorder.stop()
+                savedVideoURL = try await (
+                    streamFailureMessage == nil
+                        ? recorder.stop()
+                        : recorder.finishAfterStreamFailure()
+                )
                 updateProcessingProgress(0.55, status: "Applying overlays...")
             } catch {
-                SaveService.shared.showError("Video save failed: \(error.localizedDescription)")
+                if streamFailureMessage == nil {
+                    SaveService.shared.showError("Video save failed: \(error.localizedDescription)")
+                }
             }
 
             if let currentURL = savedVideoURL,
@@ -1158,15 +1205,17 @@ class CaptureManager: ObservableObject {
         activeWebcamOverlaySelection = nil
         self.webcamPositionEvents = []
 
+        var savedGifURL: URL?
         if let writer = gifWriterAtStop {
             let url = SaveService.shared.generateURL(for: .gif)
             do {
                 let settings = CaptureSettings.shared
-                let shouldSaveImmediately = !settings.showGifTrimmer || settings.saveImmediatelyGif
+                let gifShowTrimmer = streamFailureMessage == nil && settings.showGifTrimmer
+                let shouldSaveImmediately = streamFailureMessage != nil || !gifShowTrimmer || settings.saveImmediatelyGif
 
                 updateProcessingProgress(0.1, status: "Exporting GIF…")
 
-                if settings.showGifTrimmer {
+                if gifShowTrimmer {
                     var gifData = try await writer.stopAndReturnData()
                     updateProcessingProgress(0.5, status: "Applying overlays…")
 
@@ -1217,7 +1266,20 @@ class CaptureManager: ObservableObject {
                         reopenPickerAfterClose: shouldReturnToPickerAfterRecording
                     )
                 } else {
-                    try await writer.stop(outputURL: url)
+                    if streamFailureMessage == nil {
+                        try await writer.stop(outputURL: url)
+                    } else {
+                        let gifData = try writer.finishAfterStreamFailure()
+                        try await Self.runOffMainThrowing {
+                            try GifWriter.writeGIF(
+                                frames: gifData.frames,
+                                frameDelay: gifData.frameDelay,
+                                maxWidth: gifData.maxWidth,
+                                to: url
+                            )
+                        }
+                    }
+                    savedGifURL = url
                     updateProcessingProgress(0.5, status: "Applying overlays…")
 
                     if let capturedMouseClickData,
@@ -1288,7 +1350,9 @@ class CaptureManager: ObservableObject {
                     }
                 }
             } catch {
-                SaveService.shared.showError("GIF save failed: \(error.localizedDescription)")
+                if streamFailureMessage == nil {
+                    SaveService.shared.showError("GIF save failed: \(error.localizedDescription)")
+                }
             }
             if gifWriter === writer {
                 gifWriter = nil
@@ -1327,6 +1391,16 @@ class CaptureManager: ObservableObject {
         }
 
         dismissProcessingIndicator()
+
+        if let streamFailureMessage {
+            let didSavePartialOutput = savedVideoURL != nil || savedGifURL != nil
+            let partialOutputMessage = didSavePartialOutput
+                ? "A partial recording was saved."
+                : "No captured frames could be saved."
+            SaveService.shared.showError(
+                "Screen capture stopped unexpectedly. \(partialOutputMessage) Check Screen Recording permission in System Settings, then start a new recording. Details: \(streamFailureMessage)"
+            )
+        }
     }
 
     private func prepareForNewCaptureRequest() async {


### PR DESCRIPTION
## Summary
- recover video and GIF recordings when ScreenCaptureKit unexpectedly stops a stream
- finalize and save partial captures when frames are available, then remove recording UI state
- show an actionable Screen Recording permission recovery error

Closes #213

## Validation
- xcodebuild TinyClips Debug (codesigning disabled)
- xcodebuild TinyClipsMAS Debug (codesigning disabled)