### PR TITLE
Prevent display sleep while recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - macOS and Windows CI workflows now always report a successful check when their platform-specific files are unchanged, while skipping the unnecessary build work.
 
 ### Fixed
+- Fixed macOS video and GIF recordings allowing the display to idle-sleep or start the screen saver during capture.
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.
 - Fixed macOS shortcut changes silently accepting unavailable or conflicting global hotkeys; Settings now validates conflicts and keeps the prior working shortcut when registration fails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - macOS capture settings now offer matching before/after picker controls for screenshots, video recordings, and GIF recordings.
 - macOS multi-monitor capture settings now let you choose to ask every time, capture the display under the cursor, or capture the main display.
 - macOS and Windows CI workflows now always report a successful check when their platform-specific files are unchanged, while skipping the unnecessary build work.
+- macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
 - Fixed macOS video and GIF recordings allowing the display to idle-sleep or start the screen saver during capture.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		B10000000000000000000036 /* ScreenshotEditorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000036 /* ScreenshotEditorControls.swift */; };
 		B10000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000037 /* ScreenshotEditorCanvas.swift */; };
 		B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
+		B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B20000000000000000000001 /* TinyClipsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000001 /* TinyClipsApp.swift */; };
 		B20000000000000000000002 /* CaptureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* CaptureSettings.swift */; };
 		B20000000000000000000003 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* SettingsView.swift */; };
@@ -85,6 +86,7 @@
 		B20000000000000000000036 /* ScreenshotEditorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000036 /* ScreenshotEditorControls.swift */; };
 		B20000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000037 /* ScreenshotEditorCanvas.swift */; };
 		B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
+		B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B10000000000000000000021 /* CaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* CaptureManager.swift */; };
 		B10000000000000000000022 /* MenuBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* MenuBarViews.swift */; };
 		B10000000000000000000023 /* ProcessingIndicatorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* ProcessingIndicatorWindow.swift */; };
@@ -157,6 +159,7 @@
 		A10000000000000000000036 /* ScreenshotEditorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorControls.swift; sourceTree = "<group>"; };
 		A10000000000000000000037 /* ScreenshotEditorCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorCanvas.swift; sourceTree = "<group>"; };
 		A10000000000000000000038 /* ScreenshotEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorViewModel.swift; sourceTree = "<group>"; };
+		A10000000000000000000039 /* IdleSleepAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleSleepAssertion.swift; sourceTree = "<group>"; };
 		A10000000000000000000024 /* CaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000025 /* MenuBarViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViews.swift; sourceTree = "<group>"; };
 		A10000000000000000000026 /* ProcessingIndicatorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingIndicatorWindow.swift; sourceTree = "<group>"; };
@@ -295,6 +298,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000000000000000000009 /* SaveService.swift */,
+				A10000000000000000000039 /* IdleSleepAssertion.swift */,
 				A10000000000000000000032 /* CaptureAnalyticsStore.swift */,
 				A1000000000000000000000A /* PermissionManager.swift */,
 				A1000000000000000000000F /* SparkleController.swift */,
@@ -433,6 +437,7 @@
 				B10000000000000000000036 /* ScreenshotEditorControls.swift in Sources */,
 				B10000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */,
 				B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
+				B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
 				B1000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B10000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B10000000000000000000011 /* CountdownWindow.swift in Sources */,
@@ -491,6 +496,7 @@
 				B20000000000000000000036 /* ScreenshotEditorControls.swift in Sources */,
 				B20000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */,
 				B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
+				B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
 				B2000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B20000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B20000000000000000000011 /* CountdownWindow.swift in Sources */,

--- a/mac/TinyClips/Capture/GifWriter.swift
+++ b/mac/TinyClips/Capture/GifWriter.swift
@@ -12,6 +12,7 @@ class GifWriter: NSObject, @unchecked Sendable {
     private var isPaused = false
     private let processingQueue = DispatchQueue(label: "com.tinyclips.gif-processing")
     private let ciContext = CIContext()
+    var onStreamError: ((Error) -> Void)?
 
     func start(target: CaptureTarget) async throws {
         debugLifecycle("start requested")
@@ -30,7 +31,7 @@ class GifWriter: NSObject, @unchecked Sendable {
 
         frames = []
 
-        let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: processingQueue)
         try await stream.startCapture()
         self.stream = stream
@@ -151,7 +152,11 @@ class GifWriter: NSObject, @unchecked Sendable {
     }
 }
 
-extension GifWriter: SCStreamOutput {
+extension GifWriter: SCStreamOutput, SCStreamDelegate {
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        onStreamError?(error)
+    }
+
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .screen, sampleBuffer.isValid else { return }
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -328,6 +328,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     var onMicrophoneWarning: ((String?) -> Void)?
     var onMicrophoneDeviceName: ((String) -> Void)?
     var onMicrophoneError: ((String) -> Void)?
+    var onStreamError: ((Error) -> Void)?
 
     var isMicrophoneCaptureActive: Bool {
         microphoneSession != nil && recordMicrophone
@@ -422,7 +423,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         self.hasStartedWriting = false
 
         do {
-            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            let stream = SCStream(filter: filter, configuration: config, delegate: self)
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: writingQueue)
             if recordSystemAudio {
                 try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: writingQueue)
@@ -745,7 +746,11 @@ private final class MicrophoneOutputDelegate: NSObject, AVCaptureAudioDataOutput
     }
 }
 
-extension VideoRecorder: SCStreamOutput {
+extension VideoRecorder: SCStreamOutput, SCStreamDelegate {
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        onStreamError?(error)
+    }
+
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard sampleBuffer.isValid else { return }
         guard let writer else { return }

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -705,7 +705,9 @@ class CaptureManager: ObservableObject {
                         recordMicrophone: microphone,
                         selectedMicrophoneID: selectedMicrophoneID
                     )
-                    try self.idleSleepAssertion.begin()
+                    if CaptureSettings.shared.preventDisplaySleepWhileRecording {
+                        try self.idleSleepAssertion.begin()
+                    }
                     self.debugRecordingLifecycle("Video session \(sessionID) started")
                     self.recordingSystemAudioEnabled = recorder.isSystemAudioCaptureActive
                     self.recordingMicrophoneEnabled = recorder.isMicrophoneCaptureActive
@@ -817,7 +819,9 @@ class CaptureManager: ObservableObject {
                     self.startMouseClickMonitoringIfNeeded(for: .gif, region: target.region)
 
                     try await writer.start(target: target)
-                    try self.idleSleepAssertion.begin()
+                    if CaptureSettings.shared.preventDisplaySleepWhileRecording {
+                        try self.idleSleepAssertion.begin()
+                    }
                     self.debugRecordingLifecycle("GIF session \(sessionID) started")
                     self.showStopPanel()
                 } catch {

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -705,6 +705,12 @@ class CaptureManager: ObservableObject {
                         recordMicrophone: microphone,
                         selectedMicrophoneID: selectedMicrophoneID
                     )
+                    guard self.isRecording,
+                          self.activeRecordingSessionID == sessionID,
+                          self.videoRecorder === recorder else {
+                        await recorder.cancel()
+                        return
+                    }
                     if CaptureSettings.shared.preventDisplaySleepWhileRecording {
                         try self.idleSleepAssertion.begin()
                     }
@@ -819,6 +825,12 @@ class CaptureManager: ObservableObject {
                     self.startMouseClickMonitoringIfNeeded(for: .gif, region: target.region)
 
                     try await writer.start(target: target)
+                    guard self.isRecording,
+                          self.activeRecordingSessionID == sessionID,
+                          self.gifWriter === writer else {
+                        await writer.cancel()
+                        return
+                    }
                     if CaptureSettings.shared.preventDisplaySleepWhileRecording {
                         try self.idleSleepAssertion.begin()
                     }

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -142,6 +142,7 @@ class CaptureManager: ObservableObject {
     private var videoRecorder: VideoRecorder?
     private var webcamRecorder: WebcamRecorder?
     private var gifWriter: GifWriter?
+    private let idleSleepAssertion = IdleSleepAssertion()
     private(set) var lastVideoRecordingArtifacts: VideoRecordingArtifacts?
     private var screenshotPickerPanel: CapturePickerPanel?
     private var screenshotPickerPosition: NSPoint?
@@ -627,8 +628,9 @@ class CaptureManager: ObservableObject {
                     ? [.init(time: .zero, corner: webcamSelection.corner)]
                     : []
 
+                let recorder = VideoRecorder()
+                let webcamRecorder = WebcamRecorder()
                 do {
-                    let recorder = VideoRecorder()
                     let sessionID = self.nextRecordingSessionID()
                     self.activeRecordingSessionID = sessionID
                     self.debugRecordingLifecycle("Starting video session \(sessionID)")
@@ -653,8 +655,12 @@ class CaptureManager: ObservableObject {
                             SaveService.shared.showError("Microphone error: \(message)")
                         }
                     }
+                    recorder.onStreamError = { [weak self] error in
+                        DispatchQueue.main.async {
+                            self?.handleRecordingStreamFailure(error, sessionID: sessionID)
+                        }
+                    }
 
-                    let webcamRecorder = WebcamRecorder()
                     webcamRecorder.onWebcamDeviceName = { [weak self] name in
                         DispatchQueue.main.async {
                             self?.activeWebcamName = name.isEmpty ? nil : name
@@ -699,6 +705,7 @@ class CaptureManager: ObservableObject {
                         recordMicrophone: microphone,
                         selectedMicrophoneID: selectedMicrophoneID
                     )
+                    try self.idleSleepAssertion.begin()
                     self.debugRecordingLifecycle("Video session \(sessionID) started")
                     self.recordingSystemAudioEnabled = recorder.isSystemAudioCaptureActive
                     self.recordingMicrophoneEnabled = recorder.isMicrophoneCaptureActive
@@ -728,6 +735,9 @@ class CaptureManager: ObservableObject {
                     self.showStopPanel()
                     self.scheduleVideoAutoStopIfNeeded(timeLimitMinutes: timeLimitMinutes, sessionID: sessionID)
                 } catch {
+                    self.endIdleSleepAssertion()
+                    await recorder.cancel()
+                    await webcamRecorder.cancel()
                     self.cancelVideoAutoStopTask()
                     _ = self.stopMouseClickMonitoring()
                     self.activeMouseClickCaptureEnabledOverride = nil
@@ -739,6 +749,7 @@ class CaptureManager: ObservableObject {
                     self.activeRecordingRegion = nil
                     self.dismissRegionIndicator()
                     self.activeRecordingSessionID = nil
+                    self.videoRecorder = nil
                     self.webcamRecorder = nil
                     self.activeWebcamOverlaySelection = nil
                     self.webcamPositionEvents = []
@@ -787,11 +798,16 @@ class CaptureManager: ObservableObject {
                 countdownCompleted: countdownEnabled
             )
             Task {
+                let writer = GifWriter()
                 do {
-                    let writer = GifWriter()
                     let sessionID = self.nextRecordingSessionID()
                     self.activeRecordingSessionID = sessionID
                     self.debugRecordingLifecycle("Starting GIF session \(sessionID)")
+                    writer.onStreamError = { [weak self] error in
+                        DispatchQueue.main.async {
+                            self?.handleRecordingStreamFailure(error, sessionID: sessionID)
+                        }
+                    }
                     self.gifWriter = writer
                     self.activeRecordingRegion = target.region
                     self.isRecording = true
@@ -801,9 +817,12 @@ class CaptureManager: ObservableObject {
                     self.startMouseClickMonitoringIfNeeded(for: .gif, region: target.region)
 
                     try await writer.start(target: target)
+                    try self.idleSleepAssertion.begin()
                     self.debugRecordingLifecycle("GIF session \(sessionID) started")
                     self.showStopPanel()
                 } catch {
+                    self.endIdleSleepAssertion()
+                    await writer.cancel()
                     _ = self.stopMouseClickMonitoring()
                     self.activeMouseClickCaptureEnabledOverride = nil
                     self.isRecording = false
@@ -812,6 +831,7 @@ class CaptureManager: ObservableObject {
                     self.activeRecordingRegion = nil
                     self.dismissRegionIndicator()
                     self.activeRecordingSessionID = nil
+                    self.gifWriter = nil
                     self.debugRecordingLifecycle("GIF session failed to start: \(error.localizedDescription)")
                     SaveService.shared.showError("GIF recording failed: \(error.localizedDescription)")
                 }
@@ -846,6 +866,7 @@ class CaptureManager: ObservableObject {
         isRecording = false
         isRecordingPaused = false
         activeRecordingRequest = nil
+        endIdleSleepAssertion()
         let stoppingSessionID = activeRecordingSessionID
         activeRecordingSessionID = nil
         finalizingSessionID = stoppingSessionID
@@ -923,6 +944,7 @@ class CaptureManager: ObservableObject {
     private func discardRecording(clearActiveRequest: Bool) async {
         dismissWebcamPreview()
         dismissRegionIndicator()
+        endIdleSleepAssertion()
         guard isRecording || videoRecorder != nil || webcamRecorder != nil || gifWriter != nil else { return }
         cancelVideoAutoStopTask()
         dismissStopPanel()
@@ -1360,6 +1382,7 @@ class CaptureManager: ObservableObject {
         }
 
         if videoRecorder != nil || webcamRecorder != nil || gifWriter != nil || isRecording {
+            endIdleSleepAssertion()
             isStoppingRecording = true
             let stoppingSessionID = activeRecordingSessionID
             activeRecordingSessionID = nil
@@ -1368,6 +1391,22 @@ class CaptureManager: ObservableObject {
             await stopRecordingFlow(stoppingSessionID: stoppingSessionID)
         } else {
             dismissStopPanel()
+        }
+    }
+
+    private func handleRecordingStreamFailure(_ error: Error, sessionID: UInt64) {
+        guard activeRecordingSessionID == sessionID, isRecording else { return }
+
+        endIdleSleepAssertion()
+        SaveService.shared.showError("Recording stopped because screen capture failed: \(error.localizedDescription)")
+        discardRecording()
+    }
+
+    private func endIdleSleepAssertion() {
+        do {
+            try idleSleepAssertion.end()
+        } catch {
+            NSLog("Unable to release TinyClips idle sleep assertion: \(error.localizedDescription)")
         }
     }
 

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -341,6 +341,7 @@ class CaptureSettings: ObservableObject {
     @AppStorage("hasCompletedOnboarding") var hasCompletedOnboarding: Bool = false
     @AppStorage("multiMonitorCaptureMode") var multiMonitorCaptureMode: MultiMonitorCaptureMode = .askEveryTime
     @AppStorage("showRegionIndicator") var showRegionIndicator: Bool = true
+    @AppStorage("preventDisplaySleepWhileRecording") var preventDisplaySleepWhileRecording: Bool = true
     @AppStorage("includeTinyClipsInCapture") var includeTinyClipsInCapture: Bool = false
     @AppStorage("showBrandingOverlay") var showBrandingOverlay: Bool = false
     // Custom global hotkeys (stored as Carbon keyCode + modifiers bitmask).

--- a/mac/TinyClips/Services/IdleSleepAssertion.swift
+++ b/mac/TinyClips/Services/IdleSleepAssertion.swift
@@ -1,0 +1,68 @@
+import Foundation
+import IOKit.pwr_mgt
+
+final class IdleSleepAssertion {
+    typealias CreateAssertion = (UnsafeMutablePointer<IOPMAssertionID>) -> IOReturn
+    typealias ReleaseAssertion = (IOPMAssertionID) -> IOReturn
+
+    private let createAssertion: CreateAssertion
+    private let releaseAssertion: ReleaseAssertion
+    private var assertionID: IOPMAssertionID?
+
+    init(
+        createAssertion: @escaping CreateAssertion = { assertionID in
+            IOPMAssertionCreateWithName(
+                kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,
+                IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                "TinyClips is recording" as CFString,
+                assertionID
+            )
+        },
+        releaseAssertion: @escaping ReleaseAssertion = IOPMAssertionRelease
+    ) {
+        self.createAssertion = createAssertion
+        self.releaseAssertion = releaseAssertion
+    }
+
+    func begin() throws {
+        guard assertionID == nil else { return }
+
+        var newAssertionID = IOPMAssertionID()
+        let result = createAssertion(&newAssertionID)
+        guard result == kIOReturnSuccess else {
+            throw IdleSleepAssertionError.operationFailed(result)
+        }
+
+        assertionID = newAssertionID
+    }
+
+    func end() throws {
+        guard let assertionID else { return }
+
+        let result = releaseAssertion(assertionID)
+        guard result == kIOReturnSuccess else {
+            throw IdleSleepAssertionError.operationFailed(result)
+        }
+
+        self.assertionID = nil
+    }
+
+    deinit {
+        do {
+            try end()
+        } catch {
+            NSLog("Unable to release TinyClips idle sleep assertion: \(error.localizedDescription)")
+        }
+    }
+}
+
+private enum IdleSleepAssertionError: LocalizedError {
+    case operationFailed(IOReturn)
+
+    var errorDescription: String? {
+        switch self {
+        case let .operationFailed(status):
+            return "Power management assertion failed with status \(status)."
+        }
+    }
+}

--- a/mac/TinyClips/Views/Settings/GifSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/GifSettingsSection.swift
@@ -33,6 +33,9 @@ struct GifSettingsSection: View {
             .help("Limit GIF output width to reduce file size.")
             Toggle("Show capture region during recording", isOn: $settings.showRegionIndicator)
                 .help("Show a visible border around the selected capture area while recording.")
+            Toggle("Prevent display sleep while recording", isOn: $settings.preventDisplaySleepWhileRecording)
+                .help("Keep the display awake and prevent the screen saver while recording video or GIFs.")
+                .accessibilityHint("When enabled, TinyClips keeps the display awake while recording video or GIFs.")
             Toggle(
                 settings.gifMouseClicksUseVideoSettings
                     ? "Show mouse clicks in recording (mirrors Video)"

--- a/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
@@ -79,6 +79,10 @@ struct VideoSettingsSection: View {
             Toggle("Show capture region during recording", isOn: $settings.showRegionIndicator)
                 .help("Show a visible border around the selected capture area while recording.")
 
+            Toggle("Prevent display sleep while recording", isOn: $settings.preventDisplaySleepWhileRecording)
+                .help("Keep the display awake and prevent the screen saver while recording video or GIFs.")
+                .accessibilityHint("When enabled, TinyClips keeps the display awake while recording video or GIFs.")
+
             Toggle("Show mouse clicks in recording", isOn: $settings.showMouseClickVisualsInVideo)
                 .help("Adds a subtle pulse at click positions in saved video recordings.")
                 .accessibilityHint("When enabled, mouse clicks are shown as a pulse effect in saved video recordings.")


### PR DESCRIPTION
## Summary
- add an injectable IOPMAssertion service that prevents user-idle display sleep during active video and GIF capture
- release the assertion on stop, discard, startup and stream failures, replacement capture, and teardown
- document the fix in the macOS changelog

Closes #214

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`