### PR TITLE
Copy macOS screenshots as PNG and TIFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.
 - macOS screenshot editor exports now offer Original, 1:1, 4:3, 16:9, 3:4, and 9:16 frames plus horizontal and vertical alignment, with image pixels and annotations preserved without stretching.
+- macOS screenshot clipboard copies now publish both PNG and TIFF image representations for wider app compatibility.
 
 ## v1.5.4-mac - 2026-07-26
 

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -428,14 +428,31 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         startAutomaticUploadIfNeeded(for: url)
     }
 
+    @MainActor
     private func copyToClipboard(url: URL, type: CaptureType) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 
         switch type {
         case .screenshot:
-            if let image = NSImage(contentsOf: url) {
-                pasteboard.writeObjects([image])
+            guard let image = NSImage(contentsOf: url),
+                  let tiffData = image.tiffRepresentation,
+                  let bitmap = NSBitmapImageRep(data: tiffData) else {
+                showError("Could not prepare the screenshot for the clipboard.")
+                return
+            }
+
+            let pngData = (url.pathExtension.lowercased() == "png" ? try? Data(contentsOf: url) : nil)
+                ?? bitmap.representation(using: .png, properties: [:])
+            guard let pngData else {
+                showError("Could not prepare the screenshot for the clipboard.")
+                return
+            }
+
+            let didWritePNG = pasteboard.setData(pngData, forType: .png)
+            let didWriteTIFF = pasteboard.setData(tiffData, forType: .tiff)
+            if !didWritePNG || !didWriteTIFF {
+                showError("Could not copy the screenshot to the clipboard.")
             }
         case .video, .gif:
             pasteboard.writeObjects([url as NSURL])


### PR DESCRIPTION
## Summary
- publish PNG and TIFF pasteboard representations when saved screenshots are copied automatically
- retain original PNG bytes where available and surface clipboard preparation/write failures
- preserve video and GIF file-URL clipboard behavior

Closes #216

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`