### PR TITLE
Add microphone soft-knee limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
+- macOS microphone recording now applies a default-on soft-knee limiter that prevents loud peaks from hard-clipping before AAC encoding.
 - macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.
 - macOS screenshot editor exports now offer Original, 1:1, 4:3, 16:9, 3:4, and 9:16 frames plus horizontal and vertical alignment, with image pixels and annotations preserved without stretching.
 

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -553,6 +553,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         guard audioBufferListStatus == noErr else {
             return sampleBuffer
         }
+        defer { withExtendedLifetime(sourceBlockBuffer) {} }
 
         let audioBuffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
         guard !audioBuffers.isEmpty else {

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -299,6 +299,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     private let recorderID = UUID().uuidString
     private let microphoneSignalThreshold = 0.01
     private let microphoneSignalTimeoutSeconds: TimeInterval = 2
+    private let microphoneLimiterKnee: Float = 0.98
     private var stream: SCStream?
     private var writer: AVAssetWriter?
     private var videoInput: AVAssetWriterInput?
@@ -314,6 +315,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     private var totalPausedDuration = CMTime.zero
     private var recordSystemAudio = false
     private var recordMicrophone = false
+    private var microphoneLimiterEnabled = true
     private var systemAudioMuted = false
     private var microphoneMuted = false
     private var selectedMicrophoneID = ""
@@ -376,6 +378,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
 
         self.recordSystemAudio = recordSystemAudio
         self.recordMicrophone = recordMicrophone
+        self.microphoneLimiterEnabled = settings.microphoneLimiterEnabled
         self.selectedMicrophoneID = selectedMicrophoneID
 
         if recordSystemAudio {
@@ -506,10 +509,175 @@ class VideoRecorder: NSObject, @unchecked Sendable {
 
         writingQueue.async { [weak self] in
             guard let self, !self.isPaused, !self.microphoneMuted, self.hasStartedWriting, let micAudioInput = self.micAudioInput, micAudioInput.isReadyForMoreMediaData else { return }
-            if let adjustedSampleBuffer = self.adjustedSampleBuffer(sampleBuffer) {
-                micAudioInput.append(adjustedSampleBuffer)
-            }
+            let adjustedSampleBuffer = self.adjustedSampleBuffer(sampleBuffer) ?? sampleBuffer
+            micAudioInput.append(self.limitedMicrophoneSampleBuffer(from: adjustedSampleBuffer))
         }
+    }
+
+    private func limitedMicrophoneSampleBuffer(from sampleBuffer: CMSampleBuffer) -> CMSampleBuffer {
+        guard microphoneLimiterEnabled,
+              let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let streamDescriptionPointer = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription) else {
+            return sampleBuffer
+        }
+
+        let streamDescription = streamDescriptionPointer.pointee
+        guard streamDescription.mFormatID == kAudioFormatLinearPCM,
+              streamDescription.mBitsPerChannel == 32,
+              (streamDescription.mFormatFlags & kAudioFormatFlagIsFloat) != 0 else {
+            return sampleBuffer
+        }
+
+        let isNonInterleaved = (streamDescription.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
+        let bufferCount = isNonInterleaved ? max(1, Int(streamDescription.mChannelsPerFrame)) : 1
+        let audioBufferListSize = MemoryLayout<AudioBufferList>.size
+            + max(0, bufferCount - 1) * MemoryLayout<AudioBuffer>.size
+        let audioBufferListMemory = UnsafeMutableRawPointer.allocate(
+            byteCount: audioBufferListSize,
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { audioBufferListMemory.deallocate() }
+
+        let audioBufferList = audioBufferListMemory.assumingMemoryBound(to: AudioBufferList.self)
+        var sourceBlockBuffer: CMBlockBuffer?
+        let audioBufferListStatus = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: audioBufferList,
+            bufferListSize: audioBufferListSize,
+            blockBufferAllocator: nil,
+            blockBufferMemoryAllocator: nil,
+            flags: UInt32(kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment),
+            blockBufferOut: &sourceBlockBuffer
+        )
+        guard audioBufferListStatus == noErr else {
+            return sampleBuffer
+        }
+
+        let audioBuffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+        guard !audioBuffers.isEmpty else {
+            return sampleBuffer
+        }
+
+        var totalByteCount = 0
+        for audioBuffer in audioBuffers {
+            let byteCount = Int(audioBuffer.mDataByteSize)
+            guard audioBuffer.mData != nil,
+                  byteCount > 0,
+                  byteCount.isMultiple(of: MemoryLayout<Float>.stride) else {
+                return sampleBuffer
+            }
+            totalByteCount += byteCount
+        }
+
+        var limitedBlockBuffer: CMBlockBuffer?
+        let blockBufferStatus = CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: nil,
+            blockLength: totalByteCount,
+            blockAllocator: kCFAllocatorDefault,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: totalByteCount,
+            flags: 0,
+            blockBufferOut: &limitedBlockBuffer
+        )
+        guard blockBufferStatus == noErr, let limitedBlockBuffer else {
+            return sampleBuffer
+        }
+
+        var contiguousLength = 0
+        var totalLength = 0
+        var destinationData: UnsafeMutablePointer<Int8>?
+        let dataPointerStatus = CMBlockBufferGetDataPointer(
+            limitedBlockBuffer,
+            atOffset: 0,
+            lengthAtOffsetOut: &contiguousLength,
+            totalLengthOut: &totalLength,
+            dataPointerOut: &destinationData
+        )
+        guard dataPointerStatus == noErr,
+              totalLength == totalByteCount,
+              contiguousLength == totalByteCount,
+              let destinationData else {
+            return sampleBuffer
+        }
+
+        var destinationOffset = 0
+        for audioBuffer in audioBuffers {
+            guard let sourceData = audioBuffer.mData else {
+                return sampleBuffer
+            }
+
+            let sampleCount = Int(audioBuffer.mDataByteSize) / MemoryLayout<Float>.stride
+            let sourceSamples = sourceData.bindMemory(to: Float.self, capacity: sampleCount)
+            let destinationSamples = UnsafeMutableRawPointer(destinationData.advanced(by: destinationOffset))
+                .bindMemory(to: Float.self, capacity: sampleCount)
+
+            for sampleIndex in 0..<sampleCount {
+                let sample = sourceSamples[sampleIndex]
+                guard sample.isFinite else {
+                    return sampleBuffer
+                }
+                destinationSamples[sampleIndex] = softKneeLimitedSample(sample)
+            }
+            destinationOffset += Int(audioBuffer.mDataByteSize)
+        }
+
+        var limitedSampleBuffer: CMSampleBuffer?
+        let sampleBufferStatus = CMAudioSampleBufferCreateWithPacketDescriptions(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: limitedBlockBuffer,
+            dataReady: true,
+            makeDataReadyCallback: nil,
+            refcon: nil,
+            formatDescription: formatDescription,
+            sampleCount: CMSampleBufferGetNumSamples(sampleBuffer),
+            presentationTimeStamp: CMSampleBufferGetPresentationTimeStamp(sampleBuffer),
+            packetDescriptions: nil,
+            sampleBufferOut: &limitedSampleBuffer
+        )
+        guard sampleBufferStatus == noErr, let limitedSampleBuffer else {
+            return sampleBuffer
+        }
+
+        let timingEntryCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard timingEntryCount > 0 else {
+            return sampleBuffer
+        }
+        var timing = Array(repeating: CMSampleTimingInfo(), count: timingEntryCount)
+        var timingCount = 0
+        let timingStatus = CMSampleBufferGetSampleTimingInfoArray(
+            sampleBuffer,
+            entryCount: timing.count,
+            arrayToFill: &timing,
+            entriesNeededOut: &timingCount
+        )
+        guard timingStatus == noErr, timingCount > 0 else {
+            return sampleBuffer
+        }
+
+        var timestampPreservingSampleBuffer: CMSampleBuffer?
+        let copyStatus = CMSampleBufferCreateCopyWithNewTiming(
+            allocator: kCFAllocatorDefault,
+            sampleBuffer: limitedSampleBuffer,
+            sampleTimingEntryCount: timingCount,
+            sampleTimingArray: timing,
+            sampleBufferOut: &timestampPreservingSampleBuffer
+        )
+        return copyStatus == noErr ? (timestampPreservingSampleBuffer ?? sampleBuffer) : sampleBuffer
+    }
+
+    private func softKneeLimitedSample(_ sample: Float) -> Float {
+        let magnitude = abs(sample)
+        guard magnitude > microphoneLimiterKnee else {
+            return sample
+        }
+
+        let normalizedOverage = (magnitude - microphoneLimiterKnee) / (1 - microphoneLimiterKnee)
+        let limitedMagnitude = microphoneLimiterKnee
+            + (1 - microphoneLimiterKnee) * (2 / .pi) * atan(.pi / 2 * normalizedOverage)
+        return sample.sign == .minus ? -limitedMagnitude : limitedMagnitude
     }
 
     private func rmsLevel(from sampleBuffer: CMSampleBuffer) -> Double {
@@ -732,6 +900,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         totalPausedDuration = .zero
         recordSystemAudio = false
         recordMicrophone = false
+        microphoneLimiterEnabled = true
         systemAudioMuted = false
         microphoneMuted = false
         selectedMicrophoneID = ""

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -273,6 +273,7 @@ class CaptureSettings: ObservableObject {
     @AppStorage("showTrimmer") var showTrimmer: Bool = true
     @AppStorage("recordAudio") var recordAudio: Bool = false
     @AppStorage("recordMicrophone") var recordMicrophone: Bool = false
+    @AppStorage("microphoneLimiterEnabled") var microphoneLimiterEnabled: Bool = true
     @AppStorage("selectedMicrophoneID") var selectedMicrophoneID: String = ""
     @AppStorage("webcamEnabled") var webcamEnabled: Bool = false
     @AppStorage("selectedWebcamID") var selectedWebcamID: String = ""

--- a/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
@@ -26,6 +26,9 @@ struct VideoSettingsSection: View {
             Toggle("Record microphone", isOn: $settings.recordMicrophone)
                 .help("Include microphone input in the recording.")
 
+            Toggle("Limit microphone peaks", isOn: $settings.microphoneLimiterEnabled)
+                .help("Softly compresses loud microphone peaks before encoding to prevent distortion.")
+
             Picker("Microphone input:", selection: $settings.selectedMicrophoneID) {
                 Text("System Default").tag("")
                 ForEach(availableMicrophones) { device in


### PR DESCRIPTION
## Summary
- add a default-on, configurable soft-knee limiter for float PCM microphone buffers before AAC encoding
- preserve every adjusted CMSampleTimingInfo entry and pass through the original buffer if limiting cannot complete
- document the microphone peak protection in the changelog

Closes #215

## Validation
- xcodebuild TinyClips Debug (codesigning disabled)
- xcodebuild TinyClipsMAS Debug (codesigning disabled)
- soft-knee response assertions