### PR TITLE
Enforce single-instance macOS launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed macOS launching a second Tiny Clips process by activating the existing instance instead of duplicating the menu-bar app and global hotkeys.
 - Fixed macOS video and GIF recordings allowing the display to idle-sleep or start the screen saver during capture.
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.
 - Fixed macOS shortcut changes silently accepting unavailable or conflicting global hotkeys; Settings now validates conflicts and keeps the prior working shortcut when registration fails.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		B10000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000037 /* ScreenshotEditorCanvas.swift */; };
 		B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
 		B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
+		B1000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
 		B20000000000000000000001 /* TinyClipsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000001 /* TinyClipsApp.swift */; };
 		B20000000000000000000002 /* CaptureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* CaptureSettings.swift */; };
 		B20000000000000000000003 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* SettingsView.swift */; };
@@ -87,6 +88,7 @@
 		B20000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000037 /* ScreenshotEditorCanvas.swift */; };
 		B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
 		B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
+		B2000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
 		B10000000000000000000021 /* CaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* CaptureManager.swift */; };
 		B10000000000000000000022 /* MenuBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* MenuBarViews.swift */; };
 		B10000000000000000000023 /* ProcessingIndicatorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* ProcessingIndicatorWindow.swift */; };
@@ -132,6 +134,7 @@
 		A1000000000000000000000D /* TinyClips.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TinyClips.entitlements; sourceTree = "<group>"; };
 		A1000000000000000000000E /* TinyClips.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinyClips.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000000000000000000000F /* SparkleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleController.swift; sourceTree = "<group>"; };
+		A1000000000000000000003A /* SingleInstanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceCoordinator.swift; sourceTree = "<group>"; };
 		A10000000000000000000010 /* VideoTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrimmerWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ScreenshotEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* GifTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifTrimmerWindow.swift; sourceTree = "<group>"; };
@@ -302,6 +305,7 @@
 				A10000000000000000000032 /* CaptureAnalyticsStore.swift */,
 				A1000000000000000000000A /* PermissionManager.swift */,
 				A1000000000000000000000F /* SparkleController.swift */,
+				A1000000000000000000003A /* SingleInstanceCoordinator.swift */,
 				A10000000000000000000017 /* HotKeyManager.swift */,
 				A1000000000000000000001A /* StoreService.swift */,
 				A10000000000000000000020 /* LaunchAtLoginManager.swift */,
@@ -438,6 +442,7 @@
 				B10000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */,
 				B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
 				B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
+				B1000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */,
 				B1000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B10000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B10000000000000000000011 /* CountdownWindow.swift in Sources */,
@@ -497,6 +502,7 @@
 				B20000000000000000000037 /* ScreenshotEditorCanvas.swift in Sources */,
 				B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
 				B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
+				B2000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */,
 				B2000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B20000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B20000000000000000000011 /* CountdownWindow.swift in Sources */,

--- a/mac/TinyClips/Services/SingleInstanceCoordinator.swift
+++ b/mac/TinyClips/Services/SingleInstanceCoordinator.swift
@@ -1,0 +1,145 @@
+import AppKit
+import Foundation
+import Darwin
+
+// MARK: - Single Instance Coordinator
+
+final class SingleInstanceCoordinator {
+    static let shared = SingleInstanceCoordinator()
+
+    enum AcquisitionResult {
+        case primary
+        case alreadyRunning
+        case failure(Error)
+    }
+
+    enum Error: LocalizedError {
+        case applicationSupportDirectoryUnavailable
+        case createApplicationSupportDirectory(Swift.Error)
+        case openLockFile(Int32)
+        case acquireLock(Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case .applicationSupportDirectoryUnavailable:
+                return "Tiny Clips could not locate its Application Support directory."
+            case let .createApplicationSupportDirectory(error):
+                return "Tiny Clips could not create its Application Support directory: \(error.localizedDescription)"
+            case let .openLockFile(errorCode):
+                return "Tiny Clips could not open its single-instance lock file: \(String(cString: strerror(errorCode)))."
+            case let .acquireLock(errorCode):
+                return "Tiny Clips could not acquire its single-instance lock: \(String(cString: strerror(errorCode)))."
+            }
+        }
+    }
+
+    private let notificationName: Notification.Name
+    private var lockFileDescriptor: Int32?
+    private var activationObserver: NSObjectProtocol?
+
+    private init() {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.tinyclips.app"
+        notificationName = Notification.Name("\(bundleIdentifier).activateExistingInstance")
+    }
+
+    deinit {
+        release()
+    }
+
+    func acquire() -> AcquisitionResult {
+        if lockFileDescriptor != nil {
+            return .primary
+        }
+
+        guard let applicationSupportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return .failure(.applicationSupportDirectoryUnavailable)
+        }
+
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.tinyclips.app"
+        let lockDirectory = applicationSupportDirectory
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+
+        do {
+            try FileManager.default.createDirectory(
+                at: lockDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            return .failure(.createApplicationSupportDirectory(error))
+        }
+
+        let lockURL = lockDirectory.appendingPathComponent("TinyClips.lock", isDirectory: false)
+        let fileDescriptor = lockURL.path.withCString {
+            open($0, O_RDWR | O_CREAT, mode_t(S_IRUSR | S_IWUSR))
+        }
+        guard fileDescriptor != -1 else {
+            return .failure(.openLockFile(errno))
+        }
+
+        guard flock(fileDescriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let errorCode = errno
+            close(fileDescriptor)
+
+            if errorCode == EWOULDBLOCK || errorCode == EAGAIN {
+                postActivationRequest()
+                // The first process may have acquired the lock immediately before registering its observer.
+                usleep(50_000)
+                postActivationRequest()
+                return .alreadyRunning
+            }
+
+            return .failure(.acquireLock(errorCode))
+        }
+
+        lockFileDescriptor = fileDescriptor
+        observeActivationRequests()
+        return .primary
+    }
+
+    func release() {
+        if let activationObserver {
+            DistributedNotificationCenter.default().removeObserver(activationObserver)
+            self.activationObserver = nil
+        }
+
+        guard let lockFileDescriptor else { return }
+        flock(lockFileDescriptor, LOCK_UN)
+        close(lockFileDescriptor)
+        self.lockFileDescriptor = nil
+    }
+
+    private func observeActivationRequests() {
+        guard activationObserver == nil else { return }
+
+        activationObserver = DistributedNotificationCenter.default().addObserver(
+            forName: notificationName,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.activateExistingInstance()
+        }
+    }
+
+    private func postActivationRequest() {
+        DistributedNotificationCenter.default().postNotificationName(
+            notificationName,
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+
+    private func activateExistingInstance() {
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && $0.canBecomeKey }) else {
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+    }
+}

--- a/mac/TinyClips/Services/SingleInstanceCoordinator.swift
+++ b/mac/TinyClips/Services/SingleInstanceCoordinator.swift
@@ -1,10 +1,11 @@
 import AppKit
+import Combine
 import Foundation
 import Darwin
 
 // MARK: - Single Instance Coordinator
 
-final class SingleInstanceCoordinator {
+final class SingleInstanceCoordinator: ObservableObject {
     static let shared = SingleInstanceCoordinator()
 
     enum AcquisitionResult {
@@ -36,6 +37,7 @@ final class SingleInstanceCoordinator {
     private let notificationName: Notification.Name
     private var lockFileDescriptor: Int32?
     private var activationObserver: NSObjectProtocol?
+    @Published private(set) var activationRequestID: UInt = 0
 
     private init() {
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.tinyclips.app"
@@ -51,10 +53,13 @@ final class SingleInstanceCoordinator {
             return .primary
         }
 
+        observeActivationRequests()
+
         guard let applicationSupportDirectory = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         ).first else {
+            removeActivationObserver()
             return .failure(.applicationSupportDirectoryUnavailable)
         }
 
@@ -68,6 +73,7 @@ final class SingleInstanceCoordinator {
                 withIntermediateDirectories: true
             )
         } catch {
+            removeActivationObserver()
             return .failure(.createApplicationSupportDirectory(error))
         }
 
@@ -76,17 +82,16 @@ final class SingleInstanceCoordinator {
             open($0, O_RDWR | O_CREAT, mode_t(S_IRUSR | S_IWUSR))
         }
         guard fileDescriptor != -1 else {
+            removeActivationObserver()
             return .failure(.openLockFile(errno))
         }
 
         guard flock(fileDescriptor, LOCK_EX | LOCK_NB) == 0 else {
             let errorCode = errno
             close(fileDescriptor)
+            removeActivationObserver()
 
             if errorCode == EWOULDBLOCK || errorCode == EAGAIN {
-                postActivationRequest()
-                // The first process may have acquired the lock immediately before registering its observer.
-                usleep(50_000)
                 postActivationRequest()
                 return .alreadyRunning
             }
@@ -95,15 +100,11 @@ final class SingleInstanceCoordinator {
         }
 
         lockFileDescriptor = fileDescriptor
-        observeActivationRequests()
         return .primary
     }
 
     func release() {
-        if let activationObserver {
-            DistributedNotificationCenter.default().removeObserver(activationObserver)
-            self.activationObserver = nil
-        }
+        removeActivationObserver()
 
         guard let lockFileDescriptor else { return }
         flock(lockFileDescriptor, LOCK_UN)
@@ -123,6 +124,13 @@ final class SingleInstanceCoordinator {
         }
     }
 
+    private func removeActivationObserver() {
+        if let activationObserver {
+            DistributedNotificationCenter.default().removeObserver(activationObserver)
+            self.activationObserver = nil
+        }
+    }
+
     private func postActivationRequest() {
         DistributedNotificationCenter.default().postNotificationName(
             notificationName,
@@ -135,11 +143,32 @@ final class SingleInstanceCoordinator {
     private func activateExistingInstance() {
         NSRunningApplication.current.activate(options: [.activateAllWindows])
 
-        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && $0.canBecomeKey }) else {
+        if let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && $0.canBecomeKey }) {
+            window.makeKeyAndOrderFront(nil)
+            window.orderFrontRegardless()
+        }
+
+        activationRequestID &+= 1
+    }
+
+    func bringSettingsWindowToFront() {
+        focusSettingsWindow()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.focusSettingsWindow()
+        }
+    }
+
+    private func focusSettingsWindow() {
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+
+        guard let settingsWindow = NSApp.windows.first(where: {
+            $0.identifier?.rawValue == "settings-window" || $0.title == "Tiny Clips Settings"
+        }) else {
             return
         }
 
-        window.makeKeyAndOrderFront(nil)
-        window.orderFrontRegardless()
+        settingsWindow.makeKeyAndOrderFront(nil)
+        settingsWindow.orderFrontRegardless()
     }
 }

--- a/mac/TinyClips/TinyClipsApp.swift
+++ b/mac/TinyClips/TinyClipsApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
@@ -11,6 +12,10 @@ final class TinyClipsAppDelegate: NSObject, NSApplicationDelegate {
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
         ExternalImageOpenCoordinator.shared.handleOpen(urls: [URL(fileURLWithPath: filename)])
     }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        SingleInstanceCoordinator.shared.release()
+    }
 }
 
 struct AppWindowCommands: Commands {
@@ -22,15 +27,25 @@ struct AppWindowCommands: Commands {
 @main
 struct TinyClipsApp: App {
     @NSApplicationDelegateAdaptor(TinyClipsAppDelegate.self) private var appDelegate
-    @StateObject private var captureManager = CaptureManager()
+    @StateObject private var captureManager: CaptureManager
     @ObservedObject private var sparkleController = SparkleController.shared
 
     init() {
-        _ = try? TinyClipsTemporaryFiles.removeStaleFiles(
-            olderThan: Date().addingTimeInterval(-24 * 60 * 60)
-        )
-        _ = SparkleController.shared
-        NSApplication.shared.setActivationPolicy(CaptureSettings.shared.showInDock ? .regular : .accessory)
+        switch SingleInstanceCoordinator.shared.acquire() {
+        case .primary:
+            _ = try? TinyClipsTemporaryFiles.removeStaleFiles(
+                olderThan: Date().addingTimeInterval(-24 * 60 * 60)
+            )
+            _ = SparkleController.shared
+            NSApplication.shared.setActivationPolicy(CaptureSettings.shared.showInDock ? .regular : .accessory)
+        case .alreadyRunning:
+            exit(EXIT_SUCCESS)
+        case let .failure(error):
+            NSAlert(error: error).runModal()
+            exit(EXIT_FAILURE)
+        }
+
+        _captureManager = StateObject(wrappedValue: CaptureManager())
     }
 
     var body: some Scene {

--- a/mac/TinyClips/TinyClipsApp.swift
+++ b/mac/TinyClips/TinyClipsApp.swift
@@ -29,6 +29,7 @@ struct TinyClipsApp: App {
     @NSApplicationDelegateAdaptor(TinyClipsAppDelegate.self) private var appDelegate
     @StateObject private var captureManager: CaptureManager
     @ObservedObject private var sparkleController = SparkleController.shared
+    @ObservedObject private var singleInstanceCoordinator = SingleInstanceCoordinator.shared
 
     init() {
         switch SingleInstanceCoordinator.shared.acquire() {
@@ -53,6 +54,9 @@ struct TinyClipsApp: App {
             MenuBarContentView(captureManager: captureManager, sparkleController: sparkleController)
         } label: {
             MenuBarLabelView(captureManager: captureManager)
+                .background(
+                    SingleInstanceActivationHandler(coordinator: singleInstanceCoordinator)
+                )
         }
 
         Window("Clips Manager", id: "clips-manager") {
@@ -72,6 +76,31 @@ struct TinyClipsApp: App {
         }
 
         ScreenshotEditorScene()
+    }
+}
+
+private struct SingleInstanceActivationHandler: View {
+    @ObservedObject var coordinator: SingleInstanceCoordinator
+    @Environment(\.openWindow) private var openWindow
+    @State private var handledActivationRequestID: UInt = 0
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .onAppear {
+                handleActivationRequestIfNeeded()
+            }
+            .onChange(of: coordinator.activationRequestID) { _ in
+                handleActivationRequestIfNeeded()
+            }
+    }
+
+    private func handleActivationRequestIfNeeded() {
+        guard handledActivationRequestID != coordinator.activationRequestID else { return }
+
+        handledActivationRequestID = coordinator.activationRequestID
+        openWindow(id: "settings-window")
+        coordinator.bringSettingsWindowToFront()
     }
 }
 


### PR DESCRIPTION
Closes #217

Adds an Application Support flock lock for each macOS app variant. Duplicate launches signal and focus the existing process through DistributedNotificationCenter, then exit before registering global hotkeys. The lock is released during application termination.