### PR TITLE
Stop playback when closing video trimmers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed the macOS video trimmer so preview playback stops immediately when saving or closing the trimmer.
 - Fixed macOS recording writer failures caused by invalid or non-increasing screen, system-audio, microphone, or webcam presentation timestamps.
 - Fixed macOS video and GIF recordings allowing the display to idle-sleep or start the screen saver during capture.
 - Fixed macOS screenshot editor text annotations previewing larger than copied or saved images when background padding changes the displayed screenshot scale.

--- a/mac/TinyClips/Views/VideoTrimmerWindow.swift
+++ b/mac/TinyClips/Views/VideoTrimmerWindow.swift
@@ -14,6 +14,7 @@ final class TrimmerMenuActions {
     var togglePlayback: (() -> Void)?
     var previousFrame: (() -> Void)?
     var nextFrame: (() -> Void)?
+    var stopPlayback: (() -> Void)?
 
     func handles(_ action: Selector?) -> Bool {
         switch action {
@@ -63,6 +64,7 @@ final class TrimmerMenuActions {
         togglePlayback = nil
         previousFrame = nil
         nextFrame = nil
+        stopPlayback = nil
     }
 }
 
@@ -138,6 +140,7 @@ class VideoTrimmerWindow: NSWindow, NSWindowDelegate {
         guard !didComplete, let callback = onComplete else { return }
         didComplete = true
         onComplete = nil
+        menuActions.stopPlayback?()
         callback(url)
         orderOut(nil)
     }
@@ -362,6 +365,7 @@ private struct VideoTrimmerView: View {
                                 DispatchQueue.main.async { onDone(resultURL) }
                             }
                         } else {
+                            viewModel.stopPlayback()
                             onDone(videoURL)
                         }
                     }
@@ -435,12 +439,14 @@ private struct VideoTrimmerView: View {
                     DispatchQueue.main.async { onDone(resultURL) }
                 }
             } else {
+                viewModel.stopPlayback()
                 onDone(videoURL)
             }
         }
         menuActions.togglePlayback = { [viewModel] in viewModel.previewTrimmed() }
         menuActions.previousFrame = { [viewModel] in viewModel.stepFrame(by: -1) }
         menuActions.nextFrame = { [viewModel] in viewModel.stepFrame(by: 1) }
+        menuActions.stopPlayback = { [viewModel] in viewModel.stopPlayback() }
     }
 
     private func formatTime(_ seconds: Double) -> String {
@@ -694,11 +700,16 @@ private class TrimmerViewModel: ObservableObject {
     }
 
     func cleanup() {
-        player.pause()
+        stopPlayback()
         if let obs = timeObserver {
             player.removeTimeObserver(obs)
             timeObserver = nil
         }
+    }
+
+    func stopPlayback() {
+        player.pause()
+        isPlaying = false
     }
 
     func seek(to time: Double) {
@@ -811,6 +822,7 @@ private class TrimmerViewModel: ObservableObject {
 
     func exportVideo(trimmed: Bool, completion: @escaping (URL?) -> Void) {
         isExporting = true
+        stopPlayback()
 
         let outputSuffix = trimmed ? (removeAudio ? " (trimmed, no audio)" : " (trimmed)") : " (no audio)"
         let outputURL = sourceURL.deletingLastPathComponent()

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,9 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed the video trimmer so preview playback stops immediately when saving or closing the window.
+
 ### Added
 - Added a live webcam preview to video setup and recording on Windows. The in-recording preview can be dragged or moved with the keyboard between capture corners, and every move is synchronized to the exported recording timeline.
 - **Uploadcare cloud uploads** — Settings → Uploadcare now stores the public key and upload preferences locally while keeping the optional signing secret only in Windows Credential Locker. Tiny Clips can upload finalized screenshots, videos, GIFs, and exported frames automatically, optionally copy the delivery URL, and lets the Clips Library upload a capture manually with Copy URL and Open URL actions.

--- a/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/VideoTrimmerWindow.xaml.cs
@@ -374,6 +374,7 @@ public sealed partial class VideoTrimmerWindow : Window
             return;
         }
 
+        StopPlayback();
         var outputPath = await ExportVideoAsync(trimmed: true);
         Completed?.Invoke(this, outputPath);
         Close();
@@ -381,6 +382,7 @@ public sealed partial class VideoTrimmerWindow : Window
 
     private async void OnSaveOriginal(object sender, RoutedEventArgs e)
     {
+        StopPlayback();
         if (RemoveAudioCheck.IsChecked == true)
         {
             var outputPath = await ExportVideoAsync(trimmed: false);
@@ -464,6 +466,7 @@ public sealed partial class VideoTrimmerWindow : Window
 
     private void OnDone(object sender, RoutedEventArgs e)
     {
+        StopPlayback();
         Completed?.Invoke(this, null);
         Close();
     }
@@ -471,6 +474,7 @@ public sealed partial class VideoTrimmerWindow : Window
     private void OnWindowClosed(object sender, WindowEventArgs e)
     {
         var player = Player.MediaPlayer;
+        StopPlayback();
         if (player?.PlaybackSession is { } session)
         {
             session.PositionChanged -= OnPositionChanged;
@@ -478,6 +482,11 @@ public sealed partial class VideoTrimmerWindow : Window
 
         Player.SetMediaPlayer(null);
         player?.Dispose();
+    }
+
+    private void StopPlayback()
+    {
+        Player.MediaPlayer?.Pause();
     }
 
     /// <summary>Raised once when the window closes. Carries the trimmed file path, or null if untrimmed.</summary>


### PR DESCRIPTION
Video preview audio could continue while a trimmer was saving or closing. Pause the media player at every save and close boundary in both macOS and Windows trimmers, including before macOS exports begin.