### PR TITLE
Never leave zero-byte MP4s when a recording captures no frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed macOS recordings that capture no frames leaving zero-byte MP4 artifacts.
 - Fixed the macOS video trimmer so preview playback stops immediately when saving or closing the trimmer.
 - Fixed macOS launching a second Tiny Clips process by activating the existing instance instead of duplicating the menu-bar app and global hotkeys.
 - Fixed macOS recording writer failures caused by invalid or non-increasing screen, system-audio, microphone, or webcam presentation timestamps.

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -255,10 +255,11 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
                 }
 
                 guard self.hasWrittenVideoFrame else {
+                    let writerError = writer.status == .failed ? writer.error : nil
                     writer.cancelWriting()
                     self.removeOutputFile(at: outputURL)
                     self.reset()
-                    continuation.resume(throwing: CaptureError.noFrames)
+                    continuation.resume(throwing: writerError ?? CaptureError.noFrames)
                     return
                 }
 
@@ -951,9 +952,10 @@ class VideoRecorder: NSObject, @unchecked Sendable {
                 }
 
                 guard self.hasWrittenVideoFrame else {
+                    let writerError = writer.status == .failed ? writer.error : nil
                     writer.cancelWriting()
                     self.removeOutputFile(at: outputURL)
-                    continuation.resume(throwing: CaptureError.noFrames)
+                    continuation.resume(throwing: writerError ?? CaptureError.noFrames)
                     return
                 }
 

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -129,6 +129,7 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
     private var videoInput: AVAssetWriterInput?
     private var outputURL: URL?
     private var hasStartedWriting = false
+    private var hasWrittenVideoFrame = false
     private var isPaused = false
     private var pauseStartedAt: CMTime?
     private var totalPausedDuration = CMTime.zero
@@ -167,92 +168,115 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
         onWebcamDeviceName?(device.localizedName)
         self.outputURL = outputURL
 
-        let writer = try AVAssetWriter(url: outputURL, fileType: .mp4)
-        let dimensions = CMVideoFormatDescriptionGetDimensions(device.activeFormat.formatDescription)
-        let width = max(1, Int(dimensions.width))
-        let height = max(1, Int(dimensions.height))
-        let activeFrameDuration = device.activeVideoMinFrameDuration
-        if isPositiveNumericTime(activeFrameDuration) {
-            fallbackFrameDuration = activeFrameDuration
+        let writer: AVAssetWriter
+        do {
+            writer = try AVAssetWriter(url: outputURL, fileType: .mp4)
+        } catch {
+            removeOutputFile(at: outputURL)
+            reset()
+            throw error
         }
-        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
-            AVVideoCodecKey: AVVideoCodecType.h264,
-            AVVideoWidthKey: width,
-            AVVideoHeightKey: height,
-        ])
-        input.expectsMediaDataInRealTime = true
-        guard writer.canAdd(input) else {
-            throw CaptureError.saveFailed
-        }
-        writer.add(input)
 
-        let session = AVCaptureSession()
-        session.sessionPreset = .high
-        let cameraInput = try AVCaptureDeviceInput(device: device)
-        guard session.canAddInput(cameraInput) else {
-            throw CaptureError.webcamConnectionFailed
-        }
-        session.addInput(cameraInput)
+        do {
+            let dimensions = CMVideoFormatDescriptionGetDimensions(device.activeFormat.formatDescription)
+            let width = max(1, Int(dimensions.width))
+            let height = max(1, Int(dimensions.height))
+            let activeFrameDuration = device.activeVideoMinFrameDuration
+            if isPositiveNumericTime(activeFrameDuration) {
+                fallbackFrameDuration = activeFrameDuration
+            }
+            let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ])
+            input.expectsMediaDataInRealTime = true
+            guard writer.canAdd(input) else {
+                throw CaptureError.saveFailed
+            }
+            writer.add(input)
 
-        let output = AVCaptureVideoDataOutput()
-        output.videoSettings = [
-            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
-        ]
-        output.alwaysDiscardsLateVideoFrames = true
-        output.setSampleBufferDelegate(self, queue: writingQueue)
-        guard session.canAddOutput(output) else {
-            throw CaptureError.webcamReadFailed
-        }
-        session.addOutput(output)
+            let session = AVCaptureSession()
+            session.sessionPreset = .high
+            let cameraInput = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(cameraInput) else {
+                throw CaptureError.webcamConnectionFailed
+            }
+            session.addInput(cameraInput)
 
-        self.writer = writer
-        self.videoInput = input
-        self.session = session
-        hasStartedWriting = false
-        lastPresentationTime = nil
+            let output = AVCaptureVideoDataOutput()
+            output.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+            ]
+            output.alwaysDiscardsLateVideoFrames = true
+            output.setSampleBufferDelegate(self, queue: writingQueue)
+            guard session.canAddOutput(output) else {
+                throw CaptureError.webcamReadFailed
+            }
+            session.addOutput(output)
 
-        captureQueue.sync {
-            session.startRunning()
+            self.writer = writer
+            self.videoInput = input
+            self.session = session
+            hasStartedWriting = false
+            hasWrittenVideoFrame = false
+            lastPresentationTime = nil
+
+            captureQueue.sync {
+                session.startRunning()
+            }
+        } catch {
+            writer.cancelWriting()
+            removeOutputFile(at: outputURL)
+            reset()
+            throw error
         }
         debugLifecycle("session started")
     }
 
     func stop() async throws -> URL {
-        guard let outputURL else {
-            throw CaptureError.saveFailed
-        }
-
         captureQueue.sync {
             if let session, session.isRunning {
                 session.stopRunning()
             }
         }
 
-        guard let writer, let videoInput else {
-            reset()
-            throw CaptureError.saveFailed
-        }
-
-        if !hasStartedWriting {
-            writer.cancelWriting()
-            reset()
-            throw CaptureError.noFrames
-        }
-
         return try await withCheckedThrowingContinuation { continuation in
             writingQueue.async {
+                guard let outputURL = self.outputURL,
+                      let writer = self.writer,
+                      let videoInput = self.videoInput else {
+                    if let outputURL = self.outputURL {
+                        self.removeOutputFile(at: outputURL)
+                    }
+                    self.reset()
+                    continuation.resume(throwing: CaptureError.saveFailed)
+                    return
+                }
+
+                guard self.hasWrittenVideoFrame else {
+                    writer.cancelWriting()
+                    self.removeOutputFile(at: outputURL)
+                    self.reset()
+                    continuation.resume(throwing: CaptureError.noFrames)
+                    return
+                }
+
                 videoInput.markAsFinished()
                 writer.finishWriting {
-                    if writer.status == .completed {
-                        self.debugLifecycle("finishWriting completed")
-                        self.reset()
-                        continuation.resume(returning: outputURL)
-                    } else {
-                        let message = writer.error?.localizedDescription ?? CaptureError.saveFailed.localizedDescription
-                        self.onWebcamError?(message)
-                        self.debugLifecycle("finishWriting failed: \(message)")
-                        self.reset()
-                        continuation.resume(throwing: writer.error ?? CaptureError.saveFailed)
+                    self.writingQueue.async {
+                        if writer.status == .completed {
+                            self.debugLifecycle("finishWriting completed")
+                            self.reset()
+                            continuation.resume(returning: outputURL)
+                        } else {
+                            let message = writer.error?.localizedDescription ?? CaptureError.saveFailed.localizedDescription
+                            self.onWebcamError?(message)
+                            self.debugLifecycle("finishWriting failed: \(message)")
+                            self.removeOutputFile(at: outputURL)
+                            self.reset()
+                            continuation.resume(throwing: writer.error ?? CaptureError.saveFailed)
+                        }
                     }
                 }
             }
@@ -295,11 +319,11 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
         }
         writingQueue.sync {
             writer?.cancelWriting()
+            if let outputURL {
+                removeOutputFile(at: outputURL)
+            }
+            reset()
         }
-        if let outputURL {
-            try? FileManager.default.removeItem(at: outputURL)
-        }
-        reset()
     }
 
     private func reset() {
@@ -308,10 +332,20 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
         videoInput = nil
         outputURL = nil
         hasStartedWriting = false
+        hasWrittenVideoFrame = false
         isPaused = false
         pauseStartedAt = nil
         totalPausedDuration = .zero
         lastPresentationTime = nil
+    }
+
+    private func removeOutputFile(at url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            debugLifecycle("failed to remove incomplete output: \(error.localizedDescription)")
+        }
     }
 
     private func debugLifecycle(_ message: String) {
@@ -357,6 +391,7 @@ extension WebcamRecorder: AVCaptureVideoDataOutputSampleBufferDelegate {
 
         guard videoInput.isReadyForMoreMediaData else { return }
         if videoInput.append(adjustedSampleBuffer) {
+            hasWrittenVideoFrame = true
             lastPresentationTime = proposedLastPresentationTime
         }
     }
@@ -400,6 +435,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     private var microphoneObservers: [NSObjectProtocol] = []
     private var lastMicSignalAt = CACurrentMediaTime()
     private var hasStartedWriting = false
+    private var hasWrittenVideoFrame = false
     private var isPaused = false
     private var pauseStartedAt: CMTime?
     private var totalPausedDuration = CMTime.zero
@@ -520,6 +556,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         self.writer = writer
         self.videoInput = videoInput
         self.hasStartedWriting = false
+        self.hasWrittenVideoFrame = false
         self.didReportStreamFailure = false
         self.lastVideoPresentationTime = nil
         self.lastSystemAudioPresentationTime = nil
@@ -888,7 +925,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         stream = nil
         debugLifecycle("stream stopped")
 
-        return try await finishWriting(removeOutputIfEmpty: false)
+        return try await finishWriting()
     }
 
     func finishAfterStreamFailure() async throws -> URL {
@@ -898,41 +935,50 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         stopMicrophoneCapture()
         stream = nil
 
-        return try await finishWriting(removeOutputIfEmpty: true)
+        return try await finishWriting()
     }
 
-    private func finishWriting(removeOutputIfEmpty: Bool) async throws -> URL {
-        guard let writer, let videoInput, let outputURL else {
-            throw CaptureError.saveFailed
-        }
-
-        guard hasStartedWriting else {
-            writingQueue.sync {
-                writer.cancelWriting()
-            }
-            if removeOutputIfEmpty {
-                try? FileManager.default.removeItem(at: outputURL)
-            }
-            throw CaptureError.noFrames
-        }
-
-        nonisolated(unsafe) let capturedVideoInput = videoInput
-        nonisolated(unsafe) let capturedSystemAudioInput = self.systemAudioInput
-        nonisolated(unsafe) let capturedMicAudioInput = self.micAudioInput
-        nonisolated(unsafe) let capturedWriter = writer
-
+    private func finishWriting() async throws -> URL {
         return try await withCheckedThrowingContinuation { continuation in
             writingQueue.async {
-                capturedVideoInput.markAsFinished()
-                capturedSystemAudioInput?.markAsFinished()
-                capturedMicAudioInput?.markAsFinished()
-                capturedWriter.finishWriting {
-                    if capturedWriter.status == .completed {
-                        self.debugLifecycle("finishWriting completed")
-                        continuation.resume(returning: outputURL)
-                    } else {
-                        self.debugLifecycle("finishWriting failed: \(capturedWriter.error?.localizedDescription ?? "unknown error")")
-                        continuation.resume(throwing: capturedWriter.error ?? CaptureError.saveFailed)
+                guard let outputURL = self.outputURL,
+                      let writer = self.writer else {
+                    if let outputURL = self.outputURL {
+                        self.removeOutputFile(at: outputURL)
+                    }
+                    continuation.resume(throwing: CaptureError.saveFailed)
+                    return
+                }
+
+                guard self.hasWrittenVideoFrame else {
+                    writer.cancelWriting()
+                    self.removeOutputFile(at: outputURL)
+                    continuation.resume(throwing: CaptureError.noFrames)
+                    return
+                }
+
+                guard let videoInput = self.videoInput else {
+                    writer.cancelWriting()
+                    self.removeOutputFile(at: outputURL)
+                    continuation.resume(throwing: CaptureError.saveFailed)
+                    return
+                }
+
+                let systemAudioInput = self.systemAudioInput
+                let micAudioInput = self.micAudioInput
+                videoInput.markAsFinished()
+                systemAudioInput?.markAsFinished()
+                micAudioInput?.markAsFinished()
+                writer.finishWriting {
+                    self.writingQueue.async {
+                        if writer.status == .completed {
+                            self.debugLifecycle("finishWriting completed")
+                            continuation.resume(returning: outputURL)
+                        } else {
+                            self.debugLifecycle("finishWriting failed: \(writer.error?.localizedDescription ?? "unknown error")")
+                            self.removeOutputFile(at: outputURL)
+                            continuation.resume(throwing: writer.error ?? CaptureError.saveFailed)
+                        }
                     }
                 }
             }
@@ -997,7 +1043,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         microphoneSession = nil
     }
 
-    private func resetAfterFailedStart(removeOutputFile: Bool) async {
+    private func resetAfterFailedStart(removeOutputFile shouldRemoveOutputFile: Bool) async {
         stopMicrophoneCapture()
         if let stream {
             try? await stream.stopCapture()
@@ -1009,6 +1055,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         systemAudioInput = nil
         micAudioInput = nil
         hasStartedWriting = false
+        hasWrittenVideoFrame = false
         isPaused = false
         pauseStartedAt = nil
         totalPausedDuration = .zero
@@ -1024,12 +1071,21 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         onMicrophoneWarning?(nil)
         onMicrophoneLevel?(0)
         onMicrophoneDeviceName?("")
-        if removeOutputFile, let outputURL {
-            try? FileManager.default.removeItem(at: outputURL)
+        if shouldRemoveOutputFile, let outputURL {
+            removeOutputFile(at: outputURL)
         }
         outputURL = nil
         recordingStartedAtUptime = nil
         didReportStreamFailure = false
+    }
+
+    private func removeOutputFile(at url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            debugLifecycle("failed to remove incomplete output: \(error.localizedDescription)")
+        }
     }
 
     private func debugLifecycle(_ message: String) {
@@ -1096,6 +1152,7 @@ extension VideoRecorder: SCStreamOutput, SCStreamDelegate {
 
             if videoInput.isReadyForMoreMediaData {
                 if videoInput.append(adjustedSampleBuffer) {
+                    hasWrittenVideoFrame = true
                     lastVideoPresentationTime = proposedLastPresentationTime
                 }
             }

--- a/mac/TinyClips/Views/ClipsManagerWindow.swift
+++ b/mac/TinyClips/Views/ClipsManagerWindow.swift
@@ -410,9 +410,13 @@ private class ClipsViewModel: ObservableObject {
             options: .skipsHiddenFiles
         ) else { return [] }
         return contents.filter {
-            let isRegularFile = (try? $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) ?? false
+            let values = try? $0.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            let isRegularFile = values?.isRegularFile ?? false
+            let fileSize = values?.fileSize ?? 0
             let ext = $0.pathExtension.lowercased()
-            guard isRegularFile && ["png", "jpg", "jpeg", "mp4", "gif"].contains(ext) else { return false }
+            guard isRegularFile,
+                  fileSize > 0,
+                  ["png", "jpg", "jpeg", "mp4", "gif"].contains(ext) else { return false }
             if settings.clipsManagerIgnoreNonTinyClipsFiles {
                 return $0.lastPathComponent.hasPrefix("TinyClips ")
             }


### PR DESCRIPTION
## Why

If a recording ends before any complete screen frame is written, `VideoRecorder.stop()` cancelled the writer but left the already-created output file on disk (normal stop passed `removeOutputIfEmpty: false`; only the P1 stream-failure path cleaned up). `WebcamRecorder` had the same leak for its `-webcam.mp4` companion, both in its no-frame stop branch and in start failures after the writer was created. The result was a zero-byte `.mp4` in the user's save folder that looked like corruption in Finder and the Clips Manager.

Fixes: #221

## Approach

Cleanup-only, per the plan reviewed on the issue: a no-frame capture remains an error (`CaptureError.noFrames`) and never produces an artifact; no fallback black MP4 is written.

- **Both recorders now track `hasWrittenVideoFrame`** (set only on successful `videoInput.append`) so terminal finalization can distinguish "writer session started but no frame landed" from a real recording.
- **`VideoRecorder.finishWriting()`** (replacing the `removeOutputIfEmpty` parameter) runs its terminal decision on `writingQueue`, so it serializes with sample callbacks: no frames -> cancel, delete the output, throw `.noFrames`; `finishWriting` failure -> delete the output and rethrow the original writer error. Normal `stop()` and P1 `finishAfterStreamFailure()` now share the same artifact guarantee, while P1's partial-recording recovery and messaging are unchanged.
- **`WebcamRecorder`** gets the same invariants: an internal do/catch in `start` removes the companion if anything throws after the writer exists, and `stop`/`cancel` delete the companion on no-frame or finalization failure.
- **Cleanup never masks the original error**, deletions are idempotent and best-effort (debug-logged on failure), and each recorder only ever deletes its own output URL. `firstSampleTime`/`firstScreenSampleTime` survive reset so webcam offset compositing still works.
- **Clips Manager** defensively filters zero-byte files out of discovery (using the already-fetched `.fileSizeKey`) so artifacts from older builds stop appearing. It never deletes files.

## Validation

- `TinyClips` and `TinyClipsMAS` both build (Debug, unsigned).
- No macOS test target exists; concurrency-sensitive paths were reviewed by a dedicated code review pass (queue discipline, single-resume continuations, no deadlocks, preserved P1/P2 behavior) with no findings.

Note: runtime scenarios from the plan (immediate stop before first frame, webcam enabled + stream failure before first webcam frame, discard/restart) are worth a manual pass before release since there's no automated harness for them.