### PR TITLE
Support Continuity Camera and wind-noise removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS microphone recording now applies a default-on soft-knee limiter that prevents loud peaks from hard-clipping before AAC encoding.
+- macOS video recording now supports Continuity Camera devices and optional wind-noise removal for supported microphones.
 - macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.
 - macOS screenshot editor exports now offer Original, 1:1, 4:3, 16:9, 3:4, and 9:16 frames plus horizontal and vertical alignment, with image pixels and annotations preserved without stretching.
 - macOS screenshot clipboard copies now publish both PNG and TIFF image representations for wider app compatibility.

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -102,7 +102,7 @@ struct WebcamDeviceOption: Identifiable, Hashable {
 enum WebcamDeviceCatalog {
     private static func videoDevices() -> [AVCaptureDevice] {
         AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.builtInWideAngleCamera, .externalUnknown],
+            deviceTypes: [.builtInWideAngleCamera, .external, .continuityCamera],
             mediaType: .video,
             position: .unspecified
         ).devices
@@ -410,6 +410,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
     private var recordSystemAudio = false
     private var recordMicrophone = false
     private var microphoneLimiterEnabled = true
+    private var windNoiseRemovalEnabled = false
     private var systemAudioMuted = false
     private var microphoneMuted = false
     private var selectedMicrophoneID = ""
@@ -474,6 +475,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         self.recordSystemAudio = recordSystemAudio
         self.recordMicrophone = recordMicrophone
         self.microphoneLimiterEnabled = settings.microphoneLimiterEnabled
+        self.windNoiseRemovalEnabled = settings.windNoiseRemovalEnabled
         self.selectedMicrophoneID = selectedMicrophoneID
 
         if recordSystemAudio {
@@ -568,6 +570,9 @@ class VideoRecorder: NSObject, @unchecked Sendable {
 
         let session = AVCaptureSession()
         let input = try AVCaptureDeviceInput(device: device)
+        if windNoiseRemovalEnabled, input.isWindNoiseRemovalSupported {
+            input.isWindNoiseRemovalEnabled = true
+        }
         guard session.canAddInput(input) else {
             throw CaptureError.microphoneConnectionFailed
         }
@@ -1018,6 +1023,7 @@ class VideoRecorder: NSObject, @unchecked Sendable {
         recordSystemAudio = false
         recordMicrophone = false
         microphoneLimiterEnabled = true
+        windNoiseRemovalEnabled = false
         systemAudioMuted = false
         microphoneMuted = false
         selectedMicrophoneID = ""

--- a/mac/TinyClips/Info-MAS.plist
+++ b/mac/TinyClips/Info-MAS.plist
@@ -26,6 +26,8 @@
 	<string>TinyClips needs microphone access to record your voice alongside screen recordings.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>TinyClips needs camera access to record your camera alongside screen recordings.</string>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDocumentTypes</key>

--- a/mac/TinyClips/Info.plist
+++ b/mac/TinyClips/Info.plist
@@ -26,6 +26,8 @@
 	<string>TinyClips needs microphone access to record your voice alongside screen recordings.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>TinyClips needs camera access to record your camera alongside screen recordings.</string>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://jamesmontemagno.github.io/tiny-clips/appcast.xml</string>
 	<key>SUEnableAutomaticChecks</key>

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -274,6 +274,7 @@ class CaptureSettings: ObservableObject {
     @AppStorage("recordAudio") var recordAudio: Bool = false
     @AppStorage("recordMicrophone") var recordMicrophone: Bool = false
     @AppStorage("microphoneLimiterEnabled") var microphoneLimiterEnabled: Bool = true
+    @AppStorage("windNoiseRemovalEnabled") var windNoiseRemovalEnabled: Bool = false
     @AppStorage("selectedMicrophoneID") var selectedMicrophoneID: String = ""
     @AppStorage("webcamEnabled") var webcamEnabled: Bool = false
     @AppStorage("selectedWebcamID") var selectedWebcamID: String = ""
@@ -555,7 +556,7 @@ class CaptureSettings: ObservableObject {
             "videoMouseClickColorHex", "videoMouseClickSize", "videoMouseClickStrokeWidth", "videoMouseClickOpacity", "videoMouseClickDuration",
             "gifMouseClickColorHex", "gifMouseClickSize", "gifMouseClickStrokeWidth", "gifMouseClickOpacity", "gifMouseClickDuration",
             "showTrimmer",
-            "recordAudio", "recordMicrophone", "selectedMicrophoneID",
+            "recordAudio", "recordMicrophone", "microphoneLimiterEnabled", "windNoiseRemovalEnabled", "selectedMicrophoneID",
             "webcamEnabled", "selectedWebcamID", "webcamShape", "webcamSize", "webcamCorner", "webcamCornerRadius",
             "showScreenshotEditor", "showGifTrimmer",
             "saveImmediatelyScreenshot", "saveImmediatelyVideo", "saveImmediatelyGif",

--- a/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/VideoSettingsSection.swift
@@ -29,6 +29,10 @@ struct VideoSettingsSection: View {
             Toggle("Limit microphone peaks", isOn: $settings.microphoneLimiterEnabled)
                 .help("Softly compresses loud microphone peaks before encoding to prevent distortion.")
 
+            Toggle("Reduce background and wind noise", isOn: $settings.windNoiseRemovalEnabled)
+                .help("Uses macOS wind-noise removal when the selected microphone supports it.")
+                .accessibilityHint("When enabled, supported microphones reduce background and wind noise before recording.")
+
             Picker("Microphone input:", selection: $settings.selectedMicrophoneID) {
                 Text("System Default").tag("")
                 ForEach(availableMicrophones) { device in


### PR DESCRIPTION
## Summary
- opt both macOS app variants into Continuity Camera and expose those devices through the webcam picker
- add a default-off "Reduce background and wind noise" preference, applying it only when the selected microphone input supports it
- reset the existing microphone limiter preference alongside the new audio setting as an incidental reset-consistency fix

Closes #219

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`