### PR TITLE
Add macOS OCR region text capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
+- Added macOS OCR region capture to recognize selected screen text and copy it to the clipboard.
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS microphone recording now applies a default-on soft-knee limiter that prevents loud peaks from hard-clipping before AAC encoding.
 - macOS General settings now support separate screenshot and video/GIF save folders while preserving the shared folder as a fallback.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
 		B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B1000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
+		B1000000000000000000003B /* TextRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003B /* TextRecognitionService.swift */; };
 		B20000000000000000000001 /* TinyClipsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000001 /* TinyClipsApp.swift */; };
 		B20000000000000000000002 /* CaptureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* CaptureSettings.swift */; };
 		B20000000000000000000003 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* SettingsView.swift */; };
@@ -89,6 +90,7 @@
 		B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000038 /* ScreenshotEditorViewModel.swift */; };
 		B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B2000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
+		B2000000000000000000003B /* TextRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003B /* TextRecognitionService.swift */; };
 		B10000000000000000000021 /* CaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* CaptureManager.swift */; };
 		B10000000000000000000022 /* MenuBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* MenuBarViews.swift */; };
 		B10000000000000000000023 /* ProcessingIndicatorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* ProcessingIndicatorWindow.swift */; };
@@ -135,6 +137,7 @@
 		A1000000000000000000000E /* TinyClips.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinyClips.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000000000000000000000F /* SparkleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleController.swift; sourceTree = "<group>"; };
 		A1000000000000000000003A /* SingleInstanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceCoordinator.swift; sourceTree = "<group>"; };
+		A1000000000000000000003B /* TextRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognitionService.swift; sourceTree = "<group>"; };
 		A10000000000000000000010 /* VideoTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrimmerWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ScreenshotEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* GifTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifTrimmerWindow.swift; sourceTree = "<group>"; };
@@ -306,6 +309,7 @@
 				A1000000000000000000000A /* PermissionManager.swift */,
 				A1000000000000000000000F /* SparkleController.swift */,
 				A1000000000000000000003A /* SingleInstanceCoordinator.swift */,
+				A1000000000000000000003B /* TextRecognitionService.swift */,
 				A10000000000000000000017 /* HotKeyManager.swift */,
 				A1000000000000000000001A /* StoreService.swift */,
 				A10000000000000000000020 /* LaunchAtLoginManager.swift */,
@@ -443,6 +447,7 @@
 				B10000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
 				B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
 				B1000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */,
+				B1000000000000000000003B /* TextRecognitionService.swift in Sources */,
 				B1000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B10000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B10000000000000000000011 /* CountdownWindow.swift in Sources */,
@@ -503,6 +508,7 @@
 				B20000000000000000000038 /* ScreenshotEditorViewModel.swift in Sources */,
 				B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */,
 				B2000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */,
+				B2000000000000000000003B /* TextRecognitionService.swift in Sources */,
 				B2000000000000000000000F /* GifTrimmerWindow.swift in Sources */,
 				B20000000000000000000010 /* StartRecordingPanel.swift in Sources */,
 				B20000000000000000000011 /* CountdownWindow.swift in Sources */,

--- a/mac/TinyClips/Capture/RegionSelector.swift
+++ b/mac/TinyClips/Capture/RegionSelector.swift
@@ -4,11 +4,17 @@ import AppKit
 class RegionSelector {
     private static var activeSelector: RegionSelectorController?
 
+    static var isSelecting: Bool {
+        activeSelector != nil
+    }
+
     static func selectRegion() async -> CaptureRegion? {
         return await selectRegion(on: nil)
     }
 
     static func selectRegion(on screen: NSScreen?) async -> CaptureRegion? {
+        activeSelector?.cancel()
+
         return await withCheckedContinuation { continuation in
             let selector = RegionSelectorController(screen: screen, completion: { region in
                 Self.activeSelector = nil
@@ -27,6 +33,7 @@ private class RegionSelectorController {
     private var localMonitor: Any?
     private var globalMonitor: Any?
     private let targetScreen: NSScreen?
+    private var didFinish = false
 
     init(screen: NSScreen? = nil, completion: @escaping (CaptureRegion?) -> Void) {
         self.targetScreen = screen
@@ -89,7 +96,14 @@ private class RegionSelectorController {
         }
     }
 
+    func cancel() {
+        finish(with: nil)
+    }
+
     private func finish(with region: CaptureRegion?) {
+        guard !didFinish else { return }
+        didFinish = true
+
         if let monitor = localMonitor {
             NSEvent.removeMonitor(monitor)
             localMonitor = nil

--- a/mac/TinyClips/Capture/ScreenshotCapture.swift
+++ b/mac/TinyClips/Capture/ScreenshotCapture.swift
@@ -10,6 +10,11 @@ struct ScreenshotCapture {
     }
 
     static func capture(region: CaptureRegion, outputURL: URL) async throws -> URL {
+        let image = try await captureImage(region: region)
+        return try saveImage(image, to: outputURL)
+    }
+
+    static func captureImage(region: CaptureRegion) async throws -> CGImage {
         let filter = try await region.makeFilter()
         let config = SCStreamConfiguration()
         config.sourceRect = region.sourceRect
@@ -18,8 +23,7 @@ struct ScreenshotCapture {
         config.scalesToFit = false
         config.showsCursor = false
 
-        let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-        return try saveImage(image, to: outputURL)
+        return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
     }
 
     static func captureWindow(_ window: SCWindow) async throws -> URL {

--- a/mac/TinyClips/Capture/WindowSelector.swift
+++ b/mac/TinyClips/Capture/WindowSelector.swift
@@ -14,6 +14,10 @@ class WindowSelector {
         "com.apple.systemuiserver",
     ]
 
+    static var isSelecting: Bool {
+        activeSelector != nil
+    }
+
     static func selectWindow() async -> SCWindow? {
         let windows: [SCWindow]
         do {

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -149,8 +149,10 @@ class CaptureManager: ObservableObject {
             || isScreenshotCaptureInProgress
             || isRecordingSetupInProgress
             || RegionSelector.isSelecting
+            || WindowSelector.isSelecting
             || screenshotPickerPanel != nil
             || recordingPickerPanel != nil
+            || startPanel != nil
             || countdownWindow != nil
             || screenPickerWindow != nil
     }
@@ -383,14 +385,13 @@ class CaptureManager: ObservableObject {
             guard await PermissionManager.shared.checkPermission() else { return }
             guard let region = await RegionSelector.selectRegion() else { return }
 
-            AccessibilityAnnouncementService.shared.announce(
-                "Recognizing text from selected region.",
-                priority: .high
-            )
-            showProcessingIndicator(message: "Copying Text...", status: "Capturing region...")
-
             do {
                 let image = try await ScreenshotCapture.captureImage(region: region)
+                AccessibilityAnnouncementService.shared.announce(
+                    "Recognizing text from selected region.",
+                    priority: .high
+                )
+                showProcessingIndicator(message: "Copying Text...", status: "Recognizing text...")
                 updateProcessingProgress(0.5, status: "Recognizing text...")
 
                 switch try await TextRecognitionService.recognizeText(in: image) {
@@ -458,6 +459,16 @@ class CaptureManager: ObservableObject {
         shouldReturnToPicker: Bool,
         cursorScreen: NSScreen? = nil
     ) async {
+        let ownsPreparationState = !isCapturePreparationInProgress
+        if ownsPreparationState {
+            isCapturePreparationInProgress = true
+        }
+        defer {
+            if ownsPreparationState {
+                isCapturePreparationInProgress = false
+            }
+        }
+
         switch mode {
         case .region:
             guard let region = await RegionSelector.selectRegion() else {
@@ -2028,6 +2039,16 @@ class CaptureManager: ObservableObject {
         shouldReturnToPicker: Bool,
         cursorScreen: NSScreen? = nil
     ) async {
+        let ownsPreparationState = !isCapturePreparationInProgress
+        if ownsPreparationState {
+            isCapturePreparationInProgress = true
+        }
+        defer {
+            if ownsPreparationState {
+                isCapturePreparationInProgress = false
+            }
+        }
+
         guard let target = await chooseCaptureTarget(for: mode, cursorScreen: cursorScreen) else {
             if shouldReturnToPicker {
                 showRecordingPicker(for: type, cursorScreen: cursorScreen)

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -132,11 +132,27 @@ class CaptureManager: ObservableObject {
     @Published var activeWebcamName: String?
     @Published var microphoneLevel: Double = 0
     @Published var microphoneWarningMessage: String?
+    @Published private(set) var isOCRInFlight = false
+    @Published private(set) var isCapturePreparationInProgress = false
+    @Published private(set) var isScreenshotCaptureInProgress = false
+    @Published private(set) var isRecordingSetupInProgress = false
     @Published private(set) var captureHotKeyRegistrationError: String?
     @Published private(set) var stopHotKeyRegistrationError: String?
 
     var hotKeyRegistrationError: String? {
         captureHotKeyRegistrationError ?? stopHotKeyRegistrationError
+    }
+
+    var isCaptureActionInProgress: Bool {
+        isOCRInFlight
+            || isCapturePreparationInProgress
+            || isScreenshotCaptureInProgress
+            || isRecordingSetupInProgress
+            || RegionSelector.isSelecting
+            || screenshotPickerPanel != nil
+            || recordingPickerPanel != nil
+            || countdownWindow != nil
+            || screenPickerWindow != nil
     }
 
     private var videoRecorder: VideoRecorder?
@@ -220,79 +236,37 @@ class CaptureManager: ObservableObject {
     }
 
     private func configureGlobalHotKeys() {
-        let settings = CaptureSettings.shared
-        let result = registerCaptureHotKeys(
-            screenshot: HotKeyBinding(
-                keyCode: settings.screenshotHotKeyCode,
-                carbonModifiers: settings.screenshotHotKeyModifiers
-            ),
-            video: HotKeyBinding(
-                keyCode: settings.videoHotKeyCode,
-                carbonModifiers: settings.videoHotKeyModifiers
-            ),
-            gif: HotKeyBinding(
-                keyCode: settings.gifHotKeyCode,
-                carbonModifiers: settings.gifHotKeyModifiers
-            )
-        )
+        let result = registerCaptureHotKeys(CaptureSettings.shared.hotKeyBindings)
         captureHotKeyRegistrationError = result.errorMessage
 
         updateStopHotKeyRegistration()
     }
 
     @discardableResult
-    func applyCaptureHotKey(_ binding: HotKeyBinding, for captureType: CaptureType) -> String? {
+    func applyCaptureHotKey(_ binding: HotKeyBinding, for action: HotKeyAction) -> String? {
         let settings = CaptureSettings.shared
-        var screenshot = HotKeyBinding(
-            keyCode: settings.screenshotHotKeyCode,
-            carbonModifiers: settings.screenshotHotKeyModifiers
-        )
-        var video = HotKeyBinding(
-            keyCode: settings.videoHotKeyCode,
-            carbonModifiers: settings.videoHotKeyModifiers
-        )
-        var gif = HotKeyBinding(
-            keyCode: settings.gifHotKeyCode,
-            carbonModifiers: settings.gifHotKeyModifiers
-        )
-        let currentBinding: HotKeyBinding
-
-        switch captureType {
-        case .screenshot:
-            currentBinding = screenshot
-        case .video:
-            currentBinding = video
-        case .gif:
-            currentBinding = gif
-        }
+        var bindings = settings.hotKeyBindings
+        guard let currentBinding = bindings[action] else { return nil }
 
         if let validationError = HotKeyBinding.validationError(
             for: binding,
-            captureType: captureType,
-            captureBindings: [(.screenshot, screenshot), (.video, video), (.gif, gif)]
+            action: action,
+            bindings: bindings
         ) {
             captureHotKeyRegistrationError = validationError
             return validationError
         }
 
         if binding == currentBinding {
-            let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+            let result = registerCaptureHotKeys(bindings)
             captureHotKeyRegistrationError = result.errorMessage
             return result.errorMessage
         }
 
-        switch captureType {
-        case .screenshot:
-            screenshot = binding
-        case .video:
-            video = binding
-        case .gif:
-            gif = binding
-        }
-
-        let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+        bindings[action] = binding
+        let result = registerCaptureHotKeys(bindings)
         guard let registrationError = result.errorMessage else {
-            persistCaptureHotKeys(screenshot: screenshot, video: video, gif: gif, settings: settings)
+            persistCaptureHotKeys(bindings, settings: settings)
             captureHotKeyRegistrationError = nil
             return nil
         }
@@ -303,18 +277,15 @@ class CaptureManager: ObservableObject {
 
     @discardableResult
     func resetCaptureHotKeysToDefaults() -> String? {
-        let screenshot = HotKeyBinding.defaultScreenshot
-        let video = HotKeyBinding.defaultVideo
-        let gif = HotKeyBinding.defaultGif
-        let result = registerCaptureHotKeys(screenshot: screenshot, video: video, gif: gif)
+        let bindings = Dictionary(
+            uniqueKeysWithValues: HotKeyAction.allCases.map {
+                ($0, HotKeyBinding.defaultBinding(for: $0))
+            }
+        )
+        let result = registerCaptureHotKeys(bindings)
 
         guard let registrationError = result.errorMessage else {
-            persistCaptureHotKeys(
-                screenshot: screenshot,
-                video: video,
-                gif: gif,
-                settings: CaptureSettings.shared
-            )
+            persistCaptureHotKeys(bindings, settings: CaptureSettings.shared)
             captureHotKeyRegistrationError = nil
             return nil
         }
@@ -324,45 +295,40 @@ class CaptureManager: ObservableObject {
     }
 
     private func persistCaptureHotKeys(
-        screenshot: HotKeyBinding,
-        video: HotKeyBinding,
-        gif: HotKeyBinding,
+        _ bindings: [HotKeyAction: HotKeyBinding],
         settings: CaptureSettings
     ) {
         shouldIgnoreNextHotKeySettingsChange = true
-        settings.screenshotHotKeyCode = screenshot.keyCode
-        settings.screenshotHotKeyModifiers = screenshot.carbonModifiers
-        settings.videoHotKeyCode = video.keyCode
-        settings.videoHotKeyModifiers = video.carbonModifiers
-        settings.gifHotKeyCode = gif.keyCode
-        settings.gifHotKeyModifiers = gif.carbonModifiers
+        for action in HotKeyAction.allCases {
+            guard let binding = bindings[action] else { continue }
+            settings.setHotKeyBinding(binding, for: action)
+        }
     }
 
     private func registerCaptureHotKeys(
-        screenshot: HotKeyBinding,
-        video: HotKeyBinding,
-        gif: HotKeyBinding
+        _ bindings: [HotKeyAction: HotKeyBinding]
     ) -> HotKeyManager.RegistrationResult {
-        hotKeyManager.registerCaptureHotKeys(
-            screenshotKeyCode: UInt32(screenshot.keyCode),
-            screenshotModifiers: UInt32(screenshot.carbonModifiers),
-            onScreenshot: { [weak self] in
-                guard let self, !self.isRecording else { return }
-                self.takeScreenshot()
-            },
-            videoKeyCode: UInt32(video.keyCode),
-            videoModifiers: UInt32(video.carbonModifiers),
-            onRecordVideo: { [weak self] in
-                guard let self, !self.isRecording else { return }
-                self.startVideoRecording()
-            },
-            gifKeyCode: UInt32(gif.keyCode),
-            gifModifiers: UInt32(gif.carbonModifiers),
-            onRecordGif: { [weak self] in
-                guard let self, !self.isRecording else { return }
-                self.startGifRecording()
-            }
-        )
+        let registrations = HotKeyAction.allCases.compactMap { action -> HotKeyManager.ActionRegistration? in
+            guard let binding = bindings[action] else { return nil }
+            return HotKeyManager.ActionRegistration(
+                action: action,
+                binding: binding,
+                handler: { [weak self] in
+                    guard let self, !self.isRecording, !self.isCaptureActionInProgress else { return }
+                    switch action {
+                    case .screenshot:
+                        self.takeScreenshot()
+                    case .recordVideo:
+                        self.startVideoRecording()
+                    case .recordGif:
+                        self.startGifRecording()
+                    case .copyTextFromRegion:
+                        self.copyTextFromRegion()
+                    }
+                }
+            )
+        }
+        return hotKeyManager.registerActionHotKeys(registrations)
     }
 
     private func updateStopHotKeyRegistration() {
@@ -379,10 +345,15 @@ class CaptureManager: ObservableObject {
     }
 
     func takeScreenshot() {
+        guard !isCaptureActionInProgress else { return }
+
+        isCapturePreparationInProgress = true
         let cursorScreen = screenUnderMouseCursor()
         Task {
-            await prepareForNewCaptureRequest()
+            defer { isCapturePreparationInProgress = false }
+            guard await prepareForNewCaptureRequest() else { return }
             guard await PermissionManager.shared.checkPermission() else { return }
+            guard !isOCRInFlight else { return }
             let settings = CaptureSettings.shared
             if settings.shouldShowCapturePicker(for: .screenshot) {
                 showScreenshotPicker(cursorScreen: cursorScreen)
@@ -394,6 +365,49 @@ class CaptureManager: ObservableObject {
                     shouldReturnToPicker: false,
                     cursorScreen: cursorScreen
                 )
+            }
+        }
+    }
+
+    func copyTextFromRegion() {
+        guard !isRecording, !isCaptureActionInProgress else { return }
+
+        isOCRInFlight = true
+        Task {
+            defer {
+                dismissProcessingIndicator()
+                isOCRInFlight = false
+            }
+
+            guard await prepareForNewCaptureRequest(allowOCRInFlight: true) else { return }
+            guard await PermissionManager.shared.checkPermission() else { return }
+            guard let region = await RegionSelector.selectRegion() else { return }
+
+            AccessibilityAnnouncementService.shared.announce(
+                "Recognizing text from selected region.",
+                priority: .high
+            )
+            showProcessingIndicator(message: "Copying Text...", status: "Capturing region...")
+
+            do {
+                let image = try await ScreenshotCapture.captureImage(region: region)
+                updateProcessingProgress(0.5, status: "Recognizing text...")
+
+                switch try await TextRecognitionService.recognizeText(in: image) {
+                case .success(let text):
+                    guard SaveService.shared.copyTextToClipboard(text) else {
+                        SaveService.shared.showError("Could not copy recognized text to the clipboard.")
+                        return
+                    }
+                    AccessibilityAnnouncementService.shared.announce(
+                        "Text copied to clipboard.",
+                        priority: .medium
+                    )
+                case .noTextFound:
+                    SaveService.shared.showError("No text found in the selected region.")
+                }
+            } catch {
+                SaveService.shared.showError("Text recognition failed: \(error.localizedDescription)")
             }
         }
     }
@@ -503,11 +517,13 @@ class CaptureManager: ObservableObject {
         let doCapture = { [weak self] in
             guard let self else { return }
             self.dismissRegionIndicator()
+            self.isScreenshotCaptureInProgress = true
             AccessibilityAnnouncementService.shared.announceCaptureStart(
                 for: .screenshot,
                 countdownCompleted: countdownEnabled
             )
             Task {
+                defer { self.isScreenshotCaptureInProgress = false }
                 var didPresentEditor = false
                 do {
                     let settings = CaptureSettings.shared
@@ -576,10 +592,15 @@ class CaptureManager: ObservableObject {
     }
 
     func startVideoRecording() {
+        guard !isCaptureActionInProgress else { return }
+
+        isCapturePreparationInProgress = true
         let cursorScreen = screenUnderMouseCursor()
         Task {
-            await prepareForNewCaptureRequest()
+            defer { isCapturePreparationInProgress = false }
+            guard await prepareForNewCaptureRequest() else { return }
             guard await PermissionManager.shared.checkPermission() else { return }
+            guard !isOCRInFlight else { return }
             let settings = CaptureSettings.shared
             if settings.shouldShowCapturePicker(for: .video) {
                 showRecordingPicker(for: .video, cursorScreen: cursorScreen)
@@ -612,11 +633,17 @@ class CaptureManager: ObservableObject {
 
         let doRecord = { [weak self] in
             guard let self else { return }
+            self.isRecordingSetupInProgress = true
             AccessibilityAnnouncementService.shared.announceCaptureStart(
                 for: .video,
                 countdownCompleted: countdownEnabled
             )
             Task {
+                defer {
+                    if !self.isRecording {
+                        self.isRecordingSetupInProgress = false
+                    }
+                }
                 let shouldSaveImmediately = !settings.showTrimmer || settings.saveImmediatelyVideo
                 let url = shouldSaveImmediately
                     ? SaveService.shared.generateURL(for: .video)
@@ -680,6 +707,7 @@ class CaptureManager: ObservableObject {
                     self.webcamRecorder = nil
                     self.activeRecordingRegion = target.region
                     self.isRecording = true
+                    self.isRecordingSetupInProgress = false
                     self.isRecordingPaused = false
                     self.activeRecordingRequest = .video(
                         target: target,
@@ -789,10 +817,15 @@ class CaptureManager: ObservableObject {
     }
 
     func startGifRecording() {
+        guard !isCaptureActionInProgress else { return }
+
+        isCapturePreparationInProgress = true
         let cursorScreen = screenUnderMouseCursor()
         Task {
-            await prepareForNewCaptureRequest()
+            defer { isCapturePreparationInProgress = false }
+            guard await prepareForNewCaptureRequest() else { return }
             guard await PermissionManager.shared.checkPermission() else { return }
+            guard !isOCRInFlight else { return }
             let settings = CaptureSettings.shared
             if settings.shouldShowCapturePicker(for: .gif) {
                 showRecordingPicker(for: .gif, cursorScreen: cursorScreen)
@@ -814,11 +847,17 @@ class CaptureManager: ObservableObject {
         resetRecordingAudioStatus()
         let doRecord = { [weak self] in
             guard let self else { return }
+            self.isRecordingSetupInProgress = true
             AccessibilityAnnouncementService.shared.announceCaptureStart(
                 for: .gif,
                 countdownCompleted: countdownEnabled
             )
             Task {
+                defer {
+                    if !self.isRecording {
+                        self.isRecordingSetupInProgress = false
+                    }
+                }
                 let writer = GifWriter()
                 do {
                     let sessionID = self.nextRecordingSessionID()
@@ -837,6 +876,7 @@ class CaptureManager: ObservableObject {
                     self.gifWriter = writer
                     self.activeRecordingRegion = target.region
                     self.isRecording = true
+                    self.isRecordingSetupInProgress = false
                     self.isRecordingPaused = false
                     self.activeRecordingRequest = .gif(target: target, mouseClicksEnabled: mouseClicksEnabled)
                     self.activeMouseClickCaptureEnabledOverride = mouseClicksEnabled
@@ -1468,7 +1508,9 @@ class CaptureManager: ObservableObject {
         }
     }
 
-    private func prepareForNewCaptureRequest() async {
+    private func prepareForNewCaptureRequest(allowOCRInFlight: Bool = false) async -> Bool {
+        guard allowOCRInFlight || !isOCRInFlight else { return false }
+
         if let stopRecordingTask {
             debugRecordingLifecycle("Waiting for ongoing finalize before new capture")
             await stopRecordingTask.value
@@ -1495,7 +1537,7 @@ class CaptureManager: ObservableObject {
 
         if isStoppingRecording {
             debugRecordingLifecycle("Capture request blocked while finalize in progress")
-            return
+            return false
         }
 
         if videoRecorder != nil || webcamRecorder != nil || gifWriter != nil || isRecording {
@@ -1509,6 +1551,8 @@ class CaptureManager: ObservableObject {
         } else {
             dismissStopPanel()
         }
+
+        return true
     }
 
     private func endIdleSleepAssertion() {
@@ -1750,9 +1794,12 @@ class CaptureManager: ObservableObject {
         webcamPreviewPanel = nil
     }
 
-    private func showProcessingIndicator() {
+    private func showProcessingIndicator(
+        message: String = "Processing...",
+        status: String? = "Preparing export..."
+    ) {
         guard processingIndicatorWindow == nil else { return }
-        let window = ProcessingIndicatorWindow(message: "Processing...", status: "Preparing export...", progress: 0.0)
+        let window = ProcessingIndicatorWindow(message: message, status: status, progress: 0.0)
         processingIndicatorWindow = window
         processingIndicatorShownAt = Date()
         window.show()
@@ -1786,6 +1833,7 @@ class CaptureManager: ObservableObject {
         )
 
         func dismissNow() {
+            guard self.processingIndicatorWindow === window else { return }
             window.close()
             processingIndicatorWindow = nil
             processingIndicatorShownAt = nil

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -346,7 +346,7 @@ class CaptureSettings: ObservableObject {
     @AppStorage("includeTinyClipsInCapture") var includeTinyClipsInCapture: Bool = false
     @AppStorage("showBrandingOverlay") var showBrandingOverlay: Bool = false
     // Custom global hotkeys (stored as Carbon keyCode + modifiers bitmask).
-    // Defaults: ⌃⌥⌘5 / ⌃⌥⌘6 / ⌃⌥⌘7
+    // Defaults: ⌃⌥⌘5 / ⌃⌥⌘6 / ⌃⌥⌘7 / ⌃⌥⌘8
     // 6400 = controlKey (4096) | optionKey (2048) | cmdKey (256)
     @AppStorage("screenshotHotKeyCode") var screenshotHotKeyCode: Int = 23      // kVK_ANSI_5
     @AppStorage("screenshotHotKeyModifiers") var screenshotHotKeyModifiers: Int = 6400
@@ -354,6 +354,8 @@ class CaptureSettings: ObservableObject {
     @AppStorage("videoHotKeyModifiers") var videoHotKeyModifiers: Int = 6400
     @AppStorage("gifHotKeyCode") var gifHotKeyCode: Int = 26                    // kVK_ANSI_7
     @AppStorage("gifHotKeyModifiers") var gifHotKeyModifiers: Int = 6400
+    @AppStorage("copyTextFromRegionHotKeyCode") var copyTextFromRegionHotKeyCode: Int = 28 // kVK_ANSI_8
+    @AppStorage("copyTextFromRegionHotKeyModifiers") var copyTextFromRegionHotKeyModifiers: Int = 6400
 
     func resolvedSaveDirectory(for captureType: CaptureType) -> URL {
         URL(fileURLWithPath: saveDirectoryPath(for: captureType), isDirectory: true)
@@ -442,6 +444,56 @@ class CaptureSettings: ObservableObject {
         case .gif:
             return copyGifToClipboard
         }
+    }
+
+    func hotKeyBinding(for action: HotKeyAction) -> HotKeyBinding {
+        switch action {
+        case .screenshot:
+            return HotKeyBinding(
+                keyCode: screenshotHotKeyCode,
+                carbonModifiers: screenshotHotKeyModifiers
+            )
+        case .recordVideo:
+            return HotKeyBinding(
+                keyCode: videoHotKeyCode,
+                carbonModifiers: videoHotKeyModifiers
+            )
+        case .recordGif:
+            return HotKeyBinding(
+                keyCode: gifHotKeyCode,
+                carbonModifiers: gifHotKeyModifiers
+            )
+        case .copyTextFromRegion:
+            return HotKeyBinding(
+                keyCode: copyTextFromRegionHotKeyCode,
+                carbonModifiers: copyTextFromRegionHotKeyModifiers
+            )
+        }
+    }
+
+    func setHotKeyBinding(_ binding: HotKeyBinding, for action: HotKeyAction) {
+        switch action {
+        case .screenshot:
+            screenshotHotKeyCode = binding.keyCode
+            screenshotHotKeyModifiers = binding.carbonModifiers
+        case .recordVideo:
+            videoHotKeyCode = binding.keyCode
+            videoHotKeyModifiers = binding.carbonModifiers
+        case .recordGif:
+            gifHotKeyCode = binding.keyCode
+            gifHotKeyModifiers = binding.carbonModifiers
+        case .copyTextFromRegion:
+            copyTextFromRegionHotKeyCode = binding.keyCode
+            copyTextFromRegionHotKeyModifiers = binding.carbonModifiers
+        }
+    }
+
+    var hotKeyBindings: [HotKeyAction: HotKeyBinding] {
+        Dictionary(
+            uniqueKeysWithValues: HotKeyAction.allCases.map {
+                ($0, hotKeyBinding(for: $0))
+            }
+        )
     }
 
     func shouldShowCapturePicker(for type: CaptureType) -> Bool {
@@ -574,7 +626,8 @@ class CaptureSettings: ObservableObject {
         let hotKeyKeys = [
             "screenshotHotKeyCode", "screenshotHotKeyModifiers",
             "videoHotKeyCode", "videoHotKeyModifiers",
-            "gifHotKeyCode", "gifHotKeyModifiers"
+            "gifHotKeyCode", "gifHotKeyModifiers",
+            "copyTextFromRegionHotKeyCode", "copyTextFromRegionHotKeyModifiers"
         ]
 #if APPSTORE
         let masKeys: [String] = [

--- a/mac/TinyClips/Models/HotKeyBinding.swift
+++ b/mac/TinyClips/Models/HotKeyBinding.swift
@@ -2,6 +2,26 @@ import Carbon.HIToolbox
 import SwiftUI
 import AppKit
 
+enum HotKeyAction: UInt32, CaseIterable, Hashable {
+    case screenshot = 1
+    case recordVideo = 2
+    case recordGif = 3
+    case copyTextFromRegion = 4
+
+    var displayName: String {
+        switch self {
+        case .screenshot:
+            return "Screenshot"
+        case .recordVideo:
+            return "Record Video"
+        case .recordGif:
+            return "Record GIF"
+        case .copyTextFromRegion:
+            return "Copy Text from Region"
+        }
+    }
+}
+
 // MARK: - HotKeyBinding
 
 /// Represents a global keyboard shortcut as a Carbon keyCode + modifiers bitmask.
@@ -15,19 +35,29 @@ struct HotKeyBinding: Equatable {
     /// ⌃⌥⌘ modifier mask shared by all default capture shortcuts.
     static let defaultCaptureModifiers: Int = Int(controlKey | optionKey | cmdKey)
 
-    static let defaultScreenshot = HotKeyBinding(keyCode: 23, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘5
-    static let defaultVideo      = HotKeyBinding(keyCode: 22, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘6
-    static let defaultGif        = HotKeyBinding(keyCode: 26, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘7
     static let stopRecording     = HotKeyBinding(keyCode: kVK_ANSI_Period, carbonModifiers: Int(cmdKey))
 
     private static let supportedModifierMask = Int(controlKey | optionKey | shiftKey | cmdKey)
+
+    static func defaultBinding(for action: HotKeyAction) -> HotKeyBinding {
+        switch action {
+        case .screenshot:
+            return HotKeyBinding(keyCode: 23, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘5
+        case .recordVideo:
+            return HotKeyBinding(keyCode: 22, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘6
+        case .recordGif:
+            return HotKeyBinding(keyCode: 26, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘7
+        case .copyTextFromRegion:
+            return HotKeyBinding(keyCode: 28, carbonModifiers: defaultCaptureModifiers) // ⌃⌥⌘8
+        }
+    }
 
     // MARK: - Validation
 
     static func validationError(
         for proposedBinding: HotKeyBinding,
-        captureType: CaptureType,
-        captureBindings: [(CaptureType, HotKeyBinding)]
+        action: HotKeyAction,
+        bindings: [HotKeyAction: HotKeyBinding]
     ) -> String? {
         guard proposedBinding.carbonModifiers & supportedModifierMask != 0 else {
             return "Add at least one modifier key (Control, Option, Shift, or Command)."
@@ -37,10 +67,10 @@ struct HotKeyBinding: Equatable {
             return "That shortcut is reserved for Stop Recording (\(stopRecording.displayString)). Choose a different combination."
         }
 
-        if let conflictingType = captureBindings.first(where: {
-            $0.0 != captureType && $0.1 == proposedBinding
-        })?.0 {
-            return "That shortcut is already assigned to \(conflictingType.hotKeyDisplayName)."
+        if let conflictingAction = bindings.first(where: {
+            $0.key != action && $0.value == proposedBinding
+        })?.key {
+            return "That shortcut is already assigned to \(conflictingAction.displayName)."
         }
 
         return nil
@@ -166,17 +196,4 @@ struct HotKeyBinding: Equatable {
         }
     }
 
-}
-
-extension CaptureType {
-    var hotKeyDisplayName: String {
-        switch self {
-        case .screenshot:
-            return "Screenshot"
-        case .video:
-            return "Record Video"
-        case .gif:
-            return "Record GIF"
-        }
-    }
 }

--- a/mac/TinyClips/Services/HotKeyManager.swift
+++ b/mac/TinyClips/Services/HotKeyManager.swift
@@ -10,15 +10,9 @@ final class HotKeyManager {
 
     // MARK: - Types
 
-    enum HotKeyID: UInt32 {
-        case screenshot = 1
-        case recordVideo = 2
-        case recordGif = 3
-        case stopRecording = 4
-    }
-
     private struct RegisteredHotKey {
         let reference: EventHotKeyRef
+        let name: String
         let keyCode: UInt32
         let modifiers: UInt32
         let action: () -> Void
@@ -54,8 +48,14 @@ final class HotKeyManager {
         }
     }
 
+    struct ActionRegistration {
+        let action: HotKeyAction
+        let binding: HotKeyBinding
+        let handler: () -> Void
+    }
+
     private struct HotKeyRegistration {
-        let id: HotKeyID
+        let id: UInt32
         let name: String
         let keyCode: UInt32
         let modifiers: UInt32
@@ -66,6 +66,7 @@ final class HotKeyManager {
 
     private var eventHandlerRef: EventHandlerRef?
     private var registeredHotKeys: [UInt32: RegisteredHotKey] = [:]
+    private let stopRecordingID: UInt32 = 99
 
     // MARK: - Lifecycle
 
@@ -83,49 +84,24 @@ final class HotKeyManager {
 
     // MARK: - Public
 
-    func registerCaptureHotKeys(
-        screenshotKeyCode: UInt32,
-        screenshotModifiers: UInt32,
-        onScreenshot: @escaping () -> Void,
-        videoKeyCode: UInt32,
-        videoModifiers: UInt32,
-        onRecordVideo: @escaping () -> Void,
-        gifKeyCode: UInt32,
-        gifModifiers: UInt32,
-        onRecordGif: @escaping () -> Void
-    ) -> RegistrationResult {
-        replace(
-            hotKeys: [
-                HotKeyRegistration(
-                    id: .screenshot,
-                    name: "Screenshot",
-                    keyCode: screenshotKeyCode,
-                    modifiers: screenshotModifiers,
-                    action: onScreenshot
-                ),
-                HotKeyRegistration(
-                    id: .recordVideo,
-                    name: "Record Video",
-                    keyCode: videoKeyCode,
-                    modifiers: videoModifiers,
-                    action: onRecordVideo
-                ),
-                HotKeyRegistration(
-                    id: .recordGif,
-                    name: "Record GIF",
-                    keyCode: gifKeyCode,
-                    modifiers: gifModifiers,
-                    action: onRecordGif
-                )
-            ]
-        )
+    func registerActionHotKeys(_ registrations: [ActionRegistration]) -> RegistrationResult {
+        let hotKeys = registrations.map {
+            HotKeyRegistration(
+                id: $0.action.rawValue,
+                name: $0.action.displayName,
+                keyCode: UInt32($0.binding.keyCode),
+                modifiers: UInt32($0.binding.carbonModifiers),
+                action: $0.handler
+            )
+        }
+        return replace(hotKeys: hotKeys)
     }
 
     func registerStopHotKey(onStopRecording: @escaping () -> Void) -> RegistrationResult {
         replace(
             hotKeys: [
                 HotKeyRegistration(
-                    id: .stopRecording,
+                    id: stopRecordingID,
                     name: "Stop Recording",
                     keyCode: UInt32(HotKeyBinding.stopRecording.keyCode),
                     modifiers: UInt32(HotKeyBinding.stopRecording.carbonModifiers),
@@ -136,7 +112,7 @@ final class HotKeyManager {
     }
 
     func unregisterStopHotKey() {
-        unregister(id: .stopRecording)
+        unregister(id: stopRecordingID)
     }
 
     func unregisterAll() {
@@ -153,10 +129,10 @@ final class HotKeyManager {
     private func replace(hotKeys: [HotKeyRegistration]) -> RegistrationResult {
         let ids = hotKeys.map(\.id)
         let previousHotKeys = ids.compactMap { id in
-            registeredHotKeys[id.rawValue].map {
+            registeredHotKeys[id].map {
                 HotKeyRegistration(
                     id: id,
-                    name: name(for: id),
+                    name: $0.name,
                     keyCode: $0.keyCode,
                     modifiers: $0.modifiers,
                     action: $0.action
@@ -185,7 +161,7 @@ final class HotKeyManager {
 
     private func register(_ hotKey: HotKeyRegistration) -> Bool {
         var hotKeyRef: EventHotKeyRef?
-        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: hotKey.id.rawValue)
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: hotKey.id)
 
         lastRegistrationStatus = RegisterEventHotKey(
             hotKey.keyCode,
@@ -198,8 +174,9 @@ final class HotKeyManager {
 
         guard lastRegistrationStatus == noErr, let hotKeyRef else { return false }
 
-        registeredHotKeys[hotKey.id.rawValue] = RegisteredHotKey(
+        registeredHotKeys[hotKey.id] = RegisteredHotKey(
             reference: hotKeyRef,
+            name: hotKey.name,
             keyCode: hotKey.keyCode,
             modifiers: hotKey.modifiers,
             action: hotKey.action
@@ -207,21 +184,8 @@ final class HotKeyManager {
         return true
     }
 
-    private func name(for id: HotKeyID) -> String {
-        switch id {
-        case .screenshot:
-            return "Screenshot"
-        case .recordVideo:
-            return "Record Video"
-        case .recordGif:
-            return "Record GIF"
-        case .stopRecording:
-            return "Stop Recording"
-        }
-    }
-
-    private func unregister(id: HotKeyID) {
-        guard let registeredHotKey = registeredHotKeys.removeValue(forKey: id.rawValue) else { return }
+    private func unregister(id: UInt32) {
+        guard let registeredHotKey = registeredHotKeys.removeValue(forKey: id) else { return }
         UnregisterEventHotKey(registeredHotKey.reference)
     }
 

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -485,7 +485,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
                         metadata.uploadcareURL = result.fileURL.absoluteString
                     }
                     if shouldCopyLink {
-                        self.copyTextToClipboard(result.fileURL.absoluteString)
+                        _ = self.copyTextToClipboard(result.fileURL.absoluteString)
                     }
                 }
             } catch {
@@ -497,10 +497,28 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     @MainActor
-    private func copyTextToClipboard(_ text: String) {
+    func copyTextToClipboard(_ text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+
         let pasteboard = NSPasteboard.general
+        let previousItems = pasteboard.pasteboardItems?.map { item in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        guard pasteboard.setString(text, forType: .string) else {
+            if let previousItems, !previousItems.isEmpty {
+                pasteboard.clearContents()
+                _ = pasteboard.writeObjects(previousItems)
+            }
+            return false
+        }
+        return true
     }
 
     private func showNotification(type: CaptureType, url: URL) {

--- a/mac/TinyClips/Services/TextRecognitionService.swift
+++ b/mac/TinyClips/Services/TextRecognitionService.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Vision
+
+enum TextRecognitionResult {
+    case success(String)
+    case noTextFound
+}
+
+enum TextRecognitionError: LocalizedError {
+    case requestFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .requestFailed(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+struct TextRecognitionService {
+    private static let queue = DispatchQueue(
+        label: "com.tinyclips.text-recognition",
+        qos: .userInitiated
+    )
+
+    static func recognizeText(in image: CGImage) async throws -> TextRecognitionResult {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                do {
+                    let request = VNRecognizeTextRequest()
+                    request.revision = VNRecognizeTextRequestRevision3
+                    request.recognitionLevel = .accurate
+                    request.usesLanguageCorrection = true
+                    request.automaticallyDetectsLanguage = true
+
+                    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+                    try handler.perform([request])
+
+                    let text = (request.results ?? [])
+                        .compactMap { $0.topCandidates(1).first?.string }
+                        .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                        .joined(separator: "\n")
+
+                    continuation.resume(
+                        returning: text.isEmpty ? .noTextFound : .success(text)
+                    )
+                } catch {
+                    continuation.resume(throwing: TextRecognitionError.requestFailed(error))
+                }
+            }
+        }
+    }
+}

--- a/mac/TinyClips/Views/MenuBarViews.swift
+++ b/mac/TinyClips/Views/MenuBarViews.swift
@@ -36,24 +36,36 @@ struct MenuBarContentView: View {
             } label: {
                 Label("Screenshot…", systemImage: "camera")
             }
-            .keyboardShortcut(screenshotKey, modifiers: screenshotModifiers)
+            .keyboardShortcut(key(for: .screenshot, fallback: "5"), modifiers: modifiers(for: .screenshot))
             .accessibilityHint("Starts screenshot capture.")
+            .disabled(captureManager.isCaptureActionInProgress)
+
+            Button {
+                captureManager.copyTextFromRegion()
+            } label: {
+                Label("Copy Text from Region…", systemImage: "text.viewfinder")
+            }
+            .keyboardShortcut(key(for: .copyTextFromRegion, fallback: "8"), modifiers: modifiers(for: .copyTextFromRegion))
+            .accessibilityHint("Selects a screen region and copies recognized text to the clipboard.")
+            .disabled(captureManager.isCaptureActionInProgress)
 
             Button {
                 captureManager.startVideoRecording()
             } label: {
                 Label("Record Video...", systemImage: "video")
             }
-            .keyboardShortcut(videoKey, modifiers: videoModifiers)
+            .keyboardShortcut(key(for: .recordVideo, fallback: "6"), modifiers: modifiers(for: .recordVideo))
             .accessibilityHint("Starts video recording.")
+            .disabled(captureManager.isCaptureActionInProgress)
 
             Button {
                 captureManager.startGifRecording()
             } label: {
                 Label("Record GIF...", systemImage: "photo.on.rectangle")
             }
-            .keyboardShortcut(gifKey, modifiers: gifModifiers)
+            .keyboardShortcut(key(for: .recordGif, fallback: "7"), modifiers: modifiers(for: .recordGif))
             .accessibilityHint("Starts GIF recording.")
+            .disabled(captureManager.isCaptureActionInProgress)
 
             Divider()
         } else {
@@ -264,28 +276,12 @@ struct MenuBarContentView: View {
 
     // MARK: - Dynamic Shortcut Keys
 
-    private var screenshotKey: KeyEquivalent {
-        keyEquivalent(for: settings.screenshotHotKeyCode, fallback: "5")
+    private func key(for action: HotKeyAction, fallback: Character) -> KeyEquivalent {
+        keyEquivalent(for: settings.hotKeyBinding(for: action).keyCode, fallback: fallback)
     }
 
-    private var screenshotModifiers: EventModifiers {
-        HotKeyBinding(keyCode: settings.screenshotHotKeyCode, carbonModifiers: settings.screenshotHotKeyModifiers).swiftUIModifiers
-    }
-
-    private var videoKey: KeyEquivalent {
-        keyEquivalent(for: settings.videoHotKeyCode, fallback: "6")
-    }
-
-    private var videoModifiers: EventModifiers {
-        HotKeyBinding(keyCode: settings.videoHotKeyCode, carbonModifiers: settings.videoHotKeyModifiers).swiftUIModifiers
-    }
-
-    private var gifKey: KeyEquivalent {
-        keyEquivalent(for: settings.gifHotKeyCode, fallback: "7")
-    }
-
-    private var gifModifiers: EventModifiers {
-        HotKeyBinding(keyCode: settings.gifHotKeyCode, carbonModifiers: settings.gifHotKeyModifiers).swiftUIModifiers
+    private func modifiers(for action: HotKeyAction) -> EventModifiers {
+        settings.hotKeyBinding(for: action).swiftUIModifiers
     }
 
     private func keyEquivalent(for keyCode: Int, fallback: Character) -> KeyEquivalent {

--- a/mac/TinyClips/Views/Settings/ShortcutsSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/ShortcutsSettingsSection.swift
@@ -24,29 +24,15 @@ struct ShortcutsSettingsSection: View {
                     .accessibilityLabel("Shortcut error: \(registrationError)")
             }
 
-            ShortcutRecorderField(
-                label: "Screenshot",
-                binding: screenshotBinding,
-                defaultBinding: .defaultScreenshot,
-                onBindingRecorded: { apply($0, for: .screenshot) }
-            )
-            .accessibilityLabel("Screenshot keyboard shortcut")
-
-            ShortcutRecorderField(
-                label: "Record Video",
-                binding: videoBinding,
-                defaultBinding: .defaultVideo,
-                onBindingRecorded: { apply($0, for: .video) }
-            )
-            .accessibilityLabel("Record Video keyboard shortcut")
-
-            ShortcutRecorderField(
-                label: "Record GIF",
-                binding: gifBinding,
-                defaultBinding: .defaultGif,
-                onBindingRecorded: { apply($0, for: .gif) }
-            )
-            .accessibilityLabel("Record GIF keyboard shortcut")
+            ForEach(HotKeyAction.allCases, id: \.self) { action in
+                ShortcutRecorderField(
+                    label: action.displayName,
+                    binding: settings.hotKeyBinding(for: action),
+                    defaultBinding: HotKeyBinding.defaultBinding(for: action),
+                    onBindingRecorded: { apply($0, for: action) }
+                )
+                .accessibilityLabel("\(action.displayName) keyboard shortcut")
+            }
         }
 
         Section("Fixed Shortcuts") {
@@ -73,28 +59,7 @@ struct ShortcutsSettingsSection: View {
         }
     }
 
-    private var screenshotBinding: HotKeyBinding {
-        HotKeyBinding(
-            keyCode: settings.screenshotHotKeyCode,
-            carbonModifiers: settings.screenshotHotKeyModifiers
-        )
-    }
-
-    private var videoBinding: HotKeyBinding {
-        HotKeyBinding(
-            keyCode: settings.videoHotKeyCode,
-            carbonModifiers: settings.videoHotKeyModifiers
-        )
-    }
-
-    private var gifBinding: HotKeyBinding {
-        HotKeyBinding(
-            keyCode: settings.gifHotKeyCode,
-            carbonModifiers: settings.gifHotKeyModifiers
-        )
-    }
-
-    private func apply(_ binding: HotKeyBinding, for captureType: CaptureType) {
-        shortcutError = captureManager.applyCaptureHotKey(binding, for: captureType)
+    private func apply(_ binding: HotKeyBinding, for action: HotKeyAction) {
+        shortcutError = captureManager.applyCaptureHotKey(binding, for: action)
     }
 }


### PR DESCRIPTION
Adds a direct way to copy text from any selected screen region, without creating a saved screenshot. This makes OCR available from the menu bar and a configurable global shortcut.

- Captures the selected region in memory and recognizes text with Vision's accurate, language-aware request.
- Adds the "Copy Text from Region..." menu action and shortcut settings alongside existing capture actions.
- Serializes OCR with capture setup, selection, countdown, and processing states so overlapping capture actions cannot disrupt one another.
- Preserves the current clipboard when no text is found, capture/recognition fails, or pasteboard writing fails.

Vision result ordering is kept native to avoid imposing an unsafe geometric reading order on mixed-column or right-to-left text.

Fixes: #220