### PR TITLE
Add cross-platform teleprompter overlay for video recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
+- Added a macOS teleprompter overlay for video recordings: enter a transcript in Settings → Video and an auto-scrolling, draggable, never-captured panel scrolls it on screen while you record, with an adjustable scroll speed and a remembered position.
 - Added macOS OCR region capture to recognize selected screen text and copy it to the clipboard.
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS microphone recording now applies a default-on soft-knee limiter that prevents loud peaks from hard-clipping before AAC encoding.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B10000000000000000000014 /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* HotKeyManager.swift */; };
 		B10000000000000000000015 /* ScreenPickerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000018 /* ScreenPickerWindow.swift */; };
 		B10000000000000000000016 /* RegionIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000019 /* RegionIndicatorPanel.swift */; };
+		B1000000000000000000003C /* TeleprompterPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003C /* TeleprompterPanel.swift */; };
 		B10000000000000000000017 /* StoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001A /* StoreService.swift */; };
 		B10000000000000000000018 /* ClipsManagerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001B /* ClipsManagerWindow.swift */; };
 		B10000000000000000000019 /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001C /* SubscriptionView.swift */; };
@@ -71,6 +72,7 @@
 		B20000000000000000000014 /* HotKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000017 /* HotKeyManager.swift */; };
 		B20000000000000000000015 /* ScreenPickerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000018 /* ScreenPickerWindow.swift */; };
 		B20000000000000000000016 /* RegionIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000019 /* RegionIndicatorPanel.swift */; };
+		B2000000000000000000003C /* TeleprompterPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003C /* TeleprompterPanel.swift */; };
 		B20000000000000000000017 /* StoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001A /* StoreService.swift */; };
 		B20000000000000000000018 /* ClipsManagerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001B /* ClipsManagerWindow.swift */; };
 		B20000000000000000000019 /* SubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000001C /* SubscriptionView.swift */; };
@@ -97,6 +99,7 @@
 		B10000000000000000000024 /* GeneralSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000027 /* GeneralSettingsSection.swift */; };
 		B10000000000000000000025 /* ScreenshotSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000028 /* ScreenshotSettingsSection.swift */; };
 		B10000000000000000000026 /* VideoSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000029 /* VideoSettingsSection.swift */; };
+		B1000000000000000000003D /* TeleprompterSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003D /* TeleprompterSettingsSection.swift */; };
 		B10000000000000000000027 /* GifSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002A /* GifSettingsSection.swift */; };
 		B10000000000000000000028 /* ShortcutsSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002B /* ShortcutsSettingsSection.swift */; };
 		B10000000000000000000029 /* AboutSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002C /* AboutSettingsSection.swift */; };
@@ -110,6 +113,7 @@
 		B20000000000000000000024 /* GeneralSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000027 /* GeneralSettingsSection.swift */; };
 		B20000000000000000000025 /* ScreenshotSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000028 /* ScreenshotSettingsSection.swift */; };
 		B20000000000000000000026 /* VideoSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000029 /* VideoSettingsSection.swift */; };
+		B2000000000000000000003D /* TeleprompterSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003D /* TeleprompterSettingsSection.swift */; };
 		B20000000000000000000027 /* GifSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002A /* GifSettingsSection.swift */; };
 		B20000000000000000000028 /* ShortcutsSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002B /* ShortcutsSettingsSection.swift */; };
 		B20000000000000000000029 /* AboutSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002C /* AboutSettingsSection.swift */; };
@@ -148,6 +152,7 @@
 		A10000000000000000000017 /* HotKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyManager.swift; sourceTree = "<group>"; };
 		A10000000000000000000018 /* ScreenPickerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenPickerWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000019 /* RegionIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionIndicatorPanel.swift; sourceTree = "<group>"; };
+		A1000000000000000000003C /* TeleprompterPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeleprompterPanel.swift; sourceTree = "<group>"; };
 		A1000000000000000000001A /* StoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreService.swift; sourceTree = "<group>"; };
 		A1000000000000000000001B /* ClipsManagerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipsManagerWindow.swift; sourceTree = "<group>"; };
 		A1000000000000000000001C /* SubscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionView.swift; sourceTree = "<group>"; };
@@ -172,6 +177,7 @@
 		A10000000000000000000027 /* GeneralSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsSection.swift; sourceTree = "<group>"; };
 		A10000000000000000000028 /* ScreenshotSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSettingsSection.swift; sourceTree = "<group>"; };
 		A10000000000000000000029 /* VideoSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoSettingsSection.swift; sourceTree = "<group>"; };
+		A1000000000000000000003D /* TeleprompterSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeleprompterSettingsSection.swift; sourceTree = "<group>"; };
 		A1000000000000000000002A /* GifSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifSettingsSection.swift; sourceTree = "<group>"; };
 		A1000000000000000000002B /* ShortcutsSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsSection.swift; sourceTree = "<group>"; };
 		A1000000000000000000002C /* AboutSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettingsSection.swift; sourceTree = "<group>"; };
@@ -258,6 +264,7 @@
 				A10000000000000000000016 /* GuideWindow.swift */,
 				A10000000000000000000018 /* ScreenPickerWindow.swift */,
 				A10000000000000000000019 /* RegionIndicatorPanel.swift */,
+				A1000000000000000000003C /* TeleprompterPanel.swift */,
 				A1000000000000000000001B /* ClipsManagerWindow.swift */,
 				A1000000000000000000001C /* SubscriptionView.swift */,
 				A1000000000000000000001F /* CapturePickerPanel.swift */,
@@ -282,6 +289,7 @@
 				A1000000000000000000002B /* ShortcutsSettingsSection.swift */,
 				A10000000000000000000029 /* VideoSettingsSection.swift */,
 				A10000000000000000000033 /* AnalyticsSettingsSection.swift */,
+				A1000000000000000000003D /* TeleprompterSettingsSection.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -456,6 +464,7 @@
 				B10000000000000000000014 /* HotKeyManager.swift in Sources */,
 				B10000000000000000000015 /* ScreenPickerWindow.swift in Sources */,
 				B10000000000000000000016 /* RegionIndicatorPanel.swift in Sources */,
+				B1000000000000000000003C /* TeleprompterPanel.swift in Sources */,
 				B10000000000000000000017 /* StoreService.swift in Sources */,
 				B10000000000000000000018 /* ClipsManagerWindow.swift in Sources */,
 				B10000000000000000000019 /* SubscriptionView.swift in Sources */,
@@ -473,6 +482,7 @@
 				B10000000000000000000024 /* GeneralSettingsSection.swift in Sources */,
 				B10000000000000000000025 /* ScreenshotSettingsSection.swift in Sources */,
 				B10000000000000000000026 /* VideoSettingsSection.swift in Sources */,
+				B1000000000000000000003D /* TeleprompterSettingsSection.swift in Sources */,
 				B10000000000000000000027 /* GifSettingsSection.swift in Sources */,
 				B10000000000000000000028 /* ShortcutsSettingsSection.swift in Sources */,
 				B10000000000000000000029 /* AboutSettingsSection.swift in Sources */,
@@ -517,6 +527,7 @@
 				B20000000000000000000014 /* HotKeyManager.swift in Sources */,
 				B20000000000000000000015 /* ScreenPickerWindow.swift in Sources */,
 				B20000000000000000000016 /* RegionIndicatorPanel.swift in Sources */,
+				B2000000000000000000003C /* TeleprompterPanel.swift in Sources */,
 				B20000000000000000000017 /* StoreService.swift in Sources */,
 				B20000000000000000000018 /* ClipsManagerWindow.swift in Sources */,
 				B20000000000000000000019 /* SubscriptionView.swift in Sources */,
@@ -534,6 +545,7 @@
 				B20000000000000000000024 /* GeneralSettingsSection.swift in Sources */,
 				B20000000000000000000025 /* ScreenshotSettingsSection.swift in Sources */,
 				B20000000000000000000026 /* VideoSettingsSection.swift in Sources */,
+				B2000000000000000000003D /* TeleprompterSettingsSection.swift in Sources */,
 				B20000000000000000000027 /* GifSettingsSection.swift in Sources */,
 				B20000000000000000000028 /* ShortcutsSettingsSection.swift in Sources */,
 				B20000000000000000000029 /* AboutSettingsSection.swift in Sources */,

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -492,13 +492,14 @@ class VideoRecorder: NSObject, @unchecked Sendable {
 
     func start(
         target: CaptureTarget,
+        alwaysExcludedWindows: [SCWindow],
         outputURL: URL,
         recordSystemAudio: Bool,
         recordMicrophone: Bool,
         selectedMicrophoneID: String
     ) async throws {
         debugLifecycle("start requested")
-        let preparedTarget = try await target.prepare()
+        let preparedTarget = try await target.prepare(alwaysExcluding: alwaysExcludedWindows)
         let filter = preparedTarget.filter
         let config = preparedTarget.config
 

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -169,6 +169,7 @@ class CaptureManager: ObservableObject {
     private var shouldReturnToPickerAfterRecording = false
     private var startPanel: StartRecordingPanel?
     private var stopPanel: StopRecordingPanel?
+    private var teleprompterPanel: TeleprompterPanel?
     private var webcamPreviewPanel: WebcamPreviewPanel?
     private var regionIndicatorPanel: RegionIndicatorPanel?
     private var pendingRecordingTarget: CaptureTarget?
@@ -793,6 +794,7 @@ class CaptureManager: ObservableObject {
                         return
                     }
                     self.showStopPanel()
+                    self.showTeleprompterIfNeeded(region: target.region)
                     self.scheduleVideoAutoStopIfNeeded(timeLimitMinutes: timeLimitMinutes, sessionID: sessionID)
                 } catch {
                     self.endIdleSleepAssertion()
@@ -808,6 +810,7 @@ class CaptureManager: ObservableObject {
                     self.activeRecordingRequest = nil
                     self.activeRecordingRegion = nil
                     self.dismissRegionIndicator()
+                    self.dismissTeleprompter()
                     self.activeRecordingSessionID = nil
                     self.videoRecorder = nil
                     self.webcamRecorder = nil
@@ -949,6 +952,7 @@ class CaptureManager: ObservableObject {
         cancelVideoAutoStopTask()
 
         dismissStopPanel()
+        dismissTeleprompter()
         resetRecordingAudioStatus()
         activeRecordingRegion = nil
         isRecording = false
@@ -1053,6 +1057,7 @@ class CaptureManager: ObservableObject {
         guard isRecording || videoRecorder != nil || webcamRecorder != nil || gifWriter != nil else { return }
         cancelVideoAutoStopTask()
         dismissStopPanel()
+        dismissTeleprompter()
         _ = stopMouseClickMonitoring()
         activeMouseClickCaptureEnabledOverride = nil
         activeWebcamOverlaySelection = nil
@@ -1770,6 +1775,25 @@ class CaptureManager: ObservableObject {
         stopPanel?.close()
         stopPanel = nil
         recordPanelPosition = nil
+    }
+
+    private func showTeleprompterIfNeeded(region: CaptureRegion) {
+        let settings = CaptureSettings.shared
+        let transcript = settings.teleprompterTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard settings.teleprompterEnabled, !transcript.isEmpty else { return }
+        let panel = TeleprompterPanel(transcript: transcript, scrollSpeed: settings.teleprompterScrollSpeed)
+        panel.show(relativeTo: region)
+        teleprompterPanel = panel
+    }
+
+    private func dismissTeleprompter() {
+        teleprompterPanel?.orderOut(nil)
+        let panel = teleprompterPanel
+        teleprompterPanel = nil
+        // Defer the final release so the panel isn't deallocated mid-callback.
+        DispatchQueue.main.async {
+            panel?.close()
+        }
     }
 
     private func showWebcamPreview(

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -770,6 +770,7 @@ class CaptureManager: ObservableObject {
                     self.debugRecordingLifecycle("Video session \(sessionID) started")
                     self.recordingSystemAudioEnabled = recorder.isSystemAudioCaptureActive
                     self.recordingMicrophoneEnabled = recorder.isMicrophoneCaptureActive
+                    self.teleprompterPanel?.reveal()
                     if self.isRecordingPaused {
                         self.teleprompterPanel?.pause()
                     } else {
@@ -1801,7 +1802,7 @@ class CaptureManager: ObservableObject {
         dismissTeleprompter()
         let panel = TeleprompterPanel(transcript: transcript, scrollSpeed: settings.teleprompterScrollSpeed)
         teleprompterPanel = panel
-        panel.show(relativeTo: region)
+        panel.prepareHidden(relativeTo: region)
 
         let windowID = CGWindowID(panel.windowNumber)
         for attempt in 0..<3 {

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -742,8 +742,18 @@ class CaptureManager: ObservableObject {
                     self.activeWebcamName = nil
                     self.lastVideoRecordingArtifacts = nil
 
+                    let teleprompterWindow = await self.prepareTeleprompterIfNeeded(
+                        region: target.region,
+                        sessionID: sessionID
+                    )
+                    guard self.isRecording,
+                          self.activeRecordingSessionID == sessionID,
+                          self.videoRecorder === recorder else {
+                        return
+                    }
                     try await recorder.start(
                         target: target,
+                        alwaysExcludedWindows: teleprompterWindow.map { [$0] } ?? [],
                         outputURL: url,
                         recordSystemAudio: systemAudio,
                         recordMicrophone: microphone,
@@ -760,6 +770,11 @@ class CaptureManager: ObservableObject {
                     self.debugRecordingLifecycle("Video session \(sessionID) started")
                     self.recordingSystemAudioEnabled = recorder.isSystemAudioCaptureActive
                     self.recordingMicrophoneEnabled = recorder.isMicrophoneCaptureActive
+                    if self.isRecordingPaused {
+                        self.teleprompterPanel?.pause()
+                    } else {
+                        self.teleprompterPanel?.resume()
+                    }
 
                     if webcamEnabled, let webcamOutputURL {
                         do {
@@ -794,7 +809,6 @@ class CaptureManager: ObservableObject {
                         return
                     }
                     self.showStopPanel()
-                    self.showTeleprompterIfNeeded(region: target.region)
                     self.scheduleVideoAutoStopIfNeeded(timeLimitMinutes: timeLimitMinutes, sessionID: sessionID)
                 } catch {
                     self.endIdleSleepAssertion()
@@ -994,11 +1008,13 @@ class CaptureManager: ObservableObject {
             videoRecorder?.resume()
             webcamRecorder?.resume()
             gifWriter?.resume()
+            teleprompterPanel?.resume()
             isRecordingPaused = false
         } else {
             videoRecorder?.pause()
             webcamRecorder?.pause()
             gifWriter?.pause()
+            teleprompterPanel?.pause()
             isRecordingPaused = true
         }
     }
@@ -1777,13 +1793,37 @@ class CaptureManager: ObservableObject {
         recordPanelPosition = nil
     }
 
-    private func showTeleprompterIfNeeded(region: CaptureRegion) {
+    private func prepareTeleprompterIfNeeded(region: CaptureRegion, sessionID: UInt64) async -> SCWindow? {
         let settings = CaptureSettings.shared
         let transcript = settings.teleprompterTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard settings.teleprompterEnabled, !transcript.isEmpty else { return }
+        guard settings.teleprompterEnabled, !transcript.isEmpty else { return nil }
+
+        dismissTeleprompter()
         let panel = TeleprompterPanel(transcript: transcript, scrollSpeed: settings.teleprompterScrollSpeed)
-        panel.show(relativeTo: region)
         teleprompterPanel = panel
+        panel.show(relativeTo: region)
+
+        let windowID = CGWindowID(panel.windowNumber)
+        for attempt in 0..<3 {
+            if let content = try? await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false),
+               let window = content.windows.first(where: { $0.windowID == windowID }) {
+                guard teleprompterPanel === panel,
+                      isRecording,
+                      activeRecordingSessionID == sessionID else {
+                    return nil
+                }
+                return window
+            }
+            if attempt < 2 {
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+
+        if teleprompterPanel === panel {
+            dismissTeleprompter()
+        }
+        debugRecordingLifecycle("Teleprompter was hidden because ScreenCaptureKit could not exclude its window")
+        return nil
     }
 
     private func dismissTeleprompter() {

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -346,6 +346,9 @@ class CaptureSettings: ObservableObject {
     @AppStorage("preventDisplaySleepWhileRecording") var preventDisplaySleepWhileRecording: Bool = true
     @AppStorage("includeTinyClipsInCapture") var includeTinyClipsInCapture: Bool = false
     @AppStorage("showBrandingOverlay") var showBrandingOverlay: Bool = false
+    @AppStorage("teleprompterEnabled") var teleprompterEnabled: Bool = false
+    @AppStorage("teleprompterTranscript") var teleprompterTranscript: String = ""
+    @AppStorage("teleprompterScrollSpeed") var teleprompterScrollSpeed: Double = 50
     // Custom global hotkeys (stored as Carbon keyCode + modifiers bitmask).
     // Defaults: ⌃⌥⌘5 / ⌃⌥⌘6 / ⌃⌥⌘7 / ⌃⌥⌘8
     // 6400 = controlKey (4096) | optionKey (2048) | cmdKey (256)
@@ -622,6 +625,8 @@ class CaptureSettings: ObservableObject {
             "screenshotCountdownEnabled", "screenshotCountdownDuration",
             "hasCompletedOnboarding", "alwaysCaptureMainDisplay", "multiMonitorCaptureMode", "showRegionIndicator",
             "includeTinyClipsInCapture", "showBrandingOverlay",
+            "teleprompterEnabled", "teleprompterTranscript", "teleprompterScrollSpeed",
+            "teleprompterPanelX", "teleprompterPanelY",
             "appStoreClipCountForReview", "appStoreReviewRequested"
         ]
         let hotKeyKeys = [

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -41,14 +41,20 @@ struct CaptureRegion: Sendable {
         return config
     }
 
-    func makeFilter() async throws -> SCContentFilter {
+    func makeFilter(alwaysExcluding windows: [SCWindow] = []) async throws -> SCContentFilter {
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
         guard let display = content.displays.first(where: { $0.displayID == self.displayID }) else {
             throw CaptureError.displayNotFound
         }
         let includeTinyClips = CaptureSettings.shared.includeTinyClipsInCapture
-        let excludedApps: [SCRunningApplication] = includeTinyClips ? [] : content.applications.filter {
+        if includeTinyClips {
+            return SCContentFilter(display: display, excludingWindows: windows)
+        }
+        let excludedApps: [SCRunningApplication] = content.applications.filter {
             $0.bundleIdentifier == Bundle.main.bundleIdentifier
+        }
+        if excludedApps.isEmpty {
+            return SCContentFilter(display: display, excludingWindows: windows)
         }
         return SCContentFilter(display: display, excludingApplications: excludedApps, exceptingWindows: [])
     }
@@ -61,9 +67,9 @@ struct CaptureTarget {
         self.region = region
     }
 
-    func prepare() async throws -> PreparedCaptureTarget {
+    func prepare(alwaysExcluding windows: [SCWindow] = []) async throws -> PreparedCaptureTarget {
         PreparedCaptureTarget(
-            filter: try await region.makeFilter(),
+            filter: try await region.makeFilter(alwaysExcluding: windows),
             config: region.makeStreamConfig(),
             pixelWidth: region.pixelWidth,
             pixelHeight: region.pixelHeight

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct TeleprompterSettingsSection: View {
+    @ObservedObject var settings: CaptureSettings
+
+    var body: some View {
+        Section("Teleprompter") {
+            Toggle("Enable teleprompter", isOn: $settings.teleprompterEnabled)
+                .help("Show an auto-scrolling transcript overlay while recording video. The overlay is never captured in the recording.")
+                .accessibilityHint("When enabled, an auto-scrolling transcript overlay appears during video recordings only.")
+
+            if settings.teleprompterEnabled {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Transcript:")
+                    TextEditor(text: $settings.teleprompterTranscript)
+                        .font(.system(size: 13))
+                        .frame(minHeight: 80, maxHeight: 140)
+                        .accessibilityLabel("Teleprompter transcript")
+                        .accessibilityHint("Enter the text to scroll during video recordings.")
+                    Text("The teleprompter only appears during video recordings, never GIFs or screenshots, and is never captured.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
+                    Text("Scroll speed:")
+                    Slider(
+                        value: $settings.teleprompterScrollSpeed,
+                        in: 10...200,
+                        step: 5
+                    )
+                    .accessibilityLabel("Teleprompter scroll speed")
+                    .accessibilityValue("\(Int(settings.teleprompterScrollSpeed)) points per second")
+                    Text("\(Int(settings.teleprompterScrollSpeed)) pt/s")
+                        .monospacedDigit()
+                        .frame(width: 56, alignment: .trailing)
+                }
+                .help("Set how fast the transcript scrolls, in points per second.")
+            }
+        }
+    }
+}

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -88,6 +88,7 @@ struct SettingsView: View {
                         availableWebcams: availableWebcams,
                         selectedTab: $selectedTab
                     )
+                    TeleprompterSettingsSection(settings: settings)
                 case .gif:
                     GifSettingsSection(
                         settings: settings,

--- a/mac/TinyClips/Views/TeleprompterPanel.swift
+++ b/mac/TinyClips/Views/TeleprompterPanel.swift
@@ -36,9 +36,16 @@ final class TeleprompterPanel: NSPanel {
         contentView = hostingView
     }
 
-    func show(relativeTo region: CaptureRegion?) {
+    func prepareHidden(relativeTo region: CaptureRegion?) {
         restorePosition(for: region)
+        alphaValue = 0
+        ignoresMouseEvents = true
         orderFront(nil)
+    }
+
+    func reveal() {
+        alphaValue = 1
+        ignoresMouseEvents = false
     }
 
     func pause() {
@@ -85,7 +92,8 @@ final class TeleprompterPanel: NSPanel {
     private static func isUsableOrigin(_ origin: NSPoint, panelSize: NSSize) -> Bool {
         let panelRect = NSRect(origin: origin, size: panelSize)
         return NSScreen.screens.contains { screen in
-            screen.visibleFrame.intersects(panelRect.insetBy(dx: -panelSize.width / 4, dy: -panelSize.height / 4))
+            let visibleIntersection = screen.visibleFrame.intersection(panelRect)
+            return visibleIntersection.width >= 80 && visibleIntersection.height >= 40
         }
     }
 
@@ -179,6 +187,7 @@ private struct TeleprompterView: View {
                 .font(.system(size: 24, weight: .medium))
                 .foregroundStyle(.white)
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 12)
                 .background {
@@ -187,10 +196,11 @@ private struct TeleprompterView: View {
                     }
                 }
         }
-        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight, alignment: .top)
+        .frame(width: TeleprompterPanel.panelSize.width, alignment: .top)
+        .fixedSize(horizontal: false, vertical: true)
         .offset(y: -state.scrollOffset)
+        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight, alignment: .top)
         .clipped()
-        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight)
         .background {
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color.black.opacity(0.7))

--- a/mac/TinyClips/Views/TeleprompterPanel.swift
+++ b/mac/TinyClips/Views/TeleprompterPanel.swift
@@ -1,0 +1,157 @@
+import AppKit
+import SwiftUI
+
+final class TeleprompterPanel: NSPanel {
+    static let panelSize = NSSize(width: 600, height: 140)
+
+    private static let positionXKey = "teleprompterPanelX"
+    private static let positionYKey = "teleprompterPanelY"
+
+    private var didPersistPosition = false
+
+    init(transcript: String, scrollSpeed: Double) {
+        super.init(
+            contentRect: NSRect(origin: .zero, size: Self.panelSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        isReleasedWhenClosed = false
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isMovableByWindowBackground = true
+
+        let state = TeleprompterScrollState(scrollSpeed: scrollSpeed)
+        let hostingView = NSHostingView(rootView: TeleprompterView(state: state, transcript: transcript))
+        hostingView.setAccessibilityElement(true)
+        hostingView.setAccessibilityRole(.staticText)
+        hostingView.setAccessibilityLabel("Teleprompter")
+        hostingView.setAccessibilityValue(transcript)
+        contentView = hostingView
+    }
+
+    func show(relativeTo region: CaptureRegion?) {
+        restorePosition(for: region)
+        orderFront(nil)
+    }
+
+    override func close() {
+        persistPosition()
+        super.close()
+    }
+
+    private func restorePosition(for region: CaptureRegion?) {
+        let defaults = UserDefaults.standard
+        if let x = defaults.object(forKey: Self.positionXKey) as? Double,
+           let y = defaults.object(forKey: Self.positionYKey) as? Double {
+            let origin = NSPoint(x: x, y: y)
+            if Self.isUsableOrigin(origin, panelSize: frame.size) {
+                setFrameOrigin(origin)
+                return
+            }
+        }
+
+        guard let screen = Self.screen(for: region) ?? NSScreen.main else { return }
+        let frame = screen.frame
+        setFrameOrigin(NSPoint(
+            x: frame.midX - Self.panelSize.width / 2,
+            y: frame.maxY - Self.panelSize.height - 120
+        ))
+    }
+
+    private func persistPosition() {
+        guard !didPersistPosition else { return }
+        didPersistPosition = true
+        let defaults = UserDefaults.standard
+        defaults.set(Double(frame.origin.x), forKey: Self.positionXKey)
+        defaults.set(Double(frame.origin.y), forKey: Self.positionYKey)
+    }
+
+    private static func isUsableOrigin(_ origin: NSPoint, panelSize: NSSize) -> Bool {
+        let panelRect = NSRect(origin: origin, size: panelSize)
+        return NSScreen.screens.contains { screen in
+            screen.visibleFrame.intersects(panelRect.insetBy(dx: -panelSize.width / 4, dy: -panelSize.height / 4))
+        }
+    }
+
+    private static func screen(for region: CaptureRegion?) -> NSScreen? {
+        guard let region else { return nil }
+        return NSScreen.screens.first(where: {
+            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == region.displayID
+        })
+    }
+}
+
+private final class TeleprompterScrollState: ObservableObject {
+    @Published var scrollOffset: CGFloat = 0
+    @Published var contentHeight: CGFloat = 0
+
+    let scrollSpeed: Double
+    var timer: Timer?
+
+    init(scrollSpeed: Double) {
+        self.scrollSpeed = scrollSpeed
+    }
+
+    func start(viewportHeight: CGFloat) {
+        stop()
+        scrollOffset = 0
+        let interval: TimeInterval = 1.0 / 60.0
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            let maxOffset = max(0, self.contentHeight - viewportHeight)
+            guard maxOffset > 0 else { return }
+            let next = self.scrollOffset + self.scrollSpeed * interval
+            if next >= maxOffset {
+                self.scrollOffset = maxOffset
+                self.stop()
+            } else {
+                self.scrollOffset = next
+            }
+        }
+        if let timer {
+            RunLoop.main.add(timer, forMode: .common)
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+private struct TeleprompterView: View {
+    @ObservedObject var state: TeleprompterScrollState
+    let transcript: String
+
+    private let viewportHeight: CGFloat = TeleprompterPanel.panelSize.height - 24
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(transcript)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.onAppear { state.contentHeight = proxy.size.height }
+                    }
+                }
+        }
+        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight, alignment: .top)
+        .offset(y: -state.scrollOffset)
+        .clipped()
+        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight)
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(0.7))
+        }
+        .onAppear { state.start(viewportHeight: viewportHeight) }
+        .onDisappear { state.stop() }
+    }
+}

--- a/mac/TinyClips/Views/TeleprompterPanel.swift
+++ b/mac/TinyClips/Views/TeleprompterPanel.swift
@@ -8,8 +8,11 @@ final class TeleprompterPanel: NSPanel {
     private static let positionYKey = "teleprompterPanelY"
 
     private var didPersistPosition = false
+    private let scrollState: TeleprompterScrollState
 
     init(transcript: String, scrollSpeed: Double) {
+        let scrollState = TeleprompterScrollState(scrollSpeed: scrollSpeed)
+        self.scrollState = scrollState
         super.init(
             contentRect: NSRect(origin: .zero, size: Self.panelSize),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -22,10 +25,10 @@ final class TeleprompterPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        sharingType = .none
         isMovableByWindowBackground = true
 
-        let state = TeleprompterScrollState(scrollSpeed: scrollSpeed)
-        let hostingView = NSHostingView(rootView: TeleprompterView(state: state, transcript: transcript))
+        let hostingView = NSHostingView(rootView: TeleprompterView(state: scrollState, transcript: transcript))
         hostingView.setAccessibilityElement(true)
         hostingView.setAccessibilityRole(.staticText)
         hostingView.setAccessibilityLabel("Teleprompter")
@@ -38,7 +41,16 @@ final class TeleprompterPanel: NSPanel {
         orderFront(nil)
     }
 
+    func pause() {
+        scrollState.pause()
+    }
+
+    func resume() {
+        scrollState.resume()
+    }
+
     override func close() {
+        scrollState.stop()
         persistPosition()
         super.close()
     }
@@ -87,18 +99,50 @@ final class TeleprompterPanel: NSPanel {
 
 private final class TeleprompterScrollState: ObservableObject {
     @Published var scrollOffset: CGFloat = 0
-    @Published var contentHeight: CGFloat = 0
+    @Published var contentHeight: CGFloat = 0 {
+        didSet {
+            if !isPaused {
+                startTimer()
+            }
+        }
+    }
 
     let scrollSpeed: Double
-    var timer: Timer?
+    private var timer: Timer?
+    private var viewportHeight: CGFloat?
+    private var isPaused = true
 
     init(scrollSpeed: Double) {
         self.scrollSpeed = scrollSpeed
     }
 
     func start(viewportHeight: CGFloat) {
-        stop()
-        scrollOffset = 0
+        self.viewportHeight = viewportHeight
+        if !isPaused {
+            startTimer()
+        }
+    }
+
+    func pause() {
+        isPaused = true
+        stopTimer()
+    }
+
+    func resume() {
+        isPaused = false
+        startTimer()
+    }
+
+    func stop() {
+        isPaused = true
+        viewportHeight = nil
+        stopTimer()
+    }
+
+    private func startTimer() {
+        guard timer == nil, let viewportHeight else { return }
+        let maxOffset = max(0, contentHeight - viewportHeight)
+        guard scrollOffset < maxOffset else { return }
         let interval: TimeInterval = 1.0 / 60.0
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             guard let self else { return }
@@ -107,7 +151,7 @@ private final class TeleprompterScrollState: ObservableObject {
             let next = self.scrollOffset + self.scrollSpeed * interval
             if next >= maxOffset {
                 self.scrollOffset = maxOffset
-                self.stop()
+                self.stopTimer()
             } else {
                 self.scrollOffset = next
             }
@@ -117,7 +161,7 @@ private final class TeleprompterScrollState: ObservableObject {
         }
     }
 
-    func stop() {
+    private func stopTimer() {
         timer?.invalidate()
         timer = nil
     }

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,7 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
-- **Teleprompter transcript overlay** — Settings → Teleprompter lets you paste a script, enable the teleprompter, and tune the scroll speed (10–200 px/s). During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay is excluded from capture so it never appears in the recorded video, can be dragged anywhere (the position is remembered), and stays hidden for GIF recordings, screenshots, and when the transcript is empty.
+- **Teleprompter transcript overlay** — Settings → Teleprompter lets you paste a script, enable the teleprompter, and tune the scroll speed (10–200 DIPs/s). During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay appears only after recording starts, pauses and resumes with recording, fails closed if Windows cannot exclude it from capture, and remembers a monitor-relative position across mixed-DPI display changes.
 
 ### Fixed
 - Fixed the video trimmer so preview playback stops immediately when saving or closing the window.

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,9 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Added
+- **Teleprompter transcript overlay** — Settings → Teleprompter lets you paste a script, enable the teleprompter, and tune the scroll speed (10–200 px/s). During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay is excluded from capture so it never appears in the recorded video, can be dragged anywhere (the position is remembered), and stays hidden for GIF recordings, screenshots, and when the transcript is empty.
+
 ### Fixed
 - Fixed the video trimmer so preview playback stops immediately when saving or closing the window.
 

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -924,6 +924,24 @@ public partial class App : Application
         }
     }
 
+    private static void ShowTeleprompterFailureNotification()
+    {
+        try
+        {
+            EnsureNotificationsRegistered();
+            var notification = new AppNotificationBuilder()
+                .AddText("Teleprompter unavailable")
+                .AddText("Windows could not exclude the overlay from capture, so it was kept hidden. Recording continues.")
+                .BuildNotification();
+
+            AppNotificationManager.Default.Show(notification);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to show teleprompter failure notification: {ex}");
+        }
+    }
+
     private async Task RunStartupUpdateCheckAsync()
     {
         var result = await CheckForUpdatesAsync(isManualCheck: false);
@@ -1097,6 +1115,7 @@ public partial class App : Application
         StopRecordingTimer();
         _recordingIndicator?.UpdateElapsed(_recordingElapsedBeforePause);
         _recordingIndicator?.SetPaused(true);
+        _teleprompter?.PauseScrolling();
     }
 
     private async Task ResumeActiveRecordingAsync()
@@ -1129,6 +1148,7 @@ public partial class App : Application
 
         _recordingStartedUtc = DateTime.UtcNow;
         _recordingIndicator?.SetPaused(false);
+        _teleprompter?.ResumeScrolling();
         StartRecordingTimer();
     }
 
@@ -1139,25 +1159,38 @@ public partial class App : Application
             return;
         }
 
-        await DiscardActiveRecordingAsync(clearActiveSelection: false);
-        _activeRecordingSelection = selection;
-        _activeRecordingType = type;
-        ShowRecordingRegionIndicator(selection);
-        ShowRecordingIndicator(type, selection, stopEnabled: false, startTimer: false);
-
-        if (type == CaptureType.Video)
+        try
         {
-            var settings = Services.GetRequiredService<ICaptureSettings>();
-            await Services.GetRequiredService<IVideoRecordingService>()
-                .StartAsync(selection.Target, selection.Region, settings.VideoRecordingTimeLimitMinutes);
-        }
-        else
-        {
-            await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
-        }
+            await DiscardActiveRecordingAsync(clearActiveSelection: false);
+            _activeRecordingSelection = selection;
+            _activeRecordingType = type;
+            ShowRecordingRegionIndicator(selection);
+            ShowRecordingIndicator(type, selection, stopEnabled: false, startTimer: false);
 
-        ActivateRecordingIndicatorForStartedCapture(type);
-        UpdateRecordingState();
+            if (type == CaptureType.Video)
+            {
+                var settings = Services.GetRequiredService<ICaptureSettings>();
+                await Services.GetRequiredService<IVideoRecordingService>()
+                    .StartAsync(selection.Target, selection.Region, settings.VideoRecordingTimeLimitMinutes);
+            }
+            else
+            {
+                await Services.GetRequiredService<IGifRecordingService>().StartAsync(selection.Target, selection.Region);
+            }
+
+            ActivateRecordingIndicatorForStartedCapture(type);
+            UpdateRecordingState();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to restart {type} recording: {ex}");
+            HideRecordingIndicator();
+            CloseRecordingRegionIndicator();
+            _activeRecordingSelection = null;
+            _activeRecordingType = null;
+            _activeRecordingWasPickerInitiated = false;
+            UpdateRecordingState();
+        }
     }
 
     private Task DiscardActiveRecordingAsync() => DiscardActiveRecordingAsync(clearActiveSelection: true);
@@ -1259,7 +1292,6 @@ public partial class App : Application
         HideRecordingIndicator();
 
         var hotKeys = Services.GetRequiredService<IHotKeyService>();
-        var settings = Services.GetRequiredService<ICaptureSettings>();
         var window = new RecordingIndicatorWindow(hotKeys.StopRecordingDisplayString);
         window.StopRequested = () => _ = StopActiveRecordingAsync();
         window.PauseRequested = () => _ = PauseActiveRecordingAsync();
@@ -1291,8 +1323,6 @@ public partial class App : Application
         }
         window.ShowNear(monitor, region);
 
-        ShowTeleprompterIfNeeded(type, monitor, settings);
-
         if (startTimer)
         {
             _recordingStartedUtc = DateTime.UtcNow;
@@ -1314,6 +1344,14 @@ public partial class App : Application
             video.CanMuteMicrophone,
             video.IsMicrophoneMuted);
         ShowWebcamPreviewForActiveRecording();
+        if (_activeRecordingSelection is { } selection)
+        {
+            var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+            ShowTeleprompterIfNeeded(
+                type,
+                monitor,
+                Services.GetRequiredService<ICaptureSettings>());
+        }
         StartRecordingTimer();
         AnnounceRecordingStarted(type);
     }
@@ -1397,7 +1435,8 @@ public partial class App : Application
             return;
         }
 
-        var window = new TeleprompterWindow(settings, monitor);
+        var monitorService = Services.GetRequiredService<IMonitorService>();
+        var window = new TeleprompterWindow(settings, monitorService, monitor);
         window.Closed += (_, _) =>
         {
             if (ReferenceEquals(_teleprompter, window))
@@ -1405,8 +1444,13 @@ public partial class App : Application
                 _teleprompter = null;
             }
         };
+        if (!window.TryShow())
+        {
+            ShowTeleprompterFailureNotification();
+            return;
+        }
+
         _teleprompter = window;
-        window.Show();
     }
 
     private void HideTeleprompter()

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -1184,6 +1184,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Failed to restart {type} recording: {ex}");
+            ShowSaveFailureNotification(CaptureOutputDescription(type));
             HideRecordingIndicator();
             CloseRecordingRegionIndicator();
             _activeRecordingSelection = null;

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -47,6 +47,7 @@ public partial class App : Application
     private Window? _trimmerWindow;
     private string? _lastTrimmerSourcePath;
     private RecordingIndicatorWindow? _recordingIndicator;
+    private TeleprompterWindow? _teleprompter;
     private WebcamPreviewWindow? _webcamPreview;
     private ProcessingIndicatorWindow? _processingIndicator;
     private RegionIndicatorWindow? _recordingRegionIndicator;
@@ -1290,6 +1291,8 @@ public partial class App : Application
         }
         window.ShowNear(monitor, region);
 
+        ShowTeleprompterIfNeeded(type, monitor, settings);
+
         if (startTimer)
         {
             _recordingStartedUtc = DateTime.UtcNow;
@@ -1381,10 +1384,43 @@ public partial class App : Application
         }
     }
 
+    private void ShowTeleprompterIfNeeded(CaptureType type, MonitorInfo? monitor, ICaptureSettings settings)
+    {
+        HideTeleprompter();
+
+        // Video recordings only — the teleprompter never appears for GIFs or screenshots,
+        // and stays hidden when disabled or when there is no transcript to scroll.
+        if (type != CaptureType.Video ||
+            !settings.TeleprompterEnabled ||
+            string.IsNullOrWhiteSpace(settings.TeleprompterTranscript))
+        {
+            return;
+        }
+
+        var window = new TeleprompterWindow(settings, monitor);
+        window.Closed += (_, _) =>
+        {
+            if (ReferenceEquals(_teleprompter, window))
+            {
+                _teleprompter = null;
+            }
+        };
+        _teleprompter = window;
+        window.Show();
+    }
+
+    private void HideTeleprompter()
+    {
+        var window = _teleprompter;
+        _teleprompter = null;
+        window?.ClosePanel();
+    }
+
     private void HideRecordingIndicator()
     {
         StopRecordingTimer();
         HideWebcamPreview();
+        HideTeleprompter();
 
         var window = _recordingIndicator;
         _recordingIndicator = null;

--- a/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="TinyClips.App.Settings.Sections.TeleprompterSettingsSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="8">
+        <TextBlock
+            Margin="4,8,0,4"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Teleprompter" />
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Teleprompter overlay" />
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="Show an auto-scrolling transcript overlay while recording video. The overlay is never captured."
+                        TextWrapping="Wrap" />
+                </StackPanel>
+                <ToggleSwitch
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="TeleprompterEnabledToggle"
+                    AutomationProperties.Name="Enable teleprompter overlay"
+                    IsOn="{x:Bind ViewModel.TeleprompterEnabled, Mode=TwoWay}" />
+            </Grid>
+        </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="8">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Transcript" />
+                <TextBox
+                    MinHeight="160"
+                    AcceptsReturn="True"
+                    AutomationProperties.AutomationId="TeleprompterTranscriptTextBox"
+                    AutomationProperties.Name="Teleprompter transcript"
+                    IsEnabled="{x:Bind ViewModel.TeleprompterEnabled, Mode=OneWay}"
+                    PlaceholderText="Paste or type the script to scroll during video recordings…"
+                    Text="{x:Bind ViewModel.TeleprompterTranscript, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="Shown for video recordings only — never for GIFs or screenshots. The overlay stays hidden while this is empty."
+                    TextWrapping="Wrap" />
+            </StackPanel>
+        </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="8">
+                <Grid ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="Scroll speed" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.TeleprompterScrollSpeedDisplay, Mode=OneWay}" />
+                </Grid>
+                <Slider
+                    AutomationProperties.AutomationId="TeleprompterScrollSpeedSlider"
+                    AutomationProperties.Name="Teleprompter scroll speed"
+                    IsEnabled="{x:Bind ViewModel.TeleprompterEnabled, Mode=OneWay}"
+                    Maximum="200"
+                    Minimum="10"
+                    Value="{x:Bind ViewModel.TeleprompterScrollSpeed, Mode=TwoWay}" />
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+
+namespace TinyClips.App.Settings.Sections;
+
+/// <summary>Teleprompter overlay enable toggle, transcript text, and scroll speed.</summary>
+public sealed partial class TeleprompterSettingsSection : UserControl
+{
+    private readonly IDisposable _realizationScope;
+
+    public SettingsViewModel ViewModel { get; }
+
+    public TeleprompterSettingsSection(SettingsViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        _realizationScope = viewModel.BeginSectionRealization();
+        InitializeComponent();
+        SectionLifecycle.HookFirstLoad(this, viewModel, _realizationScope);
+    }
+}

--- a/windows/src/TinyClips.App/Settings/SettingsSectionKind.cs
+++ b/windows/src/TinyClips.App/Settings/SettingsSectionKind.cs
@@ -16,6 +16,7 @@ public enum SettingsSectionKind
     Gif,
     MouseClicks,
     Branding,
+    Teleprompter,
     Hotkeys,
     About,
 }

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -488,7 +488,7 @@ public sealed partial class SettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(TeleprompterScrollSpeedDisplay))]
     private double _teleprompterScrollSpeed = 50;
 
-    public string TeleprompterScrollSpeedDisplay => $"{TeleprompterScrollSpeed:N0} px/s";
+    public string TeleprompterScrollSpeedDisplay => $"{TeleprompterScrollSpeed:N0} DIPs/s";
 
     // Analytics
     public System.Collections.ObjectModel.ObservableCollection<CaptureAnalyticsDayViewModel> AnalyticsDays { get; } = new();

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -477,6 +477,19 @@ public sealed partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _showBrandingOverlay;
 
+    // Teleprompter
+    [ObservableProperty]
+    private bool _teleprompterEnabled;
+
+    [ObservableProperty]
+    private string _teleprompterTranscript = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TeleprompterScrollSpeedDisplay))]
+    private double _teleprompterScrollSpeed = 50;
+
+    public string TeleprompterScrollSpeedDisplay => $"{TeleprompterScrollSpeed:N0} px/s";
+
     // Analytics
     public System.Collections.ObjectModel.ObservableCollection<CaptureAnalyticsDayViewModel> AnalyticsDays { get; } = new();
 
@@ -713,6 +726,10 @@ public sealed partial class SettingsViewModel : ObservableObject
             GifMouseClickOpacity = _settings.GifMouseClickOpacity;
             GifMouseClickColorHex = _settings.GifMouseClickColorHex;
             ShowBrandingOverlay = _settings.ShowBrandingOverlay;
+
+            TeleprompterEnabled = _settings.TeleprompterEnabled;
+            TeleprompterTranscript = _settings.TeleprompterTranscript;
+            TeleprompterScrollSpeed = Math.Clamp(_settings.TeleprompterScrollSpeed, 10.0, 200.0);
         }
         finally
         {
@@ -1157,6 +1174,12 @@ public sealed partial class SettingsViewModel : ObservableObject
     partial void OnGifMouseClickColorHexChanged(string value) => Persist(() => _settings.GifMouseClickColorHex = value);
 
     partial void OnShowBrandingOverlayChanged(bool value) => Persist(() => _settings.ShowBrandingOverlay = value);
+
+    partial void OnTeleprompterEnabledChanged(bool value) => Persist(() => _settings.TeleprompterEnabled = value);
+
+    partial void OnTeleprompterTranscriptChanged(string value) => Persist(() => _settings.TeleprompterTranscript = value);
+
+    partial void OnTeleprompterScrollSpeedChanged(double value) => Persist(() => _settings.TeleprompterScrollSpeed = value);
 
     partial void OnAnalyticsRangeIndexChanged(int value)
     {

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -34,7 +34,9 @@ public sealed partial class SettingsViewModel : ObservableObject
     private readonly IClipAnalyticsService _analytics;
     private readonly IUploadcareCredentialStore _uploadcareCredentials;
     private readonly DispatcherQueue? _dispatcherQueue;
+    private readonly DispatcherQueueTimer? _teleprompterTranscriptSaveTimer;
     private bool _loading;
+    private string? _pendingTeleprompterTranscript;
     private string _savedMicrophoneId = string.Empty;
     private string _savedWebcamId = string.Empty;
 
@@ -84,6 +86,13 @@ public sealed partial class SettingsViewModel : ObservableObject
         _analytics = analytics;
         _uploadcareCredentials = uploadcareCredentials;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+        if (_dispatcherQueue is not null)
+        {
+            _teleprompterTranscriptSaveTimer = _dispatcherQueue.CreateTimer();
+            _teleprompterTranscriptSaveTimer.Interval = TimeSpan.FromMilliseconds(500);
+            _teleprompterTranscriptSaveTimer.IsRepeating = false;
+            _teleprompterTranscriptSaveTimer.Tick += (_, _) => PersistPendingTeleprompterTranscript();
+        }
         Load();
 
         // Analytics history and microphone/webcam enumeration are deferred until their
@@ -140,7 +149,23 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     /// <summary>Stops async continuations (media enumeration, permission prompts) from touching
     /// this view model once the owning window has closed.</summary>
-    public void NotifyClosed() => _closed = true;
+    public void NotifyClosed()
+    {
+        _teleprompterTranscriptSaveTimer?.Stop();
+        PersistPendingTeleprompterTranscript();
+        _closed = true;
+    }
+
+    private void PersistPendingTeleprompterTranscript()
+    {
+        if (_pendingTeleprompterTranscript is not { } transcript)
+        {
+            return;
+        }
+
+        _pendingTeleprompterTranscript = null;
+        _settings.TeleprompterTranscript = transcript;
+    }
 
     private sealed class SectionRealizationScope : IDisposable
     {
@@ -1177,7 +1202,23 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnTeleprompterEnabledChanged(bool value) => Persist(() => _settings.TeleprompterEnabled = value);
 
-    partial void OnTeleprompterTranscriptChanged(string value) => Persist(() => _settings.TeleprompterTranscript = value);
+    partial void OnTeleprompterTranscriptChanged(string value)
+    {
+        if (_loading || _pendingSectionRealizations > 0)
+        {
+            return;
+        }
+
+        _pendingTeleprompterTranscript = value;
+        if (_teleprompterTranscriptSaveTimer is null)
+        {
+            PersistPendingTeleprompterTranscript();
+            return;
+        }
+
+        _teleprompterTranscriptSaveTimer.Stop();
+        _teleprompterTranscriptSaveTimer.Start();
+    }
 
     partial void OnTeleprompterScrollSpeedChanged(double value) => Persist(() => _settings.TeleprompterScrollSpeed = value);
 

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -81,6 +81,11 @@
                     Icon="Flag"
                     Tag="Branding" />
                 <NavigationViewItem
+                    AutomationProperties.AutomationId="TeleprompterNavigationItem"
+                    Content="Teleprompter"
+                    Icon="ShowResults"
+                    Tag="Teleprompter" />
+                <NavigationViewItem
                     AutomationProperties.AutomationId="HotkeysNavigationItem"
                     Content="Hotkeys"
                     Icon="Keyboard"

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -108,6 +108,7 @@ public sealed partial class SettingsWindow : Window
             SettingsSectionKind.Gif => new GifSettingsSection(ViewModel),
             SettingsSectionKind.MouseClicks => new MouseClicksSettingsSection(ViewModel),
             SettingsSectionKind.Branding => new BrandingSettingsSection(ViewModel),
+            SettingsSectionKind.Teleprompter => new TeleprompterSettingsSection(ViewModel),
             SettingsSectionKind.Hotkeys => new HotkeysSettingsSection(ViewModel),
             SettingsSectionKind.About => new AboutSettingsSection(ViewModel),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),

--- a/windows/src/TinyClips.App/TeleprompterWindow.xaml
+++ b/windows/src/TinyClips.App/TeleprompterWindow.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="TinyClips.App.TeleprompterWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid
+        x:Name="RootGrid"
+        Background="Transparent"
+        PointerMoved="OnPointerMoved"
+        PointerPressed="OnPointerPressed"
+        PointerReleased="OnPointerReleased">
+        <Border
+            x:Name="Container"
+            Padding="16,12"
+            AutomationProperties.AutomationId="TeleprompterOverlay"
+            AutomationProperties.Name="Teleprompter"
+            Background="#99000000"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Border.Shadow>
+                <ThemeShadow />
+            </Border.Shadow>
+
+            <ScrollViewer
+                x:Name="Scroller"
+                HorizontalScrollBarVisibility="Disabled"
+                HorizontalScrollMode="Disabled"
+                VerticalScrollBarVisibility="Hidden"
+                VerticalScrollMode="Disabled"
+                ZoomMode="Disabled">
+                <TextBlock
+                    x:Name="TranscriptText"
+                    FontSize="24"
+                    Foreground="#FFFFFFFF"
+                    TextWrapping="Wrap" />
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</Window>

--- a/windows/src/TinyClips.App/TeleprompterWindow.xaml.cs
+++ b/windows/src/TinyClips.App/TeleprompterWindow.xaml.cs
@@ -1,0 +1,237 @@
+using System.Runtime.InteropServices;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using TinyClips.Core.Capture;
+using TinyClips.Core.Services;
+using Windows.Graphics;
+using WinRT.Interop;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Small always-on-top teleprompter overlay shown during video recordings. The window is
+/// excluded from screen capture, so its transcript never appears in the recorded video.
+/// The panel is draggable; its last position is persisted in device-independent pixels.
+/// </summary>
+public sealed partial class TeleprompterWindow : Window
+{
+    private const int WidthDip = 600;
+    private const int HeightDip = 140;
+    private const int TopOffsetDip = 24;
+
+    private const uint WdaExcludeFromCapture = 0x11;
+
+    // The capture-exclusion style makes the window read back as fully transparent to XAML
+    // hit-testing; a ~1% alpha background keeps the panel draggable without showing a fill.
+    private static readonly SolidColorBrush SizingSurfaceBrush = new(Microsoft.UI.ColorHelper.FromArgb(1, 0, 0, 0));
+
+    private static readonly TimeSpan ScrollInterval = TimeSpan.FromMilliseconds(16);
+
+    private readonly ICaptureSettings _settings;
+    private readonly double _scrollSpeedDipPerSecond;
+    private readonly Microsoft.UI.Dispatching.DispatcherTimer _scrollTimer;
+
+    private bool _closed;
+
+    private bool _dragging;
+    private POINT _dragCursorStart;
+    private PointInt32 _dragWindowStart;
+
+    public TeleprompterWindow(ICaptureSettings settings, MonitorInfo? monitor)
+    {
+        InitializeComponent();
+
+        _settings = settings;
+        TranscriptText.Text = settings.TeleprompterTranscript;
+        _scrollSpeedDipPerSecond = Math.Max(1.0, settings.TeleprompterScrollSpeed);
+
+        RootGrid.Background = SizingSurfaceBrush;
+        SizeChanged += OnSizeChanged;
+
+        _scrollTimer = new Microsoft.UI.Dispatching.DispatcherTimer { Interval = ScrollInterval };
+        _scrollTimer.Tick += OnScrollTick;
+
+        ConfigurePresenter();
+        PositionWindow(monitor);
+        Closed += OnClosed;
+    }
+
+    public void Show()
+    {
+        AppWindow.Show(false);
+
+        // Exclude the overlay from screen capture so it never appears in the recorded video.
+        var hwnd = WindowNative.GetWindowHandle(this);
+        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+    }
+
+    public void ClosePanel()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        _closed = true;
+        _scrollTimer.Stop();
+        Close();
+    }
+
+    private void OnSizeChanged(object sender, WindowSizeChangedEventArgs args)
+    {
+        if (_scrollTimer.IsEnabled || Scroller.ExtentHeight <= 0)
+        {
+            return;
+        }
+
+        // Text starts at the top edge (offset 0) and scrolls down from there.
+        Scroller.ChangeView(null, 0, null, disableAnimation: true);
+        _scrollTimer.Start();
+    }
+
+    private void OnScrollTick(object? sender, object e)
+    {
+        var maxOffset = Scroller.ExtentHeight - Scroller.ViewportHeight;
+        if (Scroller.VerticalOffset >= maxOffset)
+        {
+            _scrollTimer.Stop();
+            return;
+        }
+
+        var next = Scroller.VerticalOffset +
+            (_scrollSpeedDipPerSecond * ScrollInterval.TotalSeconds * GetScale());
+        Scroller.ChangeView(null, Math.Min(next, maxOffset), null, disableAnimation: true);
+    }
+
+    // Drag-anywhere support, anchored to the absolute cursor position to avoid feedback
+    // jitter as the window moves. Same pattern as RecordingIndicatorWindow.
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        GetCursorPos(out _dragCursorStart);
+        _dragWindowStart = AppWindow.Position;
+        _dragging = element.CapturePointer(e.Pointer);
+    }
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_dragging)
+        {
+            return;
+        }
+
+        GetCursorPos(out var current);
+        var dx = current.X - _dragCursorStart.X;
+        var dy = current.Y - _dragCursorStart.Y;
+
+        if (dx == 0 && dy == 0)
+        {
+            return;
+        }
+
+        AppWindow.Move(new PointInt32(_dragWindowStart.X + dx, _dragWindowStart.Y + dy));
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        _dragging = false;
+        element.ReleasePointerCapture(e.Pointer);
+        PersistPosition();
+    }
+
+    private void PersistPosition()
+    {
+        // Store the position in DIPs (window positions are physical pixels).
+        var scale = GetScale();
+        _settings.TeleprompterPosX = AppWindow.Position.X / scale;
+        _settings.TeleprompterPosY = AppWindow.Position.Y / scale;
+    }
+
+    private void ConfigurePresenter()
+    {
+        var presenter = OverlappedPresenter.CreateForContextMenu();
+        presenter.IsAlwaysOnTop = true;
+        presenter.IsMaximizable = false;
+        presenter.IsMinimizable = false;
+        AppWindow.SetPresenter(presenter);
+
+        AppWindow.IsShownInSwitchers = false;
+    }
+
+    private void PositionWindow(MonitorInfo? monitor)
+    {
+        var scale = GetScale();
+        var width = (int)Math.Round(WidthDip * scale);
+        var height = (int)Math.Round(HeightDip * scale);
+
+        AppWindow.Resize(new SizeInt32(width, height));
+
+        // Saved positions are stored in DIPs; monitor work areas are physical pixels.
+        var savedXDip = _settings.TeleprompterPosX;
+        var savedYDip = _settings.TeleprompterPosY;
+        if (savedXDip >= 0 && savedYDip >= 0)
+        {
+            AppWindow.Move(new PointInt32(
+                (int)Math.Round(savedXDip * scale),
+                (int)Math.Round(savedYDip * scale)));
+            return;
+        }
+
+        // Default: top-center of the target monitor's work area.
+        var work = GetWorkArea(monitor);
+        var x = work.X + Math.Max(0, (work.Width - width) / 2);
+        var y = work.Y + (int)Math.Round(TopOffsetDip * scale);
+        AppWindow.Move(new PointInt32(x, y));
+    }
+
+    private static RectInt32 GetWorkArea(MonitorInfo? monitor)
+    {
+        if (monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 })
+        {
+            return new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight);
+        }
+
+        return DisplayArea.Primary?.WorkArea ?? new RectInt32(0, 0, 1920, 1080);
+    }
+
+    private double GetScale()
+    {
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var dpi = GetDpiForWindow(hwnd);
+        return dpi <= 0 ? 1.0 : dpi / 96.0;
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        _closed = true;
+        _scrollTimer.Stop();
+    }
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(nint hwnd);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out POINT lpPoint);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
+}

--- a/windows/src/TinyClips.App/TeleprompterWindow.xaml.cs
+++ b/windows/src/TinyClips.App/TeleprompterWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -13,7 +14,7 @@ namespace TinyClips.App;
 /// <summary>
 /// Small always-on-top teleprompter overlay shown during video recordings. The window is
 /// excluded from screen capture, so its transcript never appears in the recorded video.
-/// The panel is draggable; its last position is persisted in device-independent pixels.
+/// The panel is draggable; its last position is persisted in target-monitor-relative DIPs.
 /// </summary>
 public sealed partial class TeleprompterWindow : Window
 {
@@ -30,27 +31,33 @@ public sealed partial class TeleprompterWindow : Window
     private static readonly TimeSpan ScrollInterval = TimeSpan.FromMilliseconds(16);
 
     private readonly ICaptureSettings _settings;
+    private readonly IMonitorService _monitorService;
     private readonly double _scrollSpeedDipPerSecond;
-    private readonly Microsoft.UI.Dispatching.DispatcherTimer _scrollTimer;
+    private readonly DispatcherTimer _scrollTimer;
 
     private bool _closed;
+    private bool _scrollingPaused;
 
     private bool _dragging;
     private POINT _dragCursorStart;
     private PointInt32 _dragWindowStart;
 
-    public TeleprompterWindow(ICaptureSettings settings, MonitorInfo? monitor)
+    public TeleprompterWindow(
+        ICaptureSettings settings,
+        IMonitorService monitorService,
+        MonitorInfo? monitor)
     {
         InitializeComponent();
 
         _settings = settings;
+        _monitorService = monitorService;
         TranscriptText.Text = settings.TeleprompterTranscript;
         _scrollSpeedDipPerSecond = Math.Max(1.0, settings.TeleprompterScrollSpeed);
 
         RootGrid.Background = SizingSurfaceBrush;
         SizeChanged += OnSizeChanged;
 
-        _scrollTimer = new Microsoft.UI.Dispatching.DispatcherTimer { Interval = ScrollInterval };
+        _scrollTimer = new DispatcherTimer { Interval = ScrollInterval };
         _scrollTimer.Tick += OnScrollTick;
 
         ConfigurePresenter();
@@ -58,13 +65,31 @@ public sealed partial class TeleprompterWindow : Window
         Closed += OnClosed;
     }
 
-    public void Show()
+    public bool TryShow()
     {
-        AppWindow.Show(false);
-
-        // Exclude the overlay from screen capture so it never appears in the recorded video.
         var hwnd = WindowNative.GetWindowHandle(this);
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        if (!SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture))
+        {
+            var error = Marshal.GetLastWin32Error();
+            Debug.WriteLine($"Teleprompter capture exclusion failed (Win32 error {error}); overlay will remain hidden.");
+            ClosePanel();
+            return false;
+        }
+
+        AppWindow.Show(false);
+        return true;
+    }
+
+    public void PauseScrolling()
+    {
+        _scrollingPaused = true;
+        _scrollTimer.Stop();
+    }
+
+    public void ResumeScrolling()
+    {
+        _scrollingPaused = false;
+        StartScrollingIfPossible();
     }
 
     public void ClosePanel()
@@ -81,14 +106,14 @@ public sealed partial class TeleprompterWindow : Window
 
     private void OnSizeChanged(object sender, WindowSizeChangedEventArgs args)
     {
-        if (_scrollTimer.IsEnabled || Scroller.ExtentHeight <= 0)
+        if (_scrollTimer.IsEnabled || _scrollingPaused || Scroller.ExtentHeight <= 0)
         {
             return;
         }
 
         // Text starts at the top edge (offset 0) and scrolls down from there.
         Scroller.ChangeView(null, 0, null, disableAnimation: true);
-        _scrollTimer.Start();
+        StartScrollingIfPossible();
     }
 
     private void OnScrollTick(object? sender, object e)
@@ -101,8 +126,18 @@ public sealed partial class TeleprompterWindow : Window
         }
 
         var next = Scroller.VerticalOffset +
-            (_scrollSpeedDipPerSecond * ScrollInterval.TotalSeconds * GetScale());
+            (_scrollSpeedDipPerSecond * ScrollInterval.TotalSeconds);
         Scroller.ChangeView(null, Math.Min(next, maxOffset), null, disableAnimation: true);
+    }
+
+    private void StartScrollingIfPossible()
+    {
+        if (!_closed &&
+            !_scrollingPaused &&
+            Scroller.ExtentHeight - Scroller.ViewportHeight > Scroller.VerticalOffset)
+        {
+            _scrollTimer.Start();
+        }
     }
 
     // Drag-anywhere support, anchored to the absolute cursor position to avoid feedback
@@ -152,10 +187,20 @@ public sealed partial class TeleprompterWindow : Window
 
     private void PersistPosition()
     {
-        // Store the position in DIPs (window positions are physical pixels).
-        var scale = GetScale();
-        _settings.TeleprompterPosX = AppWindow.Position.X / scale;
-        _settings.TeleprompterPosY = AppWindow.Position.Y / scale;
+        var monitors = _monitorService.GetMonitors();
+        var monitor = FindMonitorForWindow(monitors, AppWindow.Position, AppWindow.Size);
+        if (monitor is null)
+        {
+            return;
+        }
+
+        var position = TeleprompterPlacement.ToMonitorRelativeDips(
+            monitor,
+            AppWindow.Position.X,
+            AppWindow.Position.Y);
+        _settings.TeleprompterPosX = position.X;
+        _settings.TeleprompterPosY = position.Y;
+        _settings.TeleprompterMonitorDeviceName = monitor.DeviceName;
     }
 
     private void ConfigurePresenter()
@@ -171,45 +216,61 @@ public sealed partial class TeleprompterWindow : Window
 
     private void PositionWindow(MonitorInfo? monitor)
     {
-        var scale = GetScale();
-        var width = (int)Math.Round(WidthDip * scale);
-        var height = (int)Math.Round(HeightDip * scale);
-
-        AppWindow.Resize(new SizeInt32(width, height));
-
-        // Saved positions are stored in DIPs; monitor work areas are physical pixels.
+        var monitors = _monitorService.GetMonitors();
         var savedXDip = _settings.TeleprompterPosX;
         var savedYDip = _settings.TeleprompterPosY;
-        if (savedXDip >= 0 && savedYDip >= 0)
+        var savedMonitorName = _settings.TeleprompterMonitorDeviceName;
+        var placementMonitor = monitors.FirstOrDefault(candidate =>
+                !string.IsNullOrWhiteSpace(savedMonitorName) &&
+                string.Equals(candidate.DeviceName, savedMonitorName, StringComparison.OrdinalIgnoreCase))
+            ?? monitors.FirstOrDefault(candidate =>
+                monitor is not null &&
+                string.Equals(candidate.DeviceName, monitor.DeviceName, StringComparison.OrdinalIgnoreCase))
+            ?? monitors.FirstOrDefault(candidate => candidate.IsPrimary)
+            ?? monitors.FirstOrDefault()
+            ?? monitor;
+
+        if (placementMonitor is null)
         {
+            var work = DisplayArea.Primary?.WorkArea ?? new RectInt32(0, 0, 1920, 1080);
+            var width = Math.Min(WidthDip, work.Width);
+            var height = Math.Min(HeightDip, work.Height);
+            AppWindow.Resize(new SizeInt32(width, height));
             AppWindow.Move(new PointInt32(
-                (int)Math.Round(savedXDip * scale),
-                (int)Math.Round(savedYDip * scale)));
+                work.X + Math.Max(0, (work.Width - width) / 2),
+                work.Y + TopOffsetDip));
             return;
         }
 
-        // Default: top-center of the target monitor's work area.
-        var work = GetWorkArea(monitor);
-        var x = work.X + Math.Max(0, (work.Width - width) / 2);
-        var y = work.Y + (int)Math.Round(TopOffsetDip * scale);
-        AppWindow.Move(new PointInt32(x, y));
+        var placement = TeleprompterPlacement.Calculate(
+            placementMonitor,
+            WidthDip,
+            HeightDip,
+            TopOffsetDip,
+            savedXDip,
+            savedYDip,
+            savedPositionIsMonitorRelative: !string.IsNullOrWhiteSpace(savedMonitorName));
+        // Move the hidden window onto the target monitor before sizing so WinUI processes
+        // the DPI transition before we apply the final physical-pixel dimensions.
+        AppWindow.Move(new PointInt32(placementMonitor.WorkAreaX, placementMonitor.WorkAreaY));
+        AppWindow.Resize(new SizeInt32(placement.Width, placement.Height));
+        AppWindow.Move(new PointInt32(placement.X, placement.Y));
     }
 
-    private static RectInt32 GetWorkArea(MonitorInfo? monitor)
+    private static MonitorInfo? FindMonitorForWindow(
+        IReadOnlyList<MonitorInfo> monitors,
+        PointInt32 position,
+        SizeInt32 size)
     {
-        if (monitor is { WorkAreaWidth: > 0, WorkAreaHeight: > 0 })
-        {
-            return new RectInt32(monitor.WorkAreaX, monitor.WorkAreaY, monitor.WorkAreaWidth, monitor.WorkAreaHeight);
-        }
-
-        return DisplayArea.Primary?.WorkArea ?? new RectInt32(0, 0, 1920, 1080);
-    }
-
-    private double GetScale()
-    {
-        var hwnd = WindowNative.GetWindowHandle(this);
-        var dpi = GetDpiForWindow(hwnd);
-        return dpi <= 0 ? 1.0 : dpi / 96.0;
+        var centerX = position.X + (size.Width / 2);
+        var centerY = position.Y + (size.Height / 2);
+        return monitors.FirstOrDefault(monitor =>
+                centerX >= monitor.X &&
+                centerX < monitor.X + monitor.Width &&
+                centerY >= monitor.Y &&
+                centerY < monitor.Y + monitor.Height)
+            ?? monitors.FirstOrDefault(monitor => monitor.IsPrimary)
+            ?? monitors.FirstOrDefault();
     }
 
     private void OnClosed(object sender, WindowEventArgs args)
@@ -217,9 +278,6 @@ public sealed partial class TeleprompterWindow : Window
         _closed = true;
         _scrollTimer.Stop();
     }
-
-    [DllImport("user32.dll")]
-    private static extern uint GetDpiForWindow(nint hwnd);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT
@@ -231,7 +289,7 @@ public sealed partial class TeleprompterWindow : Window
     [DllImport("user32.dll")]
     private static extern bool GetCursorPos(out POINT lpPoint);
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
 }

--- a/windows/src/TinyClips.Core/Capture/TeleprompterPlacement.cs
+++ b/windows/src/TinyClips.Core/Capture/TeleprompterPlacement.cs
@@ -1,0 +1,58 @@
+namespace TinyClips.Core.Capture;
+
+public static class TeleprompterPlacement
+{
+    public static PixelRect Calculate(
+        MonitorInfo monitor,
+        int widthDip,
+        int heightDip,
+        int topOffsetDip,
+        double savedXDip,
+        double savedYDip,
+        bool savedPositionIsMonitorRelative)
+    {
+        var scale = monitor.ScaleFactor > 0 ? monitor.ScaleFactor : 1.0;
+        var width = Math.Max(1, (int)Math.Round(widthDip * scale));
+        var height = Math.Max(1, (int)Math.Round(heightDip * scale));
+        var workRight = monitor.WorkAreaX + Math.Max(0, monitor.WorkAreaWidth - width);
+        var workBottom = monitor.WorkAreaY + Math.Max(0, monitor.WorkAreaHeight - height);
+
+        int x;
+        int y;
+        var hasSavedPosition = double.IsFinite(savedXDip) &&
+            double.IsFinite(savedYDip) &&
+            (savedPositionIsMonitorRelative || (savedXDip >= 0 && savedYDip >= 0));
+        if (hasSavedPosition)
+        {
+            x = (int)Math.Round(savedXDip * scale);
+            y = (int)Math.Round(savedYDip * scale);
+            if (savedPositionIsMonitorRelative)
+            {
+                x += monitor.WorkAreaX;
+                y += monitor.WorkAreaY;
+            }
+        }
+        else
+        {
+            x = monitor.WorkAreaX + Math.Max(0, (monitor.WorkAreaWidth - width) / 2);
+            y = monitor.WorkAreaY + (int)Math.Round(topOffsetDip * scale);
+        }
+
+        return new PixelRect(
+            Math.Clamp(x, monitor.WorkAreaX, workRight),
+            Math.Clamp(y, monitor.WorkAreaY, workBottom),
+            width,
+            height);
+    }
+
+    public static (double X, double Y) ToMonitorRelativeDips(
+        MonitorInfo monitor,
+        int windowX,
+        int windowY)
+    {
+        var scale = monitor.ScaleFactor > 0 ? monitor.ScaleFactor : 1.0;
+        return (
+            (windowX - monitor.WorkAreaX) / scale,
+            (windowY - monitor.WorkAreaY) / scale);
+    }
+}

--- a/windows/src/TinyClips.Core/Capture/TeleprompterPlacement.cs
+++ b/windows/src/TinyClips.Core/Capture/TeleprompterPlacement.cs
@@ -12,8 +12,14 @@ public static class TeleprompterPlacement
         bool savedPositionIsMonitorRelative)
     {
         var scale = monitor.ScaleFactor > 0 ? monitor.ScaleFactor : 1.0;
-        var width = Math.Max(1, (int)Math.Round(widthDip * scale));
-        var height = Math.Max(1, (int)Math.Round(heightDip * scale));
+        var width = Math.Clamp(
+            (int)Math.Round(widthDip * scale),
+            1,
+            Math.Max(1, monitor.WorkAreaWidth));
+        var height = Math.Clamp(
+            (int)Math.Round(heightDip * scale),
+            1,
+            Math.Max(1, monitor.WorkAreaHeight));
         var workRight = monitor.WorkAreaX + Math.Max(0, monitor.WorkAreaWidth - width);
         var workBottom = monitor.WorkAreaY + Math.Max(0, monitor.WorkAreaHeight - height);
 

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -456,8 +456,20 @@ public sealed class CaptureSettings : ICaptureSettings
 
     public string TeleprompterTranscript
     {
-        get => _settings.Get("teleprompterTranscript", string.Empty);
-        set => _settings.Set("teleprompterTranscript", value);
+        get => _settings is ILargeTextSettingsService largeTextSettings
+            ? largeTextSettings.GetLargeText("teleprompterTranscript", string.Empty)
+            : _settings.Get("teleprompterTranscript", string.Empty);
+        set
+        {
+            if (_settings is ILargeTextSettingsService largeTextSettings)
+            {
+                largeTextSettings.SetLargeText("teleprompterTranscript", value);
+            }
+            else
+            {
+                _settings.Set("teleprompterTranscript", value);
+            }
+        }
     }
 
     public double TeleprompterScrollSpeed

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -448,6 +448,36 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("showBrandingOverlay", value);
     }
 
+    public bool TeleprompterEnabled
+    {
+        get => _settings.Get("teleprompterEnabled", false);
+        set => _settings.Set("teleprompterEnabled", value);
+    }
+
+    public string TeleprompterTranscript
+    {
+        get => _settings.Get("teleprompterTranscript", string.Empty);
+        set => _settings.Set("teleprompterTranscript", value);
+    }
+
+    public double TeleprompterScrollSpeed
+    {
+        get => _settings.Get("teleprompterScrollSpeed", 50.0);
+        set => _settings.Set("teleprompterScrollSpeed", value);
+    }
+
+    public double TeleprompterPosX
+    {
+        get => _settings.Get("teleprompterPosX", -1.0);
+        set => _settings.Set("teleprompterPosX", value);
+    }
+
+    public double TeleprompterPosY
+    {
+        get => _settings.Get("teleprompterPosY", -1.0);
+        set => _settings.Set("teleprompterPosY", value);
+    }
+
     public int ScreenshotHotKeyCode
     {
         get => _settings.Get("screenshotHotKeyCode", 53);
@@ -618,6 +648,11 @@ public sealed class CaptureSettings : ICaptureSettings
         ShowRegionIndicator = true;
         IncludeTinyClipsInCapture = false;
         ShowBrandingOverlay = false;
+        TeleprompterEnabled = false;
+        TeleprompterTranscript = string.Empty;
+        TeleprompterScrollSpeed = 50.0;
+        TeleprompterPosX = -1.0;
+        TeleprompterPosY = -1.0;
         UploadcareEnabled = false;
         UploadcarePublicKey = string.Empty;
         UploadcareAutoUpload = false;

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -478,6 +478,12 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("teleprompterPosY", value);
     }
 
+    public string TeleprompterMonitorDeviceName
+    {
+        get => _settings.Get("teleprompterMonitorDeviceName", string.Empty);
+        set => _settings.Set("teleprompterMonitorDeviceName", value);
+    }
+
     public int ScreenshotHotKeyCode
     {
         get => _settings.Get("screenshotHotKeyCode", 53);
@@ -653,6 +659,7 @@ public sealed class CaptureSettings : ICaptureSettings
         TeleprompterScrollSpeed = 50.0;
         TeleprompterPosX = -1.0;
         TeleprompterPosY = -1.0;
+        TeleprompterMonitorDeviceName = string.Empty;
         UploadcareEnabled = false;
         UploadcarePublicKey = string.Empty;
         UploadcareAutoUpload = false;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -71,6 +71,7 @@ public interface ICaptureSettings
     double TeleprompterScrollSpeed { get; set; }
     double TeleprompterPosX { get; set; }
     double TeleprompterPosY { get; set; }
+    string TeleprompterMonitorDeviceName { get; set; }
     bool UploadcareEnabled { get; set; }
     string UploadcarePublicKey { get; set; }
     bool UploadcareAutoUpload { get; set; }

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -66,6 +66,11 @@ public interface ICaptureSettings
     bool ShowRegionIndicator { get; set; }
     bool IncludeTinyClipsInCapture { get; set; }
     bool ShowBrandingOverlay { get; set; }
+    bool TeleprompterEnabled { get; set; }
+    string TeleprompterTranscript { get; set; }
+    double TeleprompterScrollSpeed { get; set; }
+    double TeleprompterPosX { get; set; }
+    double TeleprompterPosY { get; set; }
     bool UploadcareEnabled { get; set; }
     string UploadcarePublicKey { get; set; }
     bool UploadcareAutoUpload { get; set; }

--- a/windows/src/TinyClips.Core/Services/ISettingsService.cs
+++ b/windows/src/TinyClips.Core/Services/ISettingsService.cs
@@ -10,3 +10,9 @@ public interface ISettingsService
     AppTheme Theme { get; set; }
     string SaveDirectory { get; set; }
 }
+
+public interface ILargeTextSettingsService
+{
+    string GetLargeText(string key, string defaultValue);
+    void SetLargeText(string key, string value);
+}

--- a/windows/src/TinyClips.Core/Services/SettingsService.cs
+++ b/windows/src/TinyClips.Core/Services/SettingsService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Windows.Storage;
 using TinyClips.Core.Models;
 
@@ -6,6 +7,16 @@ namespace TinyClips.Core.Services;
 public sealed class SettingsService : ISettingsService, ILargeTextSettingsService
 {
     private readonly Dictionary<string, object> _fallbackValues = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string? _largeTextDirectory;
+
+    public SettingsService()
+    {
+    }
+
+    internal SettingsService(string largeTextDirectory)
+    {
+        _largeTextDirectory = largeTextDirectory;
+    }
 
     public AppTheme Theme
     {
@@ -77,6 +88,12 @@ public sealed class SettingsService : ISettingsService, ILargeTextSettingsServic
 
     public string GetLargeText(string key, string defaultValue)
     {
+        if (_fallbackValues.TryGetValue(key, out var fallbackValue) &&
+            fallbackValue is string fallbackText)
+        {
+            return fallbackText;
+        }
+
         try
         {
             var path = GetLargeTextPath(key);
@@ -105,9 +122,49 @@ public sealed class SettingsService : ISettingsService, ILargeTextSettingsServic
 
     public void SetLargeText(string key, string value)
     {
-        File.WriteAllText(GetLargeTextPath(key), value ?? string.Empty);
+        var persistedValue = value ?? string.Empty;
+        var path = GetLargeTextPath(key);
+        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(temporaryPath, persistedValue);
+            File.Move(temporaryPath, path, overwrite: true);
+            _fallbackValues.Remove(key);
+        }
+        catch (IOException ex)
+        {
+            Debug.WriteLine($"Failed to persist large text setting '{key}': {ex}");
+            _fallbackValues[key] = persistedValue;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"Failed to persist large text setting '{key}': {ex}");
+            _fallbackValues[key] = persistedValue;
+        }
+        finally
+        {
+            DeleteTemporaryFile(temporaryPath);
+        }
     }
 
-    private static string GetLargeTextPath(string key) =>
-        Path.Combine(ApplicationData.Current.LocalFolder.Path, $"{key}.txt");
+    private string GetLargeTextPath(string key) =>
+        Path.Combine(_largeTextDirectory ?? ApplicationData.Current.LocalFolder.Path, $"{key}.txt");
+
+    private static void DeleteTemporaryFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException ex)
+        {
+            Debug.WriteLine($"Failed to remove temporary settings file '{path}': {ex}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"Failed to remove temporary settings file '{path}': {ex}");
+        }
+    }
 }

--- a/windows/src/TinyClips.Core/Services/SettingsService.cs
+++ b/windows/src/TinyClips.Core/Services/SettingsService.cs
@@ -3,7 +3,7 @@ using TinyClips.Core.Models;
 
 namespace TinyClips.Core.Services;
 
-public sealed class SettingsService : ISettingsService
+public sealed class SettingsService : ISettingsService, ILargeTextSettingsService
 {
     private readonly Dictionary<string, object> _fallbackValues = new(StringComparer.OrdinalIgnoreCase);
 
@@ -74,4 +74,40 @@ public sealed class SettingsService : ISettingsService
             _fallbackValues[key] = persistedValue;
         }
     }
+
+    public string GetLargeText(string key, string defaultValue)
+    {
+        try
+        {
+            var path = GetLargeTextPath(key);
+            if (File.Exists(path))
+            {
+                return File.ReadAllText(path);
+            }
+
+            var legacyValue = Get(key, defaultValue);
+            if (!string.Equals(legacyValue, defaultValue, StringComparison.Ordinal))
+            {
+                SetLargeText(key, legacyValue);
+            }
+
+            return legacyValue;
+        }
+        catch (IOException)
+        {
+            return Get(key, defaultValue);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Get(key, defaultValue);
+        }
+    }
+
+    public void SetLargeText(string key, string value)
+    {
+        File.WriteAllText(GetLargeTextPath(key), value ?? string.Empty);
+    }
+
+    private static string GetLargeTextPath(string key) =>
+        Path.Combine(ApplicationData.Current.LocalFolder.Path, $"{key}.txt");
 }

--- a/windows/src/TinyClips.Core/Services/SettingsService.cs
+++ b/windows/src/TinyClips.Core/Services/SettingsService.cs
@@ -91,6 +91,7 @@ public sealed class SettingsService : ISettingsService, ILargeTextSettingsServic
         if (_fallbackValues.TryGetValue(key, out var fallbackValue) &&
             fallbackValue is string fallbackText)
         {
+            SetLargeText(key, fallbackText);
             return fallbackText;
         }
 

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -318,7 +318,7 @@ public sealed class CaptureSettingsTests
 
     private static ICaptureSettings CreateSettings() => new CaptureSettings(new TestSettingsService());
 
-    private sealed class TestSettingsService : ISettingsService
+    private sealed class TestSettingsService : ISettingsService, ILargeTextSettingsService
     {
         private readonly Dictionary<string, object> _values = new(StringComparer.OrdinalIgnoreCase);
 
@@ -348,5 +348,9 @@ public sealed class CaptureSettingsTests
         {
             _values[key] = value is null ? string.Empty : value;
         }
+
+        public string GetLargeText(string key, string defaultValue) => Get(key, defaultValue);
+
+        public void SetLargeText(string key, string value) => Set(key, value);
     }
 }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -253,6 +253,63 @@ public sealed class CaptureSettingsTests
         Assert.Equal(1, today.GifCount);
     }
 
+    [Fact]
+    public void TeleprompterSettings_DefaultToHiddenOverlayWithNoTranscript()
+    {
+        var settings = CreateSettings();
+
+        Assert.False(settings.TeleprompterEnabled);
+        Assert.Equal(string.Empty, settings.TeleprompterTranscript);
+        Assert.Equal(50.0, settings.TeleprompterScrollSpeed);
+        Assert.Equal(-1.0, settings.TeleprompterPosX);
+        Assert.Equal(-1.0, settings.TeleprompterPosY);
+    }
+
+    [Fact]
+    public void TeleprompterSettings_RoundTripThroughPersistedKeys()
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        settings.TeleprompterEnabled = true;
+        settings.TeleprompterTranscript = "Hello\nworld";
+        settings.TeleprompterScrollSpeed = 120.5;
+        settings.TeleprompterPosX = 640.0;
+        settings.TeleprompterPosY = 42.25;
+
+        Assert.True(settings.TeleprompterEnabled);
+        Assert.Equal("Hello\nworld", settings.TeleprompterTranscript);
+        Assert.Equal(120.5, settings.TeleprompterScrollSpeed);
+        Assert.Equal(640.0, settings.TeleprompterPosX);
+        Assert.Equal(42.25, settings.TeleprompterPosY);
+
+        Assert.True(settingsService.Get("teleprompterEnabled", false));
+        Assert.Equal("Hello\nworld", settingsService.Get("teleprompterTranscript", string.Empty));
+        Assert.Equal(120.5, settingsService.Get("teleprompterScrollSpeed", 50.0));
+        Assert.Equal(640.0, settingsService.Get("teleprompterPosX", -1.0));
+        Assert.Equal(42.25, settingsService.Get("teleprompterPosY", -1.0));
+    }
+
+    [Fact]
+    public void ResetToDefaults_RestoresTeleprompterDefaults()
+    {
+        var settings = CreateSettings();
+
+        settings.TeleprompterEnabled = true;
+        settings.TeleprompterTranscript = "Script";
+        settings.TeleprompterScrollSpeed = 180.0;
+        settings.TeleprompterPosX = 100.0;
+        settings.TeleprompterPosY = 200.0;
+
+        settings.ResetToDefaults();
+
+        Assert.False(settings.TeleprompterEnabled);
+        Assert.Equal(string.Empty, settings.TeleprompterTranscript);
+        Assert.Equal(50.0, settings.TeleprompterScrollSpeed);
+        Assert.Equal(-1.0, settings.TeleprompterPosX);
+        Assert.Equal(-1.0, settings.TeleprompterPosY);
+    }
+
     private static ICaptureSettings CreateSettings() => new CaptureSettings(new TestSettingsService());
 
     private sealed class TestSettingsService : ISettingsService

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -263,6 +263,7 @@ public sealed class CaptureSettingsTests
         Assert.Equal(50.0, settings.TeleprompterScrollSpeed);
         Assert.Equal(-1.0, settings.TeleprompterPosX);
         Assert.Equal(-1.0, settings.TeleprompterPosY);
+        Assert.Equal(string.Empty, settings.TeleprompterMonitorDeviceName);
     }
 
     [Fact]
@@ -276,18 +277,21 @@ public sealed class CaptureSettingsTests
         settings.TeleprompterScrollSpeed = 120.5;
         settings.TeleprompterPosX = 640.0;
         settings.TeleprompterPosY = 42.25;
+        settings.TeleprompterMonitorDeviceName = @"\\.\DISPLAY2";
 
         Assert.True(settings.TeleprompterEnabled);
         Assert.Equal("Hello\nworld", settings.TeleprompterTranscript);
         Assert.Equal(120.5, settings.TeleprompterScrollSpeed);
         Assert.Equal(640.0, settings.TeleprompterPosX);
         Assert.Equal(42.25, settings.TeleprompterPosY);
+        Assert.Equal(@"\\.\DISPLAY2", settings.TeleprompterMonitorDeviceName);
 
         Assert.True(settingsService.Get("teleprompterEnabled", false));
         Assert.Equal("Hello\nworld", settingsService.Get("teleprompterTranscript", string.Empty));
         Assert.Equal(120.5, settingsService.Get("teleprompterScrollSpeed", 50.0));
         Assert.Equal(640.0, settingsService.Get("teleprompterPosX", -1.0));
         Assert.Equal(42.25, settingsService.Get("teleprompterPosY", -1.0));
+        Assert.Equal(@"\\.\DISPLAY2", settingsService.Get("teleprompterMonitorDeviceName", string.Empty));
     }
 
     [Fact]
@@ -300,6 +304,7 @@ public sealed class CaptureSettingsTests
         settings.TeleprompterScrollSpeed = 180.0;
         settings.TeleprompterPosX = 100.0;
         settings.TeleprompterPosY = 200.0;
+        settings.TeleprompterMonitorDeviceName = @"\\.\DISPLAY2";
 
         settings.ResetToDefaults();
 
@@ -308,6 +313,7 @@ public sealed class CaptureSettingsTests
         Assert.Equal(50.0, settings.TeleprompterScrollSpeed);
         Assert.Equal(-1.0, settings.TeleprompterPosX);
         Assert.Equal(-1.0, settings.TeleprompterPosY);
+        Assert.Equal(string.Empty, settings.TeleprompterMonitorDeviceName);
     }
 
     private static ICaptureSettings CreateSettings() => new CaptureSettings(new TestSettingsService());

--- a/windows/tests/TinyClips.Core.Tests/SettingsServiceTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/SettingsServiceTests.cs
@@ -24,4 +24,68 @@ public sealed class SettingsServiceTests
 
         Assert.Equal(AppTheme.Dark, settings.Theme);
     }
+
+    [Fact]
+    public void LargeText_RoundTripsThroughFileBackedStorage()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var value = new string('a', 16_384);
+            new SettingsService(directory).SetLargeText("transcript", value);
+
+            var reloaded = new SettingsService(directory);
+
+            Assert.Equal(value, reloaded.GetLargeText("transcript", string.Empty));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LargeText_MigratesLegacyLocalSetting()
+    {
+        var directory = CreateTemporaryDirectory();
+        var key = $"legacyTranscript-{Guid.NewGuid():N}";
+        var settings = new SettingsService(directory);
+        try
+        {
+            settings.Set(key, "Legacy script");
+
+            Assert.Equal("Legacy script", settings.GetLargeText(key, string.Empty));
+            Assert.Equal("Legacy script", new SettingsService(directory).GetLargeText(key, string.Empty));
+        }
+        finally
+        {
+            settings.Set(key, string.Empty);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LargeText_FallsBackInMemoryWhenFileWriteFails()
+    {
+        var invalidDirectory = Path.GetTempFileName();
+        try
+        {
+            var settings = new SettingsService(invalidDirectory);
+
+            settings.SetLargeText("transcript", "Unsaved script");
+
+            Assert.Equal("Unsaved script", settings.GetLargeText("transcript", string.Empty));
+        }
+        finally
+        {
+            File.Delete(invalidDirectory);
+        }
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"TinyClips.Tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
 }

--- a/windows/tests/TinyClips.Core.Tests/TeleprompterPlacementTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/TeleprompterPlacementTests.cs
@@ -1,0 +1,95 @@
+using TinyClips.Core.Capture;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class TeleprompterPlacementTests
+{
+    [Fact]
+    public void Calculate_UsesTargetMonitorScaleForSizeAndRelativePosition()
+    {
+        var monitor = CreateMonitor(
+            deviceName: @"\\.\DISPLAY2",
+            workAreaX: 1920,
+            workAreaY: 40,
+            workAreaWidth: 2560,
+            workAreaHeight: 1400,
+            dpi: 144);
+
+        var placement = TeleprompterPlacement.Calculate(
+            monitor,
+            widthDip: 600,
+            heightDip: 140,
+            topOffsetDip: 24,
+            savedXDip: 100,
+            savedYDip: 50,
+            savedPositionIsMonitorRelative: true);
+
+        Assert.Equal(new PixelRect(2070, 115, 900, 210), placement);
+    }
+
+    [Fact]
+    public void Calculate_ClampsSavedPositionToCurrentWorkArea()
+    {
+        var monitor = CreateMonitor(
+            deviceName: @"\\.\DISPLAY1",
+            workAreaX: -1920,
+            workAreaY: 0,
+            workAreaWidth: 1920,
+            workAreaHeight: 1040,
+            dpi: 96);
+
+        var placement = TeleprompterPlacement.Calculate(
+            monitor,
+            widthDip: 600,
+            heightDip: 140,
+            topOffsetDip: 24,
+            savedXDip: 5000,
+            savedYDip: 5000,
+            savedPositionIsMonitorRelative: true);
+
+        Assert.Equal(new PixelRect(-600, 900, 600, 140), placement);
+    }
+
+    [Fact]
+    public void RelativePosition_RoundTripsAcrossDifferentMonitorScale()
+    {
+        var oldMonitor = CreateMonitor(@"\\.\DISPLAY2", 1920, 40, 2560, 1400, 144);
+        var relative = TeleprompterPlacement.ToMonitorRelativeDips(oldMonitor, 2220, 190);
+        var replacementMonitor = CreateMonitor(@"\\.\DISPLAY3", -1920, 0, 1920, 1040, 96);
+
+        var placement = TeleprompterPlacement.Calculate(
+            replacementMonitor,
+            widthDip: 600,
+            heightDip: 140,
+            topOffsetDip: 24,
+            savedXDip: relative.X,
+            savedYDip: relative.Y,
+            savedPositionIsMonitorRelative: true);
+
+        Assert.Equal(new PixelRect(-1720, 100, 600, 140), placement);
+    }
+
+    private static MonitorInfo CreateMonitor(
+        string deviceName,
+        int workAreaX,
+        int workAreaY,
+        int workAreaWidth,
+        int workAreaHeight,
+        int dpi) =>
+        new()
+        {
+            DeviceName = deviceName,
+            X = workAreaX,
+            Y = workAreaY,
+            Width = workAreaWidth,
+            Height = workAreaHeight,
+            WorkAreaX = workAreaX,
+            WorkAreaY = workAreaY,
+            WorkAreaWidth = workAreaWidth,
+            WorkAreaHeight = workAreaHeight,
+            DpiX = dpi,
+            DpiY = dpi,
+            IsPrimary = workAreaX == 0,
+            HMonitor = nint.Zero,
+        };
+}

--- a/windows/tests/TinyClips.Core.Tests/TeleprompterPlacementTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/TeleprompterPlacementTests.cs
@@ -51,6 +51,29 @@ public sealed class TeleprompterPlacementTests
     }
 
     [Fact]
+    public void Calculate_CapsPanelSizeToNarrowWorkArea()
+    {
+        var monitor = CreateMonitor(
+            deviceName: @"\\.\DISPLAY1",
+            workAreaX: 0,
+            workAreaY: 0,
+            workAreaWidth: 800,
+            workAreaHeight: 600,
+            dpi: 144);
+
+        var placement = TeleprompterPlacement.Calculate(
+            monitor,
+            widthDip: 600,
+            heightDip: 500,
+            topOffsetDip: 24,
+            savedXDip: -1,
+            savedYDip: -1,
+            savedPositionIsMonitorRelative: false);
+
+        Assert.Equal(new PixelRect(0, 0, 800, 600), placement);
+    }
+
+    [Fact]
     public void RelativePosition_RoundTripsAcrossDifferentMonitorScale()
     {
         var oldMonitor = CreateMonitor(@"\\.\DISPLAY2", 1920, 40, 2560, 1400, 144);


### PR DESCRIPTION
TinyClips users can now keep a script visible while recording without including it in the resulting video. This adds a configurable teleprompter to both macOS and Windows, with consistent behavior across platforms.

## What changed

- Adds transcript, enable/disable, and scroll-speed settings on macOS and Windows.
- Shows a draggable, remembered-position, semi-transparent overlay only after video recording starts.
- Automatically scrolls the transcript and pauses/resumes with the recording lifecycle.
- Keeps the overlay hidden for screenshots, GIFs, empty transcripts, and failed recording starts.
- Guarantees capture exclusion independently of the broader "include TinyClips" setting:
  - macOS resolves the panel as an `SCWindow` and explicitly excludes it from the ScreenCaptureKit filter, with `sharingType = .none` as defense in depth.
  - Windows applies `WDA_EXCLUDEFROMCAPTURE` before showing the window and fails closed if Windows rejects the affinity.
- Persists monitor-relative Windows placement and clamps it safely across mixed-DPI or removed-monitor changes.
- Adds Windows settings and placement tests, plus platform changelog entries.

## Validation

- `TinyClips` macOS scheme: build succeeded.
- `TinyClipsMAS` macOS scheme: build succeeded.
- Windows Core project: build succeeded with 0 warnings/errors.
- Windows Core tests project: build succeeded with 0 warnings/errors.
- Full WinUI app build cannot complete on this macOS host because the Windows App SDK invokes the Windows-only `XamlCompiler.exe`; it should be run on a Windows machine before merge.