### PR TITLE
Add dedicated teleprompter settings previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
-- Added a macOS teleprompter overlay for video recordings: enter a transcript in Settings → Video and an auto-scrolling, draggable, never-captured panel scrolls it on screen while you record, with an adjustable scroll speed and a remembered position.
+- Added a macOS teleprompter overlay for video recordings: configure it from the dedicated Settings → Video → Teleprompter screen, preview the selected scroll speed, and read from an auto-scrolling, draggable, never-captured panel with a remembered position.
 - Added macOS OCR region capture to recognize selected screen text and copy it to the clipboard.
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.
 - macOS microphone recording now applies a default-on soft-knee limiter that prevents loud peaks from hard-clipping before AAC encoding.

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -9,34 +9,141 @@ struct TeleprompterSettingsSection: View {
                 .help("Show an auto-scrolling transcript overlay while recording video. The overlay is never captured in the recording.")
                 .accessibilityHint("When enabled, an auto-scrolling transcript overlay appears during video recordings only.")
 
-            if settings.teleprompterEnabled {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Transcript:")
-                    TextEditor(text: $settings.teleprompterTranscript)
-                        .font(.system(size: 13))
-                        .frame(minHeight: 80, maxHeight: 140)
-                        .accessibilityLabel("Teleprompter transcript")
-                        .accessibilityHint("Enter the text to scroll during video recordings.")
-                    Text("The teleprompter only appears during video recordings, never GIFs or screenshots, and is never captured.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+            Text("The teleprompter appears during video recordings only and is never included in the captured video.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        Section("Transcript") {
+            TextEditor(text: $settings.teleprompterTranscript)
+                .font(.system(size: 13))
+                .frame(minHeight: 120, maxHeight: 180)
+                .disabled(!settings.teleprompterEnabled)
+                .accessibilityLabel("Teleprompter transcript")
+                .accessibilityHint("Enter the text to scroll during video recordings.")
+
+            Text("Paste or type the script you want to read while recording.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        Section("Scroll Speed") {
+            HStack {
+                Slider(
+                    value: $settings.teleprompterScrollSpeed,
+                    in: 10...200,
+                    step: 5
+                )
+                .disabled(!settings.teleprompterEnabled)
+                .accessibilityLabel("Teleprompter scroll speed")
+                .accessibilityValue("\(Int(settings.teleprompterScrollSpeed)) points per second")
+                Text("\(Int(settings.teleprompterScrollSpeed)) pt/s")
+                    .monospacedDigit()
+                    .frame(width: 56, alignment: .trailing)
+            }
+            .help("Set how fast the transcript scrolls, in points per second.")
+        }
+
+        Section("Preview") {
+            TeleprompterScrollPreview(
+                transcript: settings.teleprompterTranscript,
+                scrollSpeed: settings.teleprompterScrollSpeed
+            )
+            Text("This preview uses the same scroll speed as the recording overlay.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct TeleprompterScrollPreview: View {
+    let transcript: String
+    let scrollSpeed: Double
+
+    @State private var contentHeight: CGFloat = 0
+    @State private var scrollOffset: CGFloat = 0
+
+    private let viewportHeight: CGFloat = 140
+    private let frameInterval = 1.0 / 60.0
+
+    private var previewTranscript: String {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = trimmed.isEmpty
+            ? "Your transcript will scroll here while you record.\nAdjust the speed until it feels comfortable to read."
+            : String(trimmed.prefix(600))
+        return Array(repeating: text, count: 3).joined(separator: "\n\n")
+    }
+
+    private var configuration: PreviewConfiguration {
+        PreviewConfiguration(
+            transcript: previewTranscript,
+            scrollSpeed: scrollSpeed,
+            contentHeight: contentHeight
+        )
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            Text(previewTranscript)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .frame(width: proxy.size.width, alignment: .top)
+                .background {
+                    GeometryReader { contentProxy in
+                        Color.clear.preference(
+                            key: PreviewContentHeightKey.self,
+                            value: contentProxy.size.height
+                        )
+                    }
+                }
+                .offset(y: -scrollOffset)
+        }
+        .frame(height: viewportHeight)
+        .clipped()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(0.7))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .onPreferenceChange(PreviewContentHeightKey.self) { contentHeight = $0 }
+        .task(id: configuration) {
+            scrollOffset = 0
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: 16_666_667)
+                } catch {
+                    return
                 }
 
-                HStack {
-                    Text("Scroll speed:")
-                    Slider(
-                        value: $settings.teleprompterScrollSpeed,
-                        in: 10...200,
-                        step: 5
-                    )
-                    .accessibilityLabel("Teleprompter scroll speed")
-                    .accessibilityValue("\(Int(settings.teleprompterScrollSpeed)) points per second")
-                    Text("\(Int(settings.teleprompterScrollSpeed)) pt/s")
-                        .monospacedDigit()
-                        .frame(width: 56, alignment: .trailing)
-                }
-                .help("Set how fast the transcript scrolls, in points per second.")
+                let maximumOffset = max(0, contentHeight - viewportHeight)
+                guard maximumOffset > 0 else { continue }
+                let nextOffset = scrollOffset + CGFloat(scrollSpeed * frameInterval)
+                scrollOffset = nextOffset >= maximumOffset ? 0 : nextOffset
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Teleprompter scroll speed preview")
+        .accessibilityValue("Scrolling at \(Int(scrollSpeed)) points per second")
+    }
+}
+
+private struct PreviewConfiguration: Hashable {
+    let transcript: String
+    let scrollSpeed: Double
+    let contentHeight: CGFloat
+}
+
+private struct PreviewContentHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -8,6 +8,7 @@ enum SettingsTab: String, CaseIterable {
     case analytics = "Analytics"
     case screenshot = "Screenshot"
     case video = "Video"
+    case teleprompter = "Teleprompter"
     case gif = "GIF"
     case mouseClicks = "Mouse Clicks"
     case branding = "Branding"
@@ -21,6 +22,7 @@ enum SettingsTab: String, CaseIterable {
         case .analytics: return "chart.bar.xaxis"
         case .screenshot: return "camera"
         case .video: return "video"
+        case .teleprompter: return "text.alignleft"
         case .gif: return "photo.on.rectangle"
         case .mouseClicks: return "cursorarrow.rays"
         case .branding: return "flag"
@@ -52,6 +54,7 @@ struct SettingsView: View {
     @Environment(\.openWindow) private var openWindow
     @State private var selectedTab: SettingsTab? = .general
     @State private var splitVisibility: NavigationSplitViewVisibility = .all
+    @State private var videoSettingsExpanded = true
     @State private var showDisableDockWarning = false
     @State private var showQuickBugReportForm = false
     @State private var availableMicrophones: [MicrophoneDeviceOption] = []
@@ -59,9 +62,22 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $splitVisibility) {
-            List(SettingsTab.displayCases, id: \.self, selection: $selectedTab) { tab in
-                Label(tab.rawValue, systemImage: tab.icon)
-                    .tag(tab as SettingsTab?)
+            List(selection: $selectedTab) {
+                ForEach(SettingsTab.displayCases.filter { $0 != .teleprompter }, id: \.self) { tab in
+                    if tab == .video {
+                        DisclosureGroup(isExpanded: $videoSettingsExpanded) {
+                            Label("Recording", systemImage: "slider.horizontal.3")
+                                .tag(SettingsTab.video as SettingsTab?)
+                            Label(SettingsTab.teleprompter.rawValue, systemImage: SettingsTab.teleprompter.icon)
+                                .tag(SettingsTab.teleprompter as SettingsTab?)
+                        } label: {
+                            Label(tab.rawValue, systemImage: tab.icon)
+                        }
+                    } else {
+                        Label(tab.rawValue, systemImage: tab.icon)
+                            .tag(tab as SettingsTab?)
+                    }
+                }
             }
             .listStyle(.sidebar)
             .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 220)
@@ -88,6 +104,7 @@ struct SettingsView: View {
                         availableWebcams: availableWebcams,
                         selectedTab: $selectedTab
                     )
+                case .teleprompter:
                     TeleprompterSettingsSection(settings: settings)
                 case .gif:
                     GifSettingsSection(

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,7 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
-- **Teleprompter transcript overlay** — Settings → Teleprompter lets you paste a script, enable the teleprompter, and tune the scroll speed (10–200 DIPs/s). During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay appears only after recording starts, pauses and resumes with recording, fails closed if Windows cannot exclude it from capture, and remembers a monitor-relative position across mixed-DPI display changes.
+- **Teleprompter transcript overlay** — Settings → Video → Teleprompter lets you paste a script, enable the teleprompter, tune the scroll speed (10–200 DIPs/s), and preview that speed live. During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay appears only after recording starts, pauses and resumes with recording, fails closed if Windows cannot exclude it from capture, and remembers a monitor-relative position across mixed-DPI display changes.
 
 ### Fixed
 - Fixed the video trimmer so preview playback stops immediately when saving or closing the window.

--- a/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
@@ -100,6 +100,7 @@
                 </Grid>
                 <Border
                     Height="140"
+                    Padding="16,12"
                     AutomationProperties.HelpText="Shows how quickly the transcript will move during a recording."
                     AutomationProperties.Name="Teleprompter scroll speed preview"
                     Background="#99000000"
@@ -115,11 +116,8 @@
                         ZoomMode="Disabled">
                         <TextBlock
                             x:Name="PreviewText"
-                            Margin="20,12"
                             FontSize="24"
-                            FontWeight="Medium"
                             Foreground="#FFFFFFFF"
-                            TextAlignment="Center"
                             TextWrapping="Wrap" />
                     </ScrollViewer>
                 </Border>

--- a/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml
@@ -83,5 +83,52 @@
                     Value="{x:Bind ViewModel.TeleprompterScrollSpeed, Mode=TwoWay}" />
             </StackPanel>
         </Border>
+
+        <Border Style="{StaticResource SettingCardStyle}">
+            <StackPanel Spacing="8">
+                <Grid ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Preview" />
+                    <TextBlock
+                        Grid.Column="1"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.TeleprompterScrollSpeedDisplay, Mode=OneWay}" />
+                </Grid>
+                <Border
+                    Height="140"
+                    AutomationProperties.HelpText="Shows how quickly the transcript will move during a recording."
+                    AutomationProperties.Name="Teleprompter scroll speed preview"
+                    Background="#99000000"
+                    CornerRadius="{StaticResource OverlayCornerRadius}">
+                    <ScrollViewer
+                        x:Name="PreviewScroller"
+                        HorizontalScrollBarVisibility="Disabled"
+                        HorizontalScrollMode="Disabled"
+                        IsHitTestVisible="False"
+                        SizeChanged="OnPreviewSizeChanged"
+                        VerticalScrollBarVisibility="Hidden"
+                        VerticalScrollMode="Disabled"
+                        ZoomMode="Disabled">
+                        <TextBlock
+                            x:Name="PreviewText"
+                            Margin="20,12"
+                            FontSize="24"
+                            FontWeight="Medium"
+                            Foreground="#FFFFFFFF"
+                            TextAlignment="Center"
+                            TextWrapping="Wrap" />
+                    </ScrollViewer>
+                </Border>
+                <TextBlock
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="This preview uses the same scroll speed as the recording overlay."
+                    TextWrapping="Wrap" />
+            </StackPanel>
+        </Border>
     </StackPanel>
 </UserControl>

--- a/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/TeleprompterSettingsSection.xaml.cs
@@ -1,12 +1,23 @@
 using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace TinyClips.App.Settings.Sections;
 
-/// <summary>Teleprompter overlay enable toggle, transcript text, and scroll speed.</summary>
-public sealed partial class TeleprompterSettingsSection : UserControl
+/// <summary>Teleprompter overlay settings with a live, speed-accurate transcript preview.</summary>
+public sealed partial class TeleprompterSettingsSection : UserControl, ISettingsSectionLifecycle
 {
+    private static readonly TimeSpan PreviewInterval = TimeSpan.FromMilliseconds(16);
+    private const string DefaultPreviewTranscript =
+        "Your transcript will scroll here while you record.\n" +
+        "Adjust the speed until it feels comfortable to read.";
+
     private readonly IDisposable _realizationScope;
+    private readonly DispatcherTimer _previewTimer;
+    private bool _windowClosed;
 
     public SettingsViewModel ViewModel { get; }
 
@@ -15,6 +26,101 @@ public sealed partial class TeleprompterSettingsSection : UserControl
         ViewModel = viewModel;
         _realizationScope = viewModel.BeginSectionRealization();
         InitializeComponent();
+
+        _previewTimer = new DispatcherTimer { Interval = PreviewInterval };
+        _previewTimer.Tick += OnPreviewTick;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+
+        UpdatePreviewTranscript();
         SectionLifecycle.HookFirstLoad(this, viewModel, _realizationScope);
+    }
+
+    public void NotifyWindowClosed()
+    {
+        if (_windowClosed)
+        {
+            return;
+        }
+
+        _windowClosed = true;
+        _previewTimer.Stop();
+        _previewTimer.Tick -= OnPreviewTick;
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        Loaded -= OnLoaded;
+        Unloaded -= OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        PreviewScroller.ChangeView(null, 0, null, disableAnimation: true);
+        DispatcherQueue.TryEnqueue(StartPreviewIfPossible);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _previewTimer.Stop();
+    }
+
+    private void OnPreviewSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        StartPreviewIfPossible();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(SettingsViewModel.TeleprompterTranscript))
+        {
+            return;
+        }
+
+        UpdatePreviewTranscript();
+        if (IsLoaded)
+        {
+            PreviewScroller.ChangeView(null, 0, null, disableAnimation: true);
+            DispatcherQueue.TryEnqueue(StartPreviewIfPossible);
+        }
+    }
+
+    private void OnPreviewTick(object? sender, object e)
+    {
+        var maximumOffset = PreviewScroller.ExtentHeight - PreviewScroller.ViewportHeight;
+        if (maximumOffset <= 0)
+        {
+            _previewTimer.Stop();
+            return;
+        }
+
+        var nextOffset = PreviewScroller.VerticalOffset +
+            (ViewModel.TeleprompterScrollSpeed * PreviewInterval.TotalSeconds);
+        PreviewScroller.ChangeView(
+            null,
+            nextOffset >= maximumOffset ? 0 : nextOffset,
+            null,
+            disableAnimation: true);
+    }
+
+    private void StartPreviewIfPossible()
+    {
+        if (!_windowClosed &&
+            IsLoaded &&
+            PreviewScroller.ExtentHeight > PreviewScroller.ViewportHeight)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    private void UpdatePreviewTranscript()
+    {
+        var transcript = string.IsNullOrWhiteSpace(ViewModel.TeleprompterTranscript)
+            ? DefaultPreviewTranscript
+            : ViewModel.TeleprompterTranscript.Trim();
+        var preview = string.Concat(
+            transcript
+                .EnumerateRunes()
+                .Take(600)
+                .Select(rune => rune.ToString()));
+        PreviewText.Text = string.Join("\n\n", Enumerable.Repeat(preview, 3));
     }
 }

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -64,7 +64,21 @@
                     AutomationProperties.AutomationId="VideoNavigationItem"
                     Content="Video"
                     Icon="Video"
-                    Tag="Video" />
+                    IsExpanded="True"
+                    SelectsOnInvoked="False">
+                    <NavigationViewItem.MenuItems>
+                        <NavigationViewItem
+                            AutomationProperties.AutomationId="VideoRecordingNavigationItem"
+                            Content="Recording"
+                            Icon="Video"
+                            Tag="Video" />
+                        <NavigationViewItem
+                            AutomationProperties.AutomationId="TeleprompterNavigationItem"
+                            Content="Teleprompter"
+                            Icon="ShowResults"
+                            Tag="Teleprompter" />
+                    </NavigationViewItem.MenuItems>
+                </NavigationViewItem>
                 <NavigationViewItem
                     AutomationProperties.AutomationId="GifNavigationItem"
                     Content="GIF"
@@ -80,11 +94,6 @@
                     Content="Branding"
                     Icon="Flag"
                     Tag="Branding" />
-                <NavigationViewItem
-                    AutomationProperties.AutomationId="TeleprompterNavigationItem"
-                    Content="Teleprompter"
-                    Icon="ShowResults"
-                    Tag="Teleprompter" />
                 <NavigationViewItem
                     AutomationProperties.AutomationId="HotkeysNavigationItem"
                     Content="Hotkeys"


### PR DESCRIPTION
The teleprompter controls need enough space and feedback for users to tune reading speed before recording. This gives the feature a dedicated destination under Video on both platforms and adds a live preview that mirrors the production overlay.

## Summary

- Group Video settings into separate Recording and Teleprompter destinations on macOS and Windows.
- Move the macOS teleprompter controls to their own settings screen.
- Add looping transcript previews that use the configured points/DIPs-per-second speed, production typography, and overlay height.
- Keep preview timers scoped to the visible settings surface and clean them up when the Windows settings window closes.
- Update both platform changelogs for the new settings path and preview.

## Validation

- Built both macOS schemes without code signing.
- Validated the changed WinUI XAML as well-formed XML.
- Full WinUI compilation requires a Windows host because the Windows App SDK XAML compiler cannot execute in this macOS workspace.