### PR TITLE
Fix settings sidebar and support labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed the macOS and Windows settings sidebars to keep Video and Teleprompter as separate entries, cleaned up the Support label wording, and prevented the screenshot editor’s Horizontal/Vertical alignment labels from being clipped when the window is narrow.
 - Fixed macOS capture actions staying disabled after canceling a capture picker, target selection, or recording setup, and after a pre-capture countdown completes.
 - Fixed macOS recordings that capture no frames leaving zero-byte MP4 artifacts.
 - Fixed the macOS video trimmer so preview playback stops immediately when saving or closing the trimmer.

--- a/mac/TinyClips/Views/MenuBarViews.swift
+++ b/mac/TinyClips/Views/MenuBarViews.swift
@@ -150,7 +150,7 @@ struct MenuBarContentView: View {
             openWindow(id: "settings-window")
             bringSettingsWindowToFront()
         } label: {
-            Label("Support Tiny Clips…", systemImage: "heart")
+            Label("Support…", systemImage: "heart")
         }
         .accessibilityHint("Opens support and tip options.")
 #endif

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -495,35 +495,23 @@ struct ScreenshotEditorView: View {
             .accessibilityHint("Sets the export frame without stretching the screenshot.")
 
             VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .center, spacing: 8) {
-                    Text("Horizontal")
-                        .frame(width: 72, alignment: .leading)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Picker("", selection: $viewModel.horizontalExportAlignment) {
-                        ForEach(ExportHorizontalAlignment.allCases) { alignment in
-                            Text(alignment.label).tag(alignment)
-                        }
+                Picker("Horizontal", selection: $viewModel.horizontalExportAlignment) {
+                    ForEach(ExportHorizontalAlignment.allCases) { alignment in
+                        Text(alignment.label).tag(alignment)
                     }
-                    .labelsHidden()
-                    .disabled(!viewModel.hasHorizontalExportFrameSpace)
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .labelsHidden()
+                .disabled(!viewModel.hasHorizontalExportFrameSpace)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                HStack(alignment: .center, spacing: 8) {
-                    Text("Vertical")
-                        .frame(width: 72, alignment: .leading)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Picker("", selection: $viewModel.verticalExportAlignment) {
-                        ForEach(ExportVerticalAlignment.allCases) { alignment in
-                            Text(alignment.label).tag(alignment)
-                        }
+                Picker("Vertical", selection: $viewModel.verticalExportAlignment) {
+                    ForEach(ExportVerticalAlignment.allCases) { alignment in
+                        Text(alignment.label).tag(alignment)
                     }
-                    .labelsHidden()
-                    .disabled(!viewModel.hasVerticalExportFrameSpace)
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .labelsHidden()
+                .disabled(!viewModel.hasVerticalExportFrameSpace)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .accessibilityElement(children: .contain)
 

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -494,20 +494,36 @@ struct ScreenshotEditorView: View {
             }
             .accessibilityHint("Sets the export frame without stretching the screenshot.")
 
-            HStack(spacing: 8) {
-                Picker("Horizontal", selection: $viewModel.horizontalExportAlignment) {
-                    ForEach(ExportHorizontalAlignment.allCases) { alignment in
-                        Text(alignment.label).tag(alignment)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .center, spacing: 8) {
+                    Text("Horizontal")
+                        .frame(width: 72, alignment: .leading)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $viewModel.horizontalExportAlignment) {
+                        ForEach(ExportHorizontalAlignment.allCases) { alignment in
+                            Text(alignment.label).tag(alignment)
+                        }
                     }
+                    .labelsHidden()
+                    .disabled(!viewModel.hasHorizontalExportFrameSpace)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .disabled(!viewModel.hasHorizontalExportFrameSpace)
 
-                Picker("Vertical", selection: $viewModel.verticalExportAlignment) {
-                    ForEach(ExportVerticalAlignment.allCases) { alignment in
-                        Text(alignment.label).tag(alignment)
+                HStack(alignment: .center, spacing: 8) {
+                    Text("Vertical")
+                        .frame(width: 72, alignment: .leading)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $viewModel.verticalExportAlignment) {
+                        ForEach(ExportVerticalAlignment.allCases) { alignment in
+                            Text(alignment.label).tag(alignment)
+                        }
                     }
+                    .labelsHidden()
+                    .disabled(!viewModel.hasVerticalExportFrameSpace)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .disabled(!viewModel.hasVerticalExportFrameSpace)
             }
             .accessibilityElement(children: .contain)
 

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -13,7 +13,7 @@ enum SettingsTab: String, CaseIterable {
     case mouseClicks = "Mouse Clicks"
     case branding = "Branding"
     case shortcuts = "Shortcuts"
-    case pro = "Support Tiny Clips"
+    case pro = "Support"
     case about = "About"
 
     var icon: String {
@@ -54,7 +54,6 @@ struct SettingsView: View {
     @Environment(\.openWindow) private var openWindow
     @State private var selectedTab: SettingsTab? = .general
     @State private var splitVisibility: NavigationSplitViewVisibility = .all
-    @State private var videoSettingsExpanded = true
     @State private var showDisableDockWarning = false
     @State private var showQuickBugReportForm = false
     @State private var availableMicrophones: [MicrophoneDeviceOption] = []
@@ -63,20 +62,9 @@ struct SettingsView: View {
     var body: some View {
         NavigationSplitView(columnVisibility: $splitVisibility) {
             List(selection: $selectedTab) {
-                ForEach(SettingsTab.displayCases.filter { $0 != .teleprompter }, id: \.self) { tab in
-                    if tab == .video {
-                        DisclosureGroup(isExpanded: $videoSettingsExpanded) {
-                            Label("Recording", systemImage: "slider.horizontal.3")
-                                .tag(SettingsTab.video as SettingsTab?)
-                            Label(SettingsTab.teleprompter.rawValue, systemImage: SettingsTab.teleprompter.icon)
-                                .tag(SettingsTab.teleprompter as SettingsTab?)
-                        } label: {
-                            Label(tab.rawValue, systemImage: tab.icon)
-                        }
-                    } else {
-                        Label(tab.rawValue, systemImage: tab.icon)
-                            .tag(tab as SettingsTab?)
-                    }
+                ForEach(SettingsTab.displayCases, id: \.self) { tab in
+                    Label(tab.rawValue, systemImage: tab.icon)
+                        .tag(tab as SettingsTab?)
                 }
             }
             .listStyle(.sidebar)

--- a/mac/TinyClips/Views/SubscriptionView.swift
+++ b/mac/TinyClips/Views/SubscriptionView.swift
@@ -44,7 +44,7 @@ struct ProSubscriptionView: View {
                     .cornerRadius(16)
             }
 
-            Text("Support Tiny Clips")
+            Text("Support")
                 .font(.largeTitle.bold())
 
             Text("Tiny Clips is always free. Consider tipping to support independent development.")

--- a/windows/src/TinyClips.App/SettingsWindow.xaml
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml
@@ -64,21 +64,12 @@
                     AutomationProperties.AutomationId="VideoNavigationItem"
                     Content="Video"
                     Icon="Video"
-                    IsExpanded="True"
-                    SelectsOnInvoked="False">
-                    <NavigationViewItem.MenuItems>
-                        <NavigationViewItem
-                            AutomationProperties.AutomationId="VideoRecordingNavigationItem"
-                            Content="Recording"
-                            Icon="Video"
-                            Tag="Video" />
-                        <NavigationViewItem
-                            AutomationProperties.AutomationId="TeleprompterNavigationItem"
-                            Content="Teleprompter"
-                            Icon="ShowResults"
-                            Tag="Teleprompter" />
-                    </NavigationViewItem.MenuItems>
-                </NavigationViewItem>
+                    Tag="Video" />
+                <NavigationViewItem
+                    AutomationProperties.AutomationId="TeleprompterNavigationItem"
+                    Content="Teleprompter"
+                    Icon="ShowResults"
+                    Tag="Teleprompter" />
                 <NavigationViewItem
                     AutomationProperties.AutomationId="GifNavigationItem"
                     Content="GIF"


### PR DESCRIPTION
The settings UI was collapsing Video and Teleprompter into a single entry, and the Support item text was longer than the other settings labels. The screenshot editor also had narrow-window clipping in its Horizontal/Vertical alignment controls.

This change keeps Video and Teleprompter as separate entries in both the macOS and Windows settings navigation, renames the support label to "Support", and gives the editor alignment controls their own readable rows so the labels stay intact at smaller widths.

## Validation
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

I also attempted a WinUI build from this macOS host, but the Windows XAML compiler cannot execute here, so the native Windows validation is limited by the host environment.