### PR TITLE
Add per-type save folder settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
+- macOS capture folders now default to Pictures/TinyClips for screenshots and Movies/TinyClips for videos and GIFs. Turning off "Use default folders" reveals separate folders for screenshots, videos, and GIFs.
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
 - macOS capture settings now offer matching before/after picker controls for screenshots, video recordings, and GIF recordings.
 - macOS multi-monitor capture settings now let you choose to ask every time, capture the display under the cursor, or capture the main display.

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -225,12 +225,19 @@ class CaptureSettings: ObservableObject {
 
     @AppStorage("saveDirectory") var saveDirectory: String = NSHomeDirectory() + "/Desktop"
     @AppStorage("screenshotSaveDirectory") var screenshotSaveDirectory: String = ""
+    @AppStorage("videoSaveDirectory") var videoSaveDirectory: String = ""
+    @AppStorage("gifSaveDirectory") var gifSaveDirectory: String = ""
     @AppStorage("videoGifSaveDirectory") var videoGifSaveDirectory: String = ""
+    @AppStorage("useDefaultSaveDirectories") var useDefaultSaveDirectories: Bool = true
 #if APPSTORE
     @AppStorage("saveDirectoryBookmark") var saveDirectoryBookmark: Data = Data()
     @AppStorage("saveDirectoryDisplayPath") var saveDirectoryDisplayPath: String = ""
     @AppStorage("screenshotSaveDirectoryBookmark") var screenshotSaveDirectoryBookmark: Data = Data()
     @AppStorage("screenshotSaveDirectoryDisplayPath") var screenshotSaveDirectoryDisplayPath: String = ""
+    @AppStorage("videoSaveDirectoryBookmark") var videoSaveDirectoryBookmark: Data = Data()
+    @AppStorage("videoSaveDirectoryDisplayPath") var videoSaveDirectoryDisplayPath: String = ""
+    @AppStorage("gifSaveDirectoryBookmark") var gifSaveDirectoryBookmark: Data = Data()
+    @AppStorage("gifSaveDirectoryDisplayPath") var gifSaveDirectoryDisplayPath: String = ""
     @AppStorage("videoGifSaveDirectoryBookmark") var videoGifSaveDirectoryBookmark: Data = Data()
     @AppStorage("videoGifSaveDirectoryDisplayPath") var videoGifSaveDirectoryDisplayPath: String = ""
 #endif
@@ -374,27 +381,26 @@ class CaptureSettings: ObservableObject {
     func saveDirectoryPath(for captureType: CaptureType) -> String {
         switch captureType {
         case .screenshot:
-            return screenshotSaveDirectory.isEmpty ? saveDirectory : screenshotSaveDirectory
-        case .video, .gif:
-            return videoGifSaveDirectory.isEmpty ? saveDirectory : videoGifSaveDirectory
+            return screenshotSaveDirectory
+        case .video:
+            return videoSaveDirectory
+        case .gif:
+            return gifSaveDirectory
         }
     }
 
-    func isUsingSharedSaveDirectory(for captureType: CaptureType) -> Bool {
+    func hasCustomSaveDirectory(for captureType: CaptureType) -> Bool {
 #if APPSTORE
         switch captureType {
         case .screenshot:
-            return screenshotSaveDirectoryBookmark.isEmpty
-        case .video, .gif:
-            return videoGifSaveDirectoryBookmark.isEmpty
+            return !screenshotSaveDirectoryBookmark.isEmpty
+        case .video:
+            return !videoSaveDirectoryBookmark.isEmpty
+        case .gif:
+            return !gifSaveDirectoryBookmark.isEmpty
         }
 #else
-        switch captureType {
-        case .screenshot:
-            return screenshotSaveDirectory.isEmpty
-        case .video, .gif:
-            return videoGifSaveDirectory.isEmpty
-        }
+        return !saveDirectoryPath(for: captureType).isEmpty
 #endif
     }
 
@@ -403,21 +409,21 @@ class CaptureSettings: ObservableObject {
         switch captureType {
         case .screenshot:
             return screenshotSaveDirectoryBookmark
-        case .video, .gif:
-            return videoGifSaveDirectoryBookmark
+        case .video:
+            return videoSaveDirectoryBookmark
+        case .gif:
+            return gifSaveDirectoryBookmark
         }
     }
 
     func saveDirectoryDisplayPath(for captureType: CaptureType) -> String {
         switch captureType {
         case .screenshot:
-            return screenshotSaveDirectoryDisplayPath.isEmpty
-                ? saveDirectoryDisplayPath
-                : screenshotSaveDirectoryDisplayPath
-        case .video, .gif:
-            return videoGifSaveDirectoryDisplayPath.isEmpty
-                ? saveDirectoryDisplayPath
-                : videoGifSaveDirectoryDisplayPath
+            return screenshotSaveDirectoryDisplayPath
+        case .video:
+            return videoSaveDirectoryDisplayPath
+        case .gif:
+            return gifSaveDirectoryDisplayPath
         }
     }
 
@@ -426,9 +432,12 @@ class CaptureSettings: ObservableObject {
         case .screenshot:
             screenshotSaveDirectoryBookmark = bookmark
             screenshotSaveDirectoryDisplayPath = displayPath
-        case .video, .gif:
-            videoGifSaveDirectoryBookmark = bookmark
-            videoGifSaveDirectoryDisplayPath = displayPath
+        case .video:
+            videoSaveDirectoryBookmark = bookmark
+            videoSaveDirectoryDisplayPath = displayPath
+        case .gif:
+            gifSaveDirectoryBookmark = bookmark
+            gifSaveDirectoryDisplayPath = displayPath
         case nil:
             saveDirectoryBookmark = bookmark
             saveDirectoryDisplayPath = displayPath
@@ -599,7 +608,8 @@ class CaptureSettings: ObservableObject {
     func resetToDefaults(preservingHotKeys: Bool = false) {
         // Remove all keys in one pass so only a single objectWillChange fires
         let keys: [String] = [
-            "saveDirectory", "screenshotSaveDirectory", "videoGifSaveDirectory",
+            "saveDirectory", "screenshotSaveDirectory", "videoSaveDirectory", "gifSaveDirectory",
+            "videoGifSaveDirectory", "useDefaultSaveDirectories",
             "copyToClipboard", "copyScreenshotToClipboard", "copyVideoToClipboard", "copyGifToClipboard",
             "showInFinder", "showSaveNotifications", "showInDock",
             "autoUpdateEnabled",
@@ -645,6 +655,8 @@ class CaptureSettings: ObservableObject {
         let masKeys: [String] = [
             "saveDirectoryBookmark", "saveDirectoryDisplayPath",
             "screenshotSaveDirectoryBookmark", "screenshotSaveDirectoryDisplayPath",
+            "videoSaveDirectoryBookmark", "videoSaveDirectoryDisplayPath",
+            "gifSaveDirectoryBookmark", "gifSaveDirectoryDisplayPath",
             "videoGifSaveDirectoryBookmark", "videoGifSaveDirectoryDisplayPath"
         ]
 #else
@@ -665,12 +677,53 @@ class CaptureSettings: ObservableObject {
 
     private init() {
         let defaults = UserDefaults.standard
+        migrateSaveDirectorySettings(defaults)
+
         guard defaults.object(forKey: "multiMonitorCaptureMode") == nil else { return }
 
         multiMonitorCaptureMode = defaults.bool(forKey: "alwaysCaptureMainDisplay")
             ? .mainDisplay
             : .askEveryTime
         defaults.removeObject(forKey: "alwaysCaptureMainDisplay")
+    }
+
+    private func migrateSaveDirectorySettings(_ defaults: UserDefaults) {
+        guard defaults.object(forKey: "useDefaultSaveDirectories") == nil else { return }
+
+        let legacySharedDirectory = defaults.string(forKey: "saveDirectory") ?? ""
+        let legacyVideoGifDirectory = defaults.string(forKey: "videoGifSaveDirectory") ?? ""
+        let hasCustomDirectory = !legacySharedDirectory.isEmpty ||
+            !screenshotSaveDirectory.isEmpty ||
+            !legacyVideoGifDirectory.isEmpty
+#if APPSTORE
+        let hasCustomBookmark = !saveDirectoryBookmark.isEmpty ||
+            !screenshotSaveDirectoryBookmark.isEmpty ||
+            !videoGifSaveDirectoryBookmark.isEmpty
+#else
+        let hasCustomBookmark = false
+#endif
+
+        guard hasCustomDirectory || hasCustomBookmark else { return }
+
+        useDefaultSaveDirectories = false
+        if screenshotSaveDirectory.isEmpty {
+            screenshotSaveDirectory = legacySharedDirectory
+        }
+        videoSaveDirectory = legacyVideoGifDirectory.isEmpty ? legacySharedDirectory : legacyVideoGifDirectory
+        gifSaveDirectory = legacyVideoGifDirectory.isEmpty ? legacySharedDirectory : legacyVideoGifDirectory
+
+#if APPSTORE
+        if screenshotSaveDirectoryBookmark.isEmpty, !saveDirectoryBookmark.isEmpty {
+            screenshotSaveDirectoryBookmark = saveDirectoryBookmark
+            screenshotSaveDirectoryDisplayPath = saveDirectoryDisplayPath
+        }
+        let videoGifBookmark = videoGifSaveDirectoryBookmark.isEmpty ? saveDirectoryBookmark : videoGifSaveDirectoryBookmark
+        let videoGifDisplayPath = videoGifSaveDirectoryDisplayPath.isEmpty ? saveDirectoryDisplayPath : videoGifSaveDirectoryDisplayPath
+        videoSaveDirectoryBookmark = videoGifBookmark
+        videoSaveDirectoryDisplayPath = videoGifDisplayPath
+        gifSaveDirectoryBookmark = videoGifBookmark
+        gifSaveDirectoryDisplayPath = videoGifDisplayPath
+#endif
     }
 }
 

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -157,7 +157,8 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
 #if APPSTORE
     private let saveDirectoryBookmarkKey = "saveDirectoryBookmark"
     private let screenshotSaveDirectoryBookmarkKey = "screenshotSaveDirectoryBookmark"
-    private let videoGifSaveDirectoryBookmarkKey = "videoGifSaveDirectoryBookmark"
+    private let videoSaveDirectoryBookmarkKey = "videoSaveDirectoryBookmark"
+    private let gifSaveDirectoryBookmarkKey = "gifSaveDirectoryBookmark"
     private var activeSecurityScopedDirectoryURLs: [String: URL] = [:]
     private let bookmarkQueue = DispatchQueue(label: "com.tinyclips.save-service.bookmark")
 
@@ -166,8 +167,10 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         switch type {
         case .screenshot:
             keys = [screenshotSaveDirectoryBookmarkKey]
-        case .video, .gif:
-            keys = [videoGifSaveDirectoryBookmarkKey]
+        case .video:
+            keys = [videoSaveDirectoryBookmarkKey]
+        case .gif:
+            keys = [gifSaveDirectoryBookmarkKey]
         case nil:
             keys = [saveDirectoryBookmarkKey]
         }
@@ -179,7 +182,8 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         invalidateSaveDirectoryBookmarks(for: [
             saveDirectoryBookmarkKey,
             screenshotSaveDirectoryBookmarkKey,
-            videoGifSaveDirectoryBookmarkKey
+            videoSaveDirectoryBookmarkKey,
+            gifSaveDirectoryBookmarkKey
         ])
     }
 
@@ -206,22 +210,12 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     func generateURL(for type: CaptureType, fileExtension: String, stemSuffix: String?) -> URL {
-#if APPSTORE
         let directoryURL = outputDirectoryURL(for: type)
 
         try? FileManager.default.createDirectory(
             at: directoryURL,
             withIntermediateDirectories: true
         )
-#else
-        let directoryURL = CaptureSettings.shared.resolvedSaveDirectory(for: type)
-
-        // Ensure directory exists
-        try? FileManager.default.createDirectory(
-            at: directoryURL,
-            withIntermediateDirectories: true
-        )
-#endif
 
         var filename = generatedFileName(for: type, fileExtension: fileExtension)
         if let stemSuffix,
@@ -231,18 +225,22 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
             filename = ext.isEmpty ? "\(stem) \(stemSuffix)" : "\(stem) \(stemSuffix).\(ext)"
         }
 
-#if APPSTORE
         return uniqueURL(in: directoryURL, filename: filename)
-#else
-        return uniqueURL(in: directoryURL, filename: filename)
-#endif
     }
 
     func outputDirectoryURL(for type: CaptureType) -> URL {
+        let settings = CaptureSettings.shared
+        guard !settings.useDefaultSaveDirectories else {
+            return defaultDirectoryURL(for: type)
+        }
+
 #if APPSTORE
-        return appStoreOutputDirectoryURL(for: type)
+        return customDirectoryURLFromBookmark(for: type) ?? defaultDirectoryURL(for: type)
 #else
-        return CaptureSettings.shared.resolvedSaveDirectory(for: type)
+        let directory = settings.saveDirectoryPath(for: type)
+        return directory.isEmpty
+            ? defaultDirectoryURL(for: type)
+            : URL(fileURLWithPath: directory, isDirectory: true)
 #endif
     }
 
@@ -311,28 +309,21 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
-#if APPSTORE
-    private func appStoreOutputDirectoryURL(for type: CaptureType) -> URL {
-        if let customDirectory = customDirectoryURLFromBookmark(for: type) {
-            return customDirectory
-        }
-        return defaultDirectoryURL(for: type)
-    }
-
     private func defaultDirectoryURL(for type: CaptureType) -> URL {
         let fallbackBase = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
         let baseURL: URL
 
         switch type {
-        case .video:
+        case .video, .gif:
             baseURL = FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask).first ?? fallbackBase
-        case .screenshot, .gif:
+        case .screenshot:
             baseURL = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first ?? fallbackBase
         }
 
         return baseURL.appendingPathComponent("TinyClips", isDirectory: true)
     }
 
+#if APPSTORE
     private func customDirectoryURLFromBookmark(for type: CaptureType) -> URL? {
         bookmarkQueue.sync {
             for key in bookmarkKeys(for: type) {
@@ -376,9 +367,11 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
     private func bookmarkKeys(for type: CaptureType) -> [String] {
         switch type {
         case .screenshot:
-            return [screenshotSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
-        case .video, .gif:
-            return [videoGifSaveDirectoryBookmarkKey, saveDirectoryBookmarkKey]
+            return [screenshotSaveDirectoryBookmarkKey]
+        case .video:
+            return [videoSaveDirectoryBookmarkKey]
+        case .gif:
+            return [gifSaveDirectoryBookmarkKey]
         }
     }
 
@@ -391,8 +384,10 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         switch bookmarkKey {
         case screenshotSaveDirectoryBookmarkKey:
             return "screenshotSaveDirectoryDisplayPath"
-        case videoGifSaveDirectoryBookmarkKey:
-            return "videoGifSaveDirectoryDisplayPath"
+        case videoSaveDirectoryBookmarkKey:
+            return "videoSaveDirectoryDisplayPath"
+        case gifSaveDirectoryBookmarkKey:
+            return "gifSaveDirectoryDisplayPath"
         default:
             return "saveDirectoryDisplayPath"
         }

--- a/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
@@ -4,8 +4,7 @@ import SwiftUI
 struct GeneralSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
     @ObservedObject var launchAtLogin: LaunchAtLoginManager
-    let chooseSaveDirectory: (CaptureType?) -> Void
-    let resetSaveDirectory: (CaptureType?) -> Void
+    let chooseSaveDirectory: (CaptureType) -> Void
     let resetAllSettings: () -> Void
     let showInDockBinding: Binding<Bool>
     @State private var showPurgeConfirmation = false
@@ -14,41 +13,21 @@ struct GeneralSettingsSection: View {
 
     var body: some View {
         Section("Output") {
-#if APPSTORE
             VStack(alignment: .leading, spacing: 6) {
-                Text("Default locations: Screenshots/GIFs → Pictures/TinyClips, Videos → Movies/TinyClips")
+                Toggle("Use default folders", isOn: $settings.useDefaultSaveDirectories)
+                    .accessibilityLabel("Use default capture folders")
+
+                Text("Screenshots → Pictures/TinyClips, Videos and GIFs → Movies/TinyClips")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-
-                HStack {
-                    Text(settings.saveDirectoryDisplayPath.isEmpty ? "Using default folders" : settings.saveDirectoryDisplayPath)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-
-                    Spacer()
-
-                    Button("Browse…") {
-                        chooseSaveDirectory(nil)
-                    }
-
-                    if !settings.saveDirectoryBookmark.isEmpty {
-                        Button("Reset") {
-                            resetSaveDirectory(nil)
-                        }
-                    }
-                }
             }
-#else
-            HStack {
-                TextField("Save to", text: $settings.saveDirectory)
-                    .textFieldStyle(.roundedBorder)
-                Button("Browse…") {
-                    chooseSaveDirectory(nil)
-                }
+
+            if !settings.useDefaultSaveDirectories {
+                saveDirectoryRow(title: "Screenshots folder", type: .screenshot)
+                saveDirectoryRow(title: "Videos folder", type: .video)
+                saveDirectoryRow(title: "GIFs folder", type: .gif)
             }
-#endif
-            saveDirectoryRow(title: "Screenshots folder", type: .screenshot)
-            saveDirectoryRow(title: "Videos & GIFs folder", type: .video)
+
             VStack(alignment: .leading, spacing: 6) {
                 TextField("File name template", text: $settings.fileNameTemplate)
                     .textFieldStyle(.roundedBorder)
@@ -151,11 +130,6 @@ struct GeneralSettingsSection: View {
                 Button("Choose…") {
                     chooseSaveDirectory(type)
                 }
-                if !settings.isUsingSharedSaveDirectory(for: type) {
-                    Button("Reset to shared") {
-                        resetSaveDirectory(type)
-                    }
-                }
             }
 
             Text(saveDirectoryPath(for: type))
@@ -164,36 +138,26 @@ struct GeneralSettingsSection: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if settings.isUsingSharedSaveDirectory(for: type) {
-                Text(saveDirectoryHint(for: type))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
+            Text(saveDirectoryHint(for: type))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
     }
 
     private func saveDirectoryPath(for type: CaptureType) -> String {
 #if APPSTORE
-        if type == .video,
-           settings.isUsingSharedSaveDirectory(for: type),
-           settings.saveDirectoryBookmark.isEmpty {
-            let videoPath = SaveService.shared.outputDirectoryURL(for: .video).path
-            let gifPath = SaveService.shared.outputDirectoryURL(for: .gif).path
-            return "Videos: \(videoPath)  GIFs: \(gifPath)"
-        }
         let path = settings.saveDirectoryDisplayPath(for: type)
-        return path.isEmpty ? SaveService.shared.outputDirectoryURL(for: type).path : path
+        return path.isEmpty ? "No folder selected" : path
 #else
-        return settings.resolvedSaveDirectory(for: type).path
+        let path = settings.saveDirectoryPath(for: type)
+        return path.isEmpty ? "No folder selected" : path
 #endif
     }
 
     private func saveDirectoryHint(for type: CaptureType) -> String {
-#if APPSTORE
-        return settings.saveDirectoryBookmark.isEmpty ? "Using default folders" : "Using shared folder"
-#else
-        return "Using shared folder"
-#endif
+        settings.hasCustomSaveDirectory(for: type)
+            ? "Custom folder"
+            : "Choose a folder for this capture type."
     }
 
     @ViewBuilder

--- a/mac/TinyClips/Views/SettingsView.swift
+++ b/mac/TinyClips/Views/SettingsView.swift
@@ -77,7 +77,6 @@ struct SettingsView: View {
                         settings: settings,
                         launchAtLogin: launchAtLogin,
                         chooseSaveDirectory: chooseSaveDirectory,
-                        resetSaveDirectory: resetSaveDirectory,
                         resetAllSettings: resetAllSettings,
                         showInDockBinding: showInDockBinding
                     )
@@ -181,7 +180,7 @@ struct SettingsView: View {
         settingsWindowManager.selectedTab = nil
     }
 
-    private func chooseSaveDirectory(for captureType: CaptureType?) {
+    private func chooseSaveDirectory(for captureType: CaptureType) {
         DispatchQueue.main.async {
             let panel = NSOpenPanel()
             panel.canChooseFiles = false
@@ -189,7 +188,9 @@ struct SettingsView: View {
             panel.allowsMultipleSelection = false
             panel.canCreateDirectories = true
 #if APPSTORE
-            panel.directoryURL = FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask).first
+            panel.directoryURL = captureType == .screenshot
+                ? FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first
+                : FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask).first
 #endif
             guard panel.runModal() == .OK, let url = panel.url else { return }
 #if APPSTORE
@@ -204,32 +205,14 @@ struct SettingsView: View {
             switch captureType {
             case .screenshot:
                 settings.screenshotSaveDirectory = url.path
-            case .video, .gif:
-                settings.videoGifSaveDirectory = url.path
-            case nil:
-                settings.saveDirectory = url.path
+            case .video:
+                settings.videoSaveDirectory = url.path
+            case .gif:
+                settings.gifSaveDirectory = url.path
             }
 #endif
         }
     }
-
-#if APPSTORE
-    private func resetSaveDirectory(for captureType: CaptureType?) {
-        settings.resetSaveDirectory(for: captureType)
-        SaveService.shared.invalidateSaveDirectoryBookmark(for: captureType)
-    }
-#else
-    private func resetSaveDirectory(for captureType: CaptureType?) {
-        switch captureType {
-        case .screenshot:
-            settings.screenshotSaveDirectory = ""
-        case .video, .gif:
-            settings.videoGifSaveDirectory = ""
-        case nil:
-            break
-        }
-    }
-#endif
 
     private func resetAllSettings() {
         DispatchQueue.main.async {

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Independent capture folders** — Settings → General now uses Pictures/TinyClips for screenshots and Videos/TinyClips for videos and GIFs by default. Turn off **Use defaults** to choose separate folders for screenshots, videos, and GIFs.
 - **Teleprompter transcript overlay** — Settings → Video → Teleprompter lets you paste a script, enable the teleprompter, tune the scroll speed (10–200 DIPs/s), and preview that speed live. During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay appears only after recording starts, pauses and resumes with recording, fails closed if Windows cannot exclude it from capture, and remembers a monitor-relative position across mixed-DPI display changes.
 
 ### Fixed

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -291,17 +291,7 @@ public partial class App : Application
 
     private ButtonBase CreateFolderButton(Action dismiss)
     {
-        var settings = Services.GetRequiredService<ICaptureSettings>();
         var storage = Services.GetRequiredService<IClipStorageService>();
-
-        if (!string.IsNullOrWhiteSpace(settings.SaveDirectory))
-        {
-            return CreateQuickAccessButton(
-                "Open Save Folder",
-                GlyphFolder,
-                new RelayCommand(() => OpenFolder(storage.OutputDirectory(CaptureType.Screenshot))),
-                dismiss);
-        }
 
         var flyout = new MenuFlyout();
         var button = new DropDownButton

--- a/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml
@@ -50,36 +50,84 @@
             Text="Files &amp; saving" />
 
         <Border Style="{StaticResource SettingCardStyle}">
-            <Grid ColumnSpacing="16">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
-                    <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Save locations" />
-                    <TextBlock
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{x:Bind ViewModel.ScreenshotSaveLocationDisplay, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
-                    <TextBlock
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{x:Bind ViewModel.VideoGifSaveLocationDisplay, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
-                    <TextBlock
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{x:Bind ViewModel.SaveLocationModeDisplay, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
+            <StackPanel Spacing="8">
+                <Grid ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Save locations" />
+                        <TextBlock
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.SaveLocationModeDisplay, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                    <ToggleSwitch
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        AutomationProperties.AutomationId="UseDefaultSaveDirectoriesToggle"
+                        AutomationProperties.Name="Use default capture folders"
+                        Header="Use defaults"
+                        IsOn="{x:Bind ViewModel.UseDefaultSaveDirectories, Mode=TwoWay}" />
+                </Grid>
+                <StackPanel
+                    Spacing="8"
+                    Visibility="{x:Bind ViewModel.CustomSaveLocationsVisibility, Mode=OneWay}">
+                    <Grid ColumnSpacing="16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.ScreenshotSaveLocationDisplay, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                        <Button
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="BrowseScreenshotSaveDirectoryButton"
+                            AutomationProperties.Name="Choose screenshots folder"
+                            Click="OnBrowseScreenshotSaveDirectory"
+                            Content="Choose&#x2026;" />
+                    </Grid>
+                    <Grid ColumnSpacing="16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.VideoSaveLocationDisplay, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                        <Button
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="BrowseVideoSaveDirectoryButton"
+                            AutomationProperties.Name="Choose videos folder"
+                            Click="OnBrowseVideoSaveDirectory"
+                            Content="Choose&#x2026;" />
+                    </Grid>
+                    <Grid ColumnSpacing="16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.GifSaveLocationDisplay, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                        <Button
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="BrowseGifSaveDirectoryButton"
+                            AutomationProperties.Name="Choose GIFs folder"
+                            Click="OnBrowseGifSaveDirectory"
+                            Content="Choose&#x2026;" />
+                    </Grid>
                 </StackPanel>
-                <Button
-                    Grid.Column="1"
-                    VerticalAlignment="Center"
-                    AutomationProperties.AutomationId="BrowseSaveDirectoryButton"
-                    Click="OnBrowseSaveDirectory"
-                    Content="Browse&#x2026;" />
-            </Grid>
+            </StackPanel>
         </Border>
 
         <Border Style="{StaticResource SettingCardStyle}">

--- a/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Settings/Sections/GeneralSettingsSection.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using TinyClips.Core.Models;
 
 namespace TinyClips.App.Settings.Sections;
 
@@ -20,7 +21,7 @@ public sealed partial class GeneralSettingsSection : UserControl
     /// (it needs an HWND via <c>WinRT.Interop.WindowNative</c>), so this section only requests it
     /// rather than showing a picker itself.
     /// </summary>
-    public event EventHandler? BrowseSaveDirectoryRequested;
+    public event Action<CaptureType>? BrowseSaveDirectoryRequested;
 
     public GeneralSettingsSection(SettingsViewModel viewModel)
     {
@@ -30,8 +31,14 @@ public sealed partial class GeneralSettingsSection : UserControl
         SectionLifecycle.HookFirstLoad(this, viewModel, _realizationScope);
     }
 
-    private void OnBrowseSaveDirectory(object sender, RoutedEventArgs e) =>
-        BrowseSaveDirectoryRequested?.Invoke(this, EventArgs.Empty);
+    private void OnBrowseScreenshotSaveDirectory(object sender, RoutedEventArgs e) =>
+        BrowseSaveDirectoryRequested?.Invoke(CaptureType.Screenshot);
+
+    private void OnBrowseVideoSaveDirectory(object sender, RoutedEventArgs e) =>
+        BrowseSaveDirectoryRequested?.Invoke(CaptureType.Video);
+
+    private void OnBrowseGifSaveDirectory(object sender, RoutedEventArgs e) =>
+        BrowseSaveDirectoryRequested?.Invoke(CaptureType.Gif);
 
     private void OnOpenTempFolder(object sender, RoutedEventArgs e) => ViewModel.OpenTempFolder();
 

--- a/windows/src/TinyClips.App/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/SettingsViewModel.cs
@@ -180,19 +180,39 @@ public sealed partial class SettingsViewModel : ObservableObject
         }
     }
 
-    public string ScreenshotSaveLocationDisplay => $"Screenshot: {ResolveEffectiveSaveLocation(CaptureType.Screenshot)}";
+    public string ScreenshotSaveLocationDisplay => $"Screenshots: {ResolveSaveLocation(CaptureType.Screenshot)}";
 
-    public string VideoGifSaveLocationDisplay => $"Video/GIF: {ResolveEffectiveSaveLocation(CaptureType.Video)}";
+    public string VideoSaveLocationDisplay => $"Videos: {ResolveSaveLocation(CaptureType.Video)}";
 
-    public string SaveLocationModeDisplay => string.IsNullOrWhiteSpace(SaveDirectory)
-        ? "Using defaults by capture type."
-        : "Custom save location override applies to all capture types.";
+    public string GifSaveLocationDisplay => $"GIFs: {ResolveSaveLocation(CaptureType.Gif)}";
+
+    public string SaveLocationModeDisplay => UseDefaultSaveDirectories
+        ? "Screenshots save to Pictures/TinyClips; videos and GIFs save to Videos/TinyClips."
+        : "Choose a folder for each capture type.";
+
+    public Microsoft.UI.Xaml.Visibility CustomSaveLocationsVisibility => UseDefaultSaveDirectories
+        ? Microsoft.UI.Xaml.Visibility.Collapsed
+        : Microsoft.UI.Xaml.Visibility.Visible;
 
     public string TempFolderSummary => FormatTemporaryFilesSummary(TinyClipsTemporaryFiles.GetSummary());
 
-    private string ResolveEffectiveSaveLocation(CaptureType type) => string.IsNullOrWhiteSpace(SaveDirectory)
-        ? $"{_storage.OutputDirectory(type)} (default)"
-        : SaveDirectory;
+    private string ResolveSaveLocation(CaptureType type)
+    {
+        if (UseDefaultSaveDirectories)
+        {
+            return $"{_storage.OutputDirectory(type)} (default)";
+        }
+
+        var customDirectory = type switch
+        {
+            CaptureType.Screenshot => ScreenshotSaveDirectory,
+            CaptureType.Video => VideoSaveDirectory,
+            CaptureType.Gif => GifSaveDirectory,
+            _ => string.Empty,
+        };
+
+        return string.IsNullOrWhiteSpace(customDirectory) ? "No folder selected" : customDirectory;
+    }
 
     public void OpenTempFolder()
     {
@@ -239,9 +259,23 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ScreenshotSaveLocationDisplay))]
-    [NotifyPropertyChangedFor(nameof(VideoGifSaveLocationDisplay))]
+    [NotifyPropertyChangedFor(nameof(VideoSaveLocationDisplay))]
+    [NotifyPropertyChangedFor(nameof(GifSaveLocationDisplay))]
     [NotifyPropertyChangedFor(nameof(SaveLocationModeDisplay))]
-    private string _saveDirectory = string.Empty;
+    [NotifyPropertyChangedFor(nameof(CustomSaveLocationsVisibility))]
+    private bool _useDefaultSaveDirectories;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ScreenshotSaveLocationDisplay))]
+    private string _screenshotSaveDirectory = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(VideoSaveLocationDisplay))]
+    private string _videoSaveDirectory = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(GifSaveLocationDisplay))]
+    private string _gifSaveDirectory = string.Empty;
 
     [ObservableProperty]
     private string _fileNameTemplate = string.Empty;
@@ -667,7 +701,10 @@ public sealed partial class SettingsViewModel : ObservableObject
                 AppTheme.Dark => 2,
                 _ => 0,
             };
-            SaveDirectory = _settings.SaveDirectory;
+            UseDefaultSaveDirectories = _settings.UseDefaultSaveDirectories;
+            ScreenshotSaveDirectory = _settings.ScreenshotSaveDirectory;
+            VideoSaveDirectory = _settings.VideoSaveDirectory;
+            GifSaveDirectory = _settings.GifSaveDirectory;
             FileNameTemplate = string.IsNullOrWhiteSpace(_settings.FileNameTemplate)
                 ? "TinyClips {date} at {time}"
                 : _settings.FileNameTemplate;
@@ -939,10 +976,17 @@ public sealed partial class SettingsViewModel : ObservableObject
         ThemeChanged?.Invoke();
     }
 
-    partial void OnSaveDirectoryChanged(string value)
-    {
-        Persist(() => _settings.SaveDirectory = value);
-    }
+    partial void OnUseDefaultSaveDirectoriesChanged(bool value) =>
+        Persist(() => _settings.UseDefaultSaveDirectories = value);
+
+    partial void OnScreenshotSaveDirectoryChanged(string value) =>
+        Persist(() => _settings.ScreenshotSaveDirectory = value);
+
+    partial void OnVideoSaveDirectoryChanged(string value) =>
+        Persist(() => _settings.VideoSaveDirectory = value);
+
+    partial void OnGifSaveDirectoryChanged(string value) =>
+        Persist(() => _settings.GifSaveDirectory = value);
 
     partial void OnFileNameTemplateChanged(string value) => Persist(() => _settings.FileNameTemplate = value);
 

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using TinyClips.App.Settings;
 using TinyClips.App.Settings.Sections;
+using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 using Windows.Graphics;
 using Windows.Storage;

--- a/windows/src/TinyClips.App/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/SettingsWindow.xaml.cs
@@ -128,11 +128,13 @@ public sealed partial class SettingsWindow : Window
     // The folder picker must be owned by this window (it needs an HWND via
     // WinRT.Interop.WindowNative), so GeneralSettingsSection only raises a request event and this
     // shell shows the picker on its behalf.
-    private async void OnBrowseSaveDirectoryRequested(object? sender, EventArgs e)
+    private async void OnBrowseSaveDirectoryRequested(CaptureType type)
     {
         var picker = new FolderPicker
         {
-            SuggestedStartLocation = PickerLocationId.PicturesLibrary,
+            SuggestedStartLocation = type == CaptureType.Screenshot
+                ? PickerLocationId.PicturesLibrary
+                : PickerLocationId.VideosLibrary,
         };
         picker.FileTypeFilter.Add("*");
 
@@ -142,7 +144,18 @@ public sealed partial class SettingsWindow : Window
         StorageFolder? folder = await picker.PickSingleFolderAsync();
         if (folder is not null)
         {
-            ViewModel.SaveDirectory = folder.Path;
+            switch (type)
+            {
+                case CaptureType.Screenshot:
+                    ViewModel.ScreenshotSaveDirectory = folder.Path;
+                    break;
+                case CaptureType.Video:
+                    ViewModel.VideoSaveDirectory = folder.Path;
+                    break;
+                case CaptureType.Gif:
+                    ViewModel.GifSaveDirectory = folder.Path;
+                    break;
+            }
         }
     }
 }

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -11,12 +11,37 @@ public sealed class CaptureSettings : ICaptureSettings
     {
         _settings = settings;
         _analytics = analytics;
+        MigrateLegacySaveDirectory();
     }
 
     public string SaveDirectory
     {
         get => _settings.SaveDirectory;
         set => _settings.SaveDirectory = value;
+    }
+
+    public bool UseDefaultSaveDirectories
+    {
+        get => _settings.Get("useDefaultSaveDirectories", true);
+        set => _settings.Set("useDefaultSaveDirectories", value);
+    }
+
+    public string ScreenshotSaveDirectory
+    {
+        get => _settings.Get("screenshotSaveDirectory", string.Empty);
+        set => _settings.Set("screenshotSaveDirectory", value);
+    }
+
+    public string VideoSaveDirectory
+    {
+        get => _settings.Get("videoSaveDirectory", string.Empty);
+        set => _settings.Set("videoSaveDirectory", value);
+    }
+
+    public string GifSaveDirectory
+    {
+        get => _settings.Get("gifSaveDirectory", string.Empty);
+        set => _settings.Set("gifSaveDirectory", value);
     }
 
     public AppTheme Theme
@@ -605,6 +630,10 @@ public sealed class CaptureSettings : ICaptureSettings
     public void ResetToDefaults()
     {
         SaveDirectory = string.Empty;
+        UseDefaultSaveDirectories = true;
+        ScreenshotSaveDirectory = string.Empty;
+        VideoSaveDirectory = string.Empty;
+        GifSaveDirectory = string.Empty;
         Theme = AppTheme.Default;
         CopyScreenshotToClipboard = true;
         CopyVideoToClipboard = false;
@@ -677,6 +706,25 @@ public sealed class CaptureSettings : ICaptureSettings
         UploadcareAutoUpload = false;
         UploadcareCopyUrl = false;
         _analytics?.Clear();
+    }
+
+    private void MigrateLegacySaveDirectory()
+    {
+        if (_settings.Get("saveDirectoryFoldersMigrated", false))
+        {
+            return;
+        }
+
+        var legacyDirectory = SaveDirectory.Trim();
+        if (!string.IsNullOrWhiteSpace(legacyDirectory))
+        {
+            UseDefaultSaveDirectories = false;
+            ScreenshotSaveDirectory = legacyDirectory;
+            VideoSaveDirectory = legacyDirectory;
+            GifSaveDirectory = legacyDirectory;
+        }
+
+        _settings.Set("saveDirectoryFoldersMigrated", true);
         ScreenshotHotKeyCode = 53;
         ScreenshotHotKeyModifiers = 6;
         VideoHotKeyCode = 54;

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -705,6 +705,12 @@ public sealed class CaptureSettings : ICaptureSettings
         UploadcarePublicKey = string.Empty;
         UploadcareAutoUpload = false;
         UploadcareCopyUrl = false;
+        ScreenshotHotKeyCode = 53;
+        ScreenshotHotKeyModifiers = 6;
+        VideoHotKeyCode = 54;
+        VideoHotKeyModifiers = 6;
+        GifHotKeyCode = 55;
+        GifHotKeyModifiers = 6;
         _analytics?.Clear();
     }
 
@@ -725,12 +731,6 @@ public sealed class CaptureSettings : ICaptureSettings
         }
 
         _settings.Set("saveDirectoryFoldersMigrated", true);
-        ScreenshotHotKeyCode = 53;
-        ScreenshotHotKeyModifiers = 6;
-        VideoHotKeyCode = 54;
-        VideoHotKeyModifiers = 6;
-        GifHotKeyCode = 55;
-        GifHotKeyModifiers = 6;
     }
 
     private static WebcamShape ParseWebcamShape(string value) =>        (value ?? string.Empty).ToLowerInvariant() switch

--- a/windows/src/TinyClips.Core/Services/ClipStorageService.cs
+++ b/windows/src/TinyClips.Core/Services/ClipStorageService.cs
@@ -19,14 +19,23 @@ public sealed class ClipStorageService : IClipStorageService
 
     public string OutputDirectory(CaptureType type)
     {
-        if (!string.IsNullOrWhiteSpace(_settings.SaveDirectory))
+        if (!_settings.UseDefaultSaveDirectories)
         {
-            return _settings.SaveDirectory.Trim();
+            var customDirectory = type switch
+            {
+                CaptureType.Screenshot => _settings.ScreenshotSaveDirectory,
+                CaptureType.Video => _settings.VideoSaveDirectory,
+                CaptureType.Gif => _settings.GifSaveDirectory,
+                _ => string.Empty,
+            };
+
+            if (!string.IsNullOrWhiteSpace(customDirectory))
+            {
+                return customDirectory.Trim();
+            }
         }
 
-        // Split defaults by media type: screenshots in Pictures, recordings in Videos.
-        // This keeps recording flows away from Pictures (which is commonly CFA-protected)
-        // while preserving screenshot expectations.
+        // Screenshots belong in Pictures; video formats belong in Videos.
         var folder = type == CaptureType.Screenshot
             ? _fileSystem.GetFolderPath(Environment.SpecialFolder.MyPictures)
             : _fileSystem.GetFolderPath(Environment.SpecialFolder.MyVideos);

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -5,6 +5,10 @@ namespace TinyClips.Core.Services;
 public interface ICaptureSettings
 {
     string SaveDirectory { get; set; }
+    bool UseDefaultSaveDirectories { get; set; }
+    string ScreenshotSaveDirectory { get; set; }
+    string VideoSaveDirectory { get; set; }
+    string GifSaveDirectory { get; set; }
     AppTheme Theme { get; set; }
     bool CopyScreenshotToClipboard { get; set; }
     bool CopyVideoToClipboard { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -11,6 +11,10 @@ public sealed class CaptureSettingsTests
         var settings = CreateSettings();
 
         Assert.True(settings.CopyScreenshotToClipboard);
+        Assert.True(settings.UseDefaultSaveDirectories);
+        Assert.Equal(string.Empty, settings.ScreenshotSaveDirectory);
+        Assert.Equal(string.Empty, settings.VideoSaveDirectory);
+        Assert.Equal(string.Empty, settings.GifSaveDirectory);
         Assert.Equal(10.0, settings.GifFrameRate);
         Assert.Equal(30, settings.VideoFrameRate);
         Assert.Equal(100, settings.ScreenshotScale);
@@ -38,6 +42,10 @@ public sealed class CaptureSettingsTests
         var settings = CreateSettings();
 
         settings.CopyScreenshotToClipboard = false;
+        settings.UseDefaultSaveDirectories = false;
+        settings.ScreenshotSaveDirectory = @"C:\Captures\Screenshots";
+        settings.VideoSaveDirectory = @"C:\Captures\Videos";
+        settings.GifSaveDirectory = @"C:\Captures\Gifs";
         settings.GifFrameRate = 24.5;
         settings.VideoFrameRate = 60;
         settings.FileNameTemplate = "Custom {date}";
@@ -54,6 +62,10 @@ public sealed class CaptureSettingsTests
         settings.UploadcareCopyUrl = true;
 
         Assert.False(settings.CopyScreenshotToClipboard);
+        Assert.False(settings.UseDefaultSaveDirectories);
+        Assert.Equal(@"C:\Captures\Screenshots", settings.ScreenshotSaveDirectory);
+        Assert.Equal(@"C:\Captures\Videos", settings.VideoSaveDirectory);
+        Assert.Equal(@"C:\Captures\Gifs", settings.GifSaveDirectory);
         Assert.Equal(24.5, settings.GifFrameRate);
         Assert.Equal(60, settings.VideoFrameRate);
         Assert.Equal("Custom {date}", settings.FileNameTemplate);

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -31,6 +31,36 @@ public sealed class CaptureSettingsTests
         Assert.Equal(string.Empty, settings.UploadcarePublicKey);
         Assert.False(settings.UploadcareAutoUpload);
         Assert.False(settings.UploadcareCopyUrl);
+    }
+
+    [Fact]
+    public void SaveDirectoryMigration_PreservesHotkeys_AndResetRestoresDefaults()
+    {
+        var settingsService = new TestSettingsService { SaveDirectory = @"C:\Captures" };
+        settingsService.Set("screenshotHotKeyCode", 80);
+        settingsService.Set("screenshotHotKeyModifiers", 4);
+        settingsService.Set("videoHotKeyCode", 81);
+        settingsService.Set("videoHotKeyModifiers", 5);
+        settingsService.Set("gifHotKeyCode", 82);
+        settingsService.Set("gifHotKeyModifiers", 7);
+
+        var settings = new CaptureSettings(settingsService);
+
+        Assert.Equal(80, settings.ScreenshotHotKeyCode);
+        Assert.Equal(4, settings.ScreenshotHotKeyModifiers);
+        Assert.Equal(81, settings.VideoHotKeyCode);
+        Assert.Equal(5, settings.VideoHotKeyModifiers);
+        Assert.Equal(82, settings.GifHotKeyCode);
+        Assert.Equal(7, settings.GifHotKeyModifiers);
+
+        settings.ResetToDefaults();
+
+        Assert.Equal(53, settings.ScreenshotHotKeyCode);
+        Assert.Equal(6, settings.ScreenshotHotKeyModifiers);
+        Assert.Equal(54, settings.VideoHotKeyCode);
+        Assert.Equal(6, settings.VideoHotKeyModifiers);
+        Assert.Equal(55, settings.GifHotKeyCode);
+        Assert.Equal(6, settings.GifHotKeyModifiers);
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Screenshot));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Video));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Gif));

--- a/windows/tests/TinyClips.Core.Tests/ClipStorageServiceTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/ClipStorageServiceTests.cs
@@ -19,7 +19,7 @@ public sealed class ClipStorageServiceTests
     }
 
     [Fact]
-    public void OutputDirectory_UsesSaveDirectoryOrTypeSpecificDefaults()
+    public void OutputDirectory_UsesCustomDirectoriesOrTypeSpecificDefaults()
     {
         var fakeFileSystem = new FakeFileSystem
         {
@@ -31,12 +31,17 @@ public sealed class ClipStorageServiceTests
         };
 
         var settings = CreateSettings();
-        settings.SaveDirectory = "C:\\Temp\\TinyClips";
+        settings.UseDefaultSaveDirectories = false;
+        settings.ScreenshotSaveDirectory = "C:\\Temp\\Screenshots";
+        settings.VideoSaveDirectory = "C:\\Temp\\Videos";
+        settings.GifSaveDirectory = "C:\\Temp\\Gifs";
         var saveDirectoryService = CreateService(settings, fakeFileSystem);
 
-        Assert.Equal("C:\\Temp\\TinyClips", saveDirectoryService.OutputDirectory(CaptureType.Screenshot));
+        Assert.Equal("C:\\Temp\\Screenshots", saveDirectoryService.OutputDirectory(CaptureType.Screenshot));
+        Assert.Equal("C:\\Temp\\Videos", saveDirectoryService.OutputDirectory(CaptureType.Video));
+        Assert.Equal("C:\\Temp\\Gifs", saveDirectoryService.OutputDirectory(CaptureType.Gif));
 
-        settings.SaveDirectory = string.Empty;
+        settings.UseDefaultSaveDirectories = true;
         var defaultService = CreateService(settings, fakeFileSystem);
 
         var expectedVideos = Path.Combine("C:\\Users\\Test\\Videos", "TinyClips");
@@ -51,7 +56,8 @@ public sealed class ClipStorageServiceTests
     {
         var fakeFileSystem = new FakeFileSystem();
         var settings = CreateSettings();
-        settings.SaveDirectory = "C:\\Temp\\TinyClips";
+        settings.UseDefaultSaveDirectories = false;
+        settings.ScreenshotSaveDirectory = "C:\\Temp\\TinyClips";
         var deterministicNames = new FixedFileNameService();
         var service = new ClipStorageService(settings, deterministicNames, fakeFileSystem);
 


### PR DESCRIPTION
Capture destinations need platform-appropriate defaults while still allowing each output type to be organized independently.

This adds a Use defaults toggle on macOS and Windows. Default mode saves screenshots to Pictures/TinyClips and videos/GIFs to Movies or Videos TinyClips. Disabling it reveals separate folder pickers for screenshots, videos, and GIFs.

Existing custom folder preferences are migrated into the new per-type settings. Windows storage and quick-access folder actions now resolve each capture type independently, and Core tests cover default and custom destination behavior.