### PR TITLE
Improve macOS teleprompter controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
+- macOS teleprompter preview now starts only on demand, with a Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, and small/medium/large text-size and panel-height presets.
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
 - macOS capture settings now offer matching before/after picker controls for screenshots, video recordings, and GIF recordings.
 - macOS multi-monitor capture settings now let you choose to ask every time, capture the display under the cursor, or capture the main display.

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -1801,7 +1801,12 @@ class CaptureManager: ObservableObject {
         guard settings.teleprompterEnabled, !transcript.isEmpty else { return nil }
 
         dismissTeleprompter()
-        let panel = TeleprompterPanel(transcript: transcript, scrollSpeed: settings.teleprompterScrollSpeed)
+        let panel = TeleprompterPanel(
+            transcript: transcript,
+            scrollSpeed: settings.teleprompterScrollSpeed,
+            fontSize: TeleprompterDisplaySize(rawValue: settings.teleprompterFontSize) ?? .medium,
+            panelHeight: TeleprompterDisplaySize(rawValue: settings.teleprompterPanelHeight) ?? .medium
+        )
         teleprompterPanel = panel
         panel.prepareHidden(relativeTo: region)
 

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -173,6 +173,32 @@ enum MultiMonitorCaptureMode: String, CaseIterable {
     }
 }
 
+enum TeleprompterDisplaySize: String, CaseIterable {
+    case small
+    case medium
+    case large
+
+    var label: String {
+        rawValue.capitalized
+    }
+
+    var fontSize: CGFloat {
+        switch self {
+        case .small: return 20
+        case .medium: return 24
+        case .large: return 30
+        }
+    }
+
+    var panelHeight: CGFloat {
+        switch self {
+        case .small: return 120
+        case .medium: return 140
+        case .large: return 220
+        }
+    }
+}
+
 // MARK: - Settings
 
 struct MouseClickOverlayStyle: Sendable {
@@ -355,6 +381,8 @@ class CaptureSettings: ObservableObject {
     @AppStorage("teleprompterEnabled") var teleprompterEnabled: Bool = false
     @AppStorage("teleprompterTranscript") var teleprompterTranscript: String = ""
     @AppStorage("teleprompterScrollSpeed") var teleprompterScrollSpeed: Double = 50
+    @AppStorage("teleprompterFontSize") var teleprompterFontSize: String = TeleprompterDisplaySize.medium.rawValue
+    @AppStorage("teleprompterPanelHeight") var teleprompterPanelHeight: String = TeleprompterDisplaySize.medium.rawValue
     // Custom global hotkeys (stored as Carbon keyCode + modifiers bitmask).
     // Defaults: ⌃⌥⌘5 / ⌃⌥⌘6 / ⌃⌥⌘7 / ⌃⌥⌘8
     // 6400 = controlKey (4096) | optionKey (2048) | cmdKey (256)
@@ -631,7 +659,7 @@ class CaptureSettings: ObservableObject {
             "screenshotCountdownEnabled", "screenshotCountdownDuration",
             "hasCompletedOnboarding", "alwaysCaptureMainDisplay", "multiMonitorCaptureMode", "showRegionIndicator",
             "includeTinyClipsInCapture", "showBrandingOverlay",
-            "teleprompterEnabled", "teleprompterTranscript", "teleprompterScrollSpeed",
+            "teleprompterEnabled", "teleprompterTranscript", "teleprompterScrollSpeed", "teleprompterFontSize", "teleprompterPanelHeight",
             "teleprompterPanelX", "teleprompterPanelY",
             "appStoreClipCountForReview", "appStoreReviewRequested"
         ]

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -3,6 +3,14 @@ import SwiftUI
 struct TeleprompterSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
 
+    private var fontSize: TeleprompterDisplaySize {
+        TeleprompterDisplaySize(rawValue: settings.teleprompterFontSize) ?? .medium
+    }
+
+    private var panelHeight: TeleprompterDisplaySize {
+        TeleprompterDisplaySize(rawValue: settings.teleprompterPanelHeight) ?? .medium
+    }
+
     var body: some View {
         Section("Teleprompter") {
             Toggle("Enable teleprompter", isOn: $settings.teleprompterEnabled)
@@ -31,10 +39,15 @@ struct TeleprompterSettingsSection: View {
             HStack {
                 Slider(
                     value: $settings.teleprompterScrollSpeed,
-                    in: 10...200,
-                    step: 5
+                    in: 0...100,
+                    step: 1
                 )
+                .controlSize(.large)
+                .frame(height: 28)
                 .disabled(!settings.teleprompterEnabled)
+                .onAppear {
+                    settings.teleprompterScrollSpeed = min(max(settings.teleprompterScrollSpeed, 0), 100)
+                }
                 .accessibilityLabel("Teleprompter scroll speed")
                 .accessibilityValue("\(Int(settings.teleprompterScrollSpeed)) points per second")
                 Text("\(Int(settings.teleprompterScrollSpeed)) pt/s")
@@ -44,12 +57,34 @@ struct TeleprompterSettingsSection: View {
             .help("Set how fast the transcript scrolls, in points per second.")
         }
 
+        Section("Appearance") {
+            Picker("Text size:", selection: $settings.teleprompterFontSize) {
+                ForEach(TeleprompterDisplaySize.allCases, id: \.rawValue) { size in
+                    Text(size.label).tag(size.rawValue)
+                }
+            }
+            .disabled(!settings.teleprompterEnabled)
+            .help("Choose the teleprompter text size.")
+            .accessibilityLabel("Teleprompter text size")
+
+            Picker("Panel height:", selection: $settings.teleprompterPanelHeight) {
+                ForEach(TeleprompterDisplaySize.allCases, id: \.rawValue) { size in
+                    Text(size.label).tag(size.rawValue)
+                }
+            }
+            .disabled(!settings.teleprompterEnabled)
+            .help("Choose the teleprompter panel height.")
+            .accessibilityLabel("Teleprompter panel height")
+        }
+
         Section("Preview") {
             TeleprompterScrollPreview(
                 transcript: settings.teleprompterTranscript,
-                scrollSpeed: settings.teleprompterScrollSpeed
+                scrollSpeed: settings.teleprompterScrollSpeed,
+                fontSize: fontSize.fontSize,
+                viewportHeight: panelHeight.panelHeight
             )
-            Text("This preview uses the same scroll speed as the recording overlay.")
+            Text("This preview uses the same size, height, and scroll speed as the recording overlay.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -59,11 +94,13 @@ struct TeleprompterSettingsSection: View {
 private struct TeleprompterScrollPreview: View {
     let transcript: String
     let scrollSpeed: Double
+    let fontSize: CGFloat
+    let viewportHeight: CGFloat
 
     @State private var contentHeight: CGFloat = 0
     @State private var scrollOffset: CGFloat = 0
+    @State private var isPreviewing = false
 
-    private let viewportHeight: CGFloat = 140
     private let frameInterval = 1.0 / 60.0
 
     private var previewTranscript: String {
@@ -78,43 +115,60 @@ private struct TeleprompterScrollPreview: View {
         PreviewConfiguration(
             transcript: previewTranscript,
             scrollSpeed: scrollSpeed,
-            contentHeight: contentHeight
+            contentHeight: contentHeight,
+            isPreviewing: isPreviewing,
+            fontSize: fontSize,
+            viewportHeight: viewportHeight
         )
     }
 
     var body: some View {
-        GeometryReader { proxy in
-            Text(previewTranscript)
-                .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(.white)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 12)
-                .frame(width: proxy.size.width, alignment: .top)
-                .background {
-                    GeometryReader { contentProxy in
-                        Color.clear.preference(
-                            key: PreviewContentHeightKey.self,
-                            value: contentProxy.size.height
-                        )
+        VStack(alignment: .leading, spacing: 8) {
+            GeometryReader { proxy in
+                Text(previewTranscript)
+                    .font(.system(size: fontSize, weight: .medium))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .frame(width: proxy.size.width, alignment: .top)
+                    .background {
+                        GeometryReader { contentProxy in
+                            Color.clear.preference(
+                                key: PreviewContentHeightKey.self,
+                                value: contentProxy.size.height
+                            )
+                        }
                     }
+                    .offset(y: -scrollOffset)
+            }
+            .frame(height: viewportHeight)
+            .clipped()
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.black.opacity(0.7))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Teleprompter scroll speed preview")
+            .accessibilityValue("Scrolling at \(Int(scrollSpeed)) points per second")
+
+            Button(isPreviewing ? "Stop Preview" : "Start Preview") {
+                isPreviewing.toggle()
+                if !isPreviewing {
+                    scrollOffset = 0
                 }
-                .offset(y: -scrollOffset)
-        }
-        .frame(height: viewportHeight)
-        .clipped()
-        .background {
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color.black.opacity(0.7))
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+            .accessibilityHint(isPreviewing ? "Stops and resets the preview." : "Starts the preview from the beginning.")
         }
         .onPreferenceChange(PreviewContentHeightKey.self) { contentHeight = $0 }
         .task(id: configuration) {
             scrollOffset = 0
+            guard isPreviewing, scrollSpeed > 0 else { return }
             while !Task.isCancelled {
                 do {
                     try await Task.sleep(nanoseconds: 16_666_667)
@@ -128,9 +182,6 @@ private struct TeleprompterScrollPreview: View {
                 scrollOffset = nextOffset >= maximumOffset ? 0 : nextOffset
             }
         }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Teleprompter scroll speed preview")
-        .accessibilityValue("Scrolling at \(Int(scrollSpeed)) points per second")
     }
 }
 
@@ -138,6 +189,9 @@ private struct PreviewConfiguration: Hashable {
     let transcript: String
     let scrollSpeed: Double
     let contentHeight: CGFloat
+    let isPreviewing: Bool
+    let fontSize: CGFloat
+    let viewportHeight: CGFloat
 }
 
 private struct PreviewContentHeightKey: PreferenceKey {

--- a/mac/TinyClips/Views/TeleprompterPanel.swift
+++ b/mac/TinyClips/Views/TeleprompterPanel.swift
@@ -2,19 +2,25 @@ import AppKit
 import SwiftUI
 
 final class TeleprompterPanel: NSPanel {
-    static let panelSize = NSSize(width: 600, height: 140)
-
     private static let positionXKey = "teleprompterPanelX"
     private static let positionYKey = "teleprompterPanelY"
 
     private var didPersistPosition = false
     private let scrollState: TeleprompterScrollState
+    private let panelSize: NSSize
 
-    init(transcript: String, scrollSpeed: Double) {
+    init(
+        transcript: String,
+        scrollSpeed: Double,
+        fontSize: TeleprompterDisplaySize,
+        panelHeight: TeleprompterDisplaySize
+    ) {
+        let panelSize = NSSize(width: 600, height: panelHeight.panelHeight)
         let scrollState = TeleprompterScrollState(scrollSpeed: scrollSpeed)
+        self.panelSize = panelSize
         self.scrollState = scrollState
         super.init(
-            contentRect: NSRect(origin: .zero, size: Self.panelSize),
+            contentRect: NSRect(origin: .zero, size: panelSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -28,7 +34,14 @@ final class TeleprompterPanel: NSPanel {
         sharingType = .none
         isMovableByWindowBackground = true
 
-        let hostingView = NSHostingView(rootView: TeleprompterView(state: scrollState, transcript: transcript))
+        let hostingView = NSHostingView(
+            rootView: TeleprompterView(
+                state: scrollState,
+                transcript: transcript,
+                panelSize: panelSize,
+                fontSize: fontSize.fontSize
+            )
+        )
         hostingView.setAccessibilityElement(true)
         hostingView.setAccessibilityRole(.staticText)
         hostingView.setAccessibilityLabel("Teleprompter")
@@ -76,8 +89,8 @@ final class TeleprompterPanel: NSPanel {
         guard let screen = Self.screen(for: region) ?? NSScreen.main else { return }
         let frame = screen.frame
         setFrameOrigin(NSPoint(
-            x: frame.midX - Self.panelSize.width / 2,
-            y: frame.maxY - Self.panelSize.height - 120
+            x: frame.midX - panelSize.width / 2,
+            y: frame.maxY - panelSize.height - 120
         ))
     }
 
@@ -121,7 +134,7 @@ private final class TeleprompterScrollState: ObservableObject {
     private var isPaused = true
 
     init(scrollSpeed: Double) {
-        self.scrollSpeed = scrollSpeed
+        self.scrollSpeed = min(max(scrollSpeed, 0), 100)
     }
 
     func start(viewportHeight: CGFloat) {
@@ -148,7 +161,7 @@ private final class TeleprompterScrollState: ObservableObject {
     }
 
     private func startTimer() {
-        guard timer == nil, let viewportHeight else { return }
+        guard timer == nil, scrollSpeed > 0, let viewportHeight else { return }
         let maxOffset = max(0, contentHeight - viewportHeight)
         guard scrollOffset < maxOffset else { return }
         let interval: TimeInterval = 1.0 / 60.0
@@ -178,13 +191,17 @@ private final class TeleprompterScrollState: ObservableObject {
 private struct TeleprompterView: View {
     @ObservedObject var state: TeleprompterScrollState
     let transcript: String
+    let panelSize: NSSize
+    let fontSize: CGFloat
 
-    private let viewportHeight: CGFloat = TeleprompterPanel.panelSize.height - 24
+    private var viewportHeight: CGFloat {
+        panelSize.height - 24
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             Text(transcript)
-                .font(.system(size: 24, weight: .medium))
+                .font(.system(size: fontSize, weight: .medium))
                 .foregroundStyle(.white)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -196,10 +213,10 @@ private struct TeleprompterView: View {
                     }
                 }
         }
-        .frame(width: TeleprompterPanel.panelSize.width, alignment: .top)
+        .frame(width: panelSize.width, alignment: .top)
         .fixedSize(horizontal: false, vertical: true)
         .offset(y: -state.scrollOffset)
-        .frame(width: TeleprompterPanel.panelSize.width, height: viewportHeight, alignment: .top)
+        .frame(width: panelSize.width, height: viewportHeight, alignment: .top)
         .clipped()
         .background {
             RoundedRectangle(cornerRadius: 12)


### PR DESCRIPTION
The teleprompter preview started scrolling immediately and its speed control was difficult to adjust precisely. This makes its behavior explicit and gives users better control over the reading layout.

- Add Start Preview and Stop Preview controls, retaining the preview at rest until started.
- Change scroll speed to 0-100 pt/s in 1 pt/s increments and enlarge its interaction target.
- Add persistent small, medium, and large presets for both text size and panel height, applied to the preview and recording overlay.
- Clamp legacy out-of-range speed values and treat zero as a stationary overlay.