### PR TITLE
Fix teleprompter preview consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed the macOS teleprompter preview viewport height and VoiceOver scrolling-status announcement.
 - Fixed the macOS and Windows settings sidebars to keep Video and Teleprompter as separate entries, cleaned up the Support label wording, and prevented the screenshot editor’s Horizontal/Vertical alignment labels from being clipped when the window is narrow.
 - Fixed macOS capture actions staying disabled after canceling a capture picker, target selection, or recording setup, and after a pre-capture countdown completes.
 - Fixed macOS recordings that capture no frames leaving zero-byte MP4 artifacts.

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -197,6 +197,10 @@ enum TeleprompterDisplaySize: String, CaseIterable {
         case .large: return 220
         }
     }
+
+    var viewportHeight: CGFloat {
+        panelHeight - 24
+    }
 }
 
 // MARK: - Settings

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -82,7 +82,7 @@ struct TeleprompterSettingsSection: View {
                 transcript: settings.teleprompterTranscript,
                 scrollSpeed: settings.teleprompterScrollSpeed,
                 fontSize: fontSize.fontSize,
-                viewportHeight: panelHeight.panelHeight
+                viewportHeight: panelHeight.viewportHeight
             )
             Text("This preview uses the same size, height, and scroll speed as the recording overlay.")
                 .font(.caption)
@@ -122,6 +122,10 @@ private struct TeleprompterScrollPreview: View {
         )
     }
 
+    private var isScrolling: Bool {
+        isPreviewing && scrollSpeed > 0 && contentHeight > viewportHeight
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             GeometryReader { proxy in
@@ -155,7 +159,11 @@ private struct TeleprompterScrollPreview: View {
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("Teleprompter scroll speed preview")
-            .accessibilityValue("Scrolling at \(Int(scrollSpeed)) points per second")
+            .accessibilityValue(
+                isScrolling
+                    ? "Scrolling at \(Int(scrollSpeed)) points per second"
+                    : "Stopped"
+            )
 
             Button(isPreviewing ? "Stop Preview" : "Start Preview") {
                 isPreviewing.toggle()

--- a/mac/TinyClips/Views/TeleprompterPanel.swift
+++ b/mac/TinyClips/Views/TeleprompterPanel.swift
@@ -39,6 +39,7 @@ final class TeleprompterPanel: NSPanel {
                 state: scrollState,
                 transcript: transcript,
                 panelSize: panelSize,
+                viewportHeight: panelHeight.viewportHeight,
                 fontSize: fontSize.fontSize
             )
         )
@@ -192,11 +193,8 @@ private struct TeleprompterView: View {
     @ObservedObject var state: TeleprompterScrollState
     let transcript: String
     let panelSize: NSSize
+    let viewportHeight: CGFloat
     let fontSize: CGFloat
-
-    private var viewportHeight: CGFloat {
-        panelSize.height - 24
-    }
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
The teleprompter preview claimed to match the recording overlay but used a taller viewport, and VoiceOver could announce scrolling while the preview was stationary.

- Centralize the overlay's effective viewport height and use it for both the preview and recording panel.
- Report the preview as stopped to VoiceOver until it is actively scrolling at a positive speed.