### PR TITLE
Persist default save folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
+- macOS now persists the concrete per-type capture folder defaults, so custom-folder settings are populated with Pictures/TinyClips or Movies/TinyClips before a folder is selected.
 - macOS capture folders now default to Pictures/TinyClips for screenshots and Movies/TinyClips for videos and GIFs. Turning off "Use default folders" reveals separate folders for screenshots, videos, and GIFs.
 - macOS teleprompter preview now starts only on demand, with a Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, and small/medium/large text-size and panel-height presets.
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -250,20 +250,20 @@ class CaptureSettings: ObservableObject {
     static let shared = CaptureSettings()
 
     @AppStorage("saveDirectory") var saveDirectory: String = NSHomeDirectory() + "/Desktop"
-    @AppStorage("screenshotSaveDirectory") var screenshotSaveDirectory: String = ""
-    @AppStorage("videoSaveDirectory") var videoSaveDirectory: String = ""
-    @AppStorage("gifSaveDirectory") var gifSaveDirectory: String = ""
+    @AppStorage("screenshotSaveDirectory") var screenshotSaveDirectory: String = defaultSaveDirectoryURL(for: .screenshot).path
+    @AppStorage("videoSaveDirectory") var videoSaveDirectory: String = defaultSaveDirectoryURL(for: .video).path
+    @AppStorage("gifSaveDirectory") var gifSaveDirectory: String = defaultSaveDirectoryURL(for: .gif).path
     @AppStorage("videoGifSaveDirectory") var videoGifSaveDirectory: String = ""
     @AppStorage("useDefaultSaveDirectories") var useDefaultSaveDirectories: Bool = true
 #if APPSTORE
     @AppStorage("saveDirectoryBookmark") var saveDirectoryBookmark: Data = Data()
     @AppStorage("saveDirectoryDisplayPath") var saveDirectoryDisplayPath: String = ""
     @AppStorage("screenshotSaveDirectoryBookmark") var screenshotSaveDirectoryBookmark: Data = Data()
-    @AppStorage("screenshotSaveDirectoryDisplayPath") var screenshotSaveDirectoryDisplayPath: String = ""
+    @AppStorage("screenshotSaveDirectoryDisplayPath") var screenshotSaveDirectoryDisplayPath: String = defaultSaveDirectoryURL(for: .screenshot).path
     @AppStorage("videoSaveDirectoryBookmark") var videoSaveDirectoryBookmark: Data = Data()
-    @AppStorage("videoSaveDirectoryDisplayPath") var videoSaveDirectoryDisplayPath: String = ""
+    @AppStorage("videoSaveDirectoryDisplayPath") var videoSaveDirectoryDisplayPath: String = defaultSaveDirectoryURL(for: .video).path
     @AppStorage("gifSaveDirectoryBookmark") var gifSaveDirectoryBookmark: Data = Data()
-    @AppStorage("gifSaveDirectoryDisplayPath") var gifSaveDirectoryDisplayPath: String = ""
+    @AppStorage("gifSaveDirectoryDisplayPath") var gifSaveDirectoryDisplayPath: String = defaultSaveDirectoryURL(for: .gif).path
     @AppStorage("videoGifSaveDirectoryBookmark") var videoGifSaveDirectoryBookmark: Data = Data()
     @AppStorage("videoGifSaveDirectoryDisplayPath") var videoGifSaveDirectoryDisplayPath: String = ""
 #endif
@@ -404,6 +404,15 @@ class CaptureSettings: ObservableObject {
 
     func resolvedSaveDirectory(for captureType: CaptureType) -> URL {
         URL(fileURLWithPath: saveDirectoryPath(for: captureType), isDirectory: true)
+    }
+
+    static func defaultSaveDirectoryURL(for captureType: CaptureType) -> URL {
+        let fallbackBase = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        let searchPath: FileManager.SearchPathDirectory = captureType == .screenshot
+            ? .picturesDirectory
+            : .moviesDirectory
+        let baseURL = FileManager.default.urls(for: searchPath, in: .userDomainMask).first ?? fallbackBase
+        return baseURL.appendingPathComponent("TinyClips", isDirectory: true)
     }
 
     func saveDirectoryPath(for captureType: CaptureType) -> String {
@@ -693,6 +702,14 @@ class CaptureSettings: ObservableObject {
         for key in keys + (preservingHotKeys ? [] : hotKeyKeys) + masKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
+        screenshotSaveDirectory = Self.defaultSaveDirectoryURL(for: .screenshot).path
+        videoSaveDirectory = Self.defaultSaveDirectoryURL(for: .video).path
+        gifSaveDirectory = Self.defaultSaveDirectoryURL(for: .gif).path
+#if APPSTORE
+        screenshotSaveDirectoryDisplayPath = Self.defaultSaveDirectoryURL(for: .screenshot).path
+        videoSaveDirectoryDisplayPath = Self.defaultSaveDirectoryURL(for: .video).path
+        gifSaveDirectoryDisplayPath = Self.defaultSaveDirectoryURL(for: .gif).path
+#endif
 #if APPSTORE
         SaveService.shared.invalidateAllSaveDirectoryBookmarks()
 #endif
@@ -706,6 +723,7 @@ class CaptureSettings: ObservableObject {
     private init() {
         let defaults = UserDefaults.standard
         migrateSaveDirectorySettings(defaults)
+        ensureSaveDirectoryDefaults(defaults)
 
         guard defaults.object(forKey: "multiMonitorCaptureMode") == nil else { return }
 
@@ -720,8 +738,9 @@ class CaptureSettings: ObservableObject {
 
         let legacySharedDirectory = defaults.string(forKey: "saveDirectory") ?? ""
         let legacyVideoGifDirectory = defaults.string(forKey: "videoGifSaveDirectory") ?? ""
+        let legacyScreenshotDirectory = defaults.string(forKey: "screenshotSaveDirectory") ?? ""
         let hasCustomDirectory = !legacySharedDirectory.isEmpty ||
-            !screenshotSaveDirectory.isEmpty ||
+            !legacyScreenshotDirectory.isEmpty ||
             !legacyVideoGifDirectory.isEmpty
 #if APPSTORE
         let hasCustomBookmark = !saveDirectoryBookmark.isEmpty ||
@@ -734,8 +753,10 @@ class CaptureSettings: ObservableObject {
         guard hasCustomDirectory || hasCustomBookmark else { return }
 
         useDefaultSaveDirectories = false
-        if screenshotSaveDirectory.isEmpty {
+        if legacyScreenshotDirectory.isEmpty {
             screenshotSaveDirectory = legacySharedDirectory
+        } else {
+            screenshotSaveDirectory = legacyScreenshotDirectory
         }
         videoSaveDirectory = legacyVideoGifDirectory.isEmpty ? legacySharedDirectory : legacyVideoGifDirectory
         gifSaveDirectory = legacyVideoGifDirectory.isEmpty ? legacySharedDirectory : legacyVideoGifDirectory
@@ -751,6 +772,30 @@ class CaptureSettings: ObservableObject {
         videoSaveDirectoryDisplayPath = videoGifDisplayPath
         gifSaveDirectoryBookmark = videoGifBookmark
         gifSaveDirectoryDisplayPath = videoGifDisplayPath
+#endif
+    }
+
+    private func ensureSaveDirectoryDefaults(_ defaults: UserDefaults) {
+        let paths: [(String, URL)] = [
+            ("screenshotSaveDirectory", Self.defaultSaveDirectoryURL(for: .screenshot)),
+            ("videoSaveDirectory", Self.defaultSaveDirectoryURL(for: .video)),
+            ("gifSaveDirectory", Self.defaultSaveDirectoryURL(for: .gif))
+        ]
+
+        for (key, url) in paths where (defaults.string(forKey: key) ?? "").isEmpty {
+            defaults.set(url.path, forKey: key)
+        }
+
+#if APPSTORE
+        let displayPaths: [(String, URL)] = [
+            ("screenshotSaveDirectoryDisplayPath", Self.defaultSaveDirectoryURL(for: .screenshot)),
+            ("videoSaveDirectoryDisplayPath", Self.defaultSaveDirectoryURL(for: .video)),
+            ("gifSaveDirectoryDisplayPath", Self.defaultSaveDirectoryURL(for: .gif))
+        ]
+
+        for (key, url) in displayPaths where (defaults.string(forKey: key) ?? "").isEmpty {
+            defaults.set(url.path, forKey: key)
+        }
 #endif
     }
 }

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -310,17 +310,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     private func defaultDirectoryURL(for type: CaptureType) -> URL {
-        let fallbackBase = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
-        let baseURL: URL
-
-        switch type {
-        case .video, .gif:
-            baseURL = FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask).first ?? fallbackBase
-        case .screenshot:
-            baseURL = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first ?? fallbackBase
-        }
-
-        return baseURL.appendingPathComponent("TinyClips", isDirectory: true)
+        CaptureSettings.defaultSaveDirectoryURL(for: type)
     }
 
 #if APPSTORE

--- a/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/GeneralSettingsSection.swift
@@ -155,9 +155,7 @@ struct GeneralSettingsSection: View {
     }
 
     private func saveDirectoryHint(for type: CaptureType) -> String {
-        settings.hasCustomSaveDirectory(for: type)
-            ? "Custom folder"
-            : "Choose a folder for this capture type."
+        "Saved captures of this type use this folder."
     }
 
     @ViewBuilder

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,7 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Persisted default capture folders** — Tiny Clips now saves concrete Pictures/TinyClips and Videos/TinyClips values for every capture type, including existing settings and reset settings.
 - **Independent capture folders** — Settings → General now uses Pictures/TinyClips for screenshots and Videos/TinyClips for videos and GIFs by default. Turn off **Use defaults** to choose separate folders for screenshots, videos, and GIFs.
 - **Teleprompter transcript overlay** — Settings → Video → Teleprompter lets you paste a script, enable the teleprompter, tune the scroll speed (10–200 DIPs/s), and preview that speed live. During video recordings a small semi-transparent black overlay auto-scrolls the transcript on screen. The overlay appears only after recording starts, pauses and resumes with recording, fails closed if Windows cannot exclude it from capture, and remembers a monitor-relative position across mixed-DPI display changes.
 

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -28,20 +28,34 @@ public sealed class CaptureSettings : ICaptureSettings
 
     public string ScreenshotSaveDirectory
     {
-        get => _settings.Get("screenshotSaveDirectory", string.Empty);
+        get => _settings.Get("screenshotSaveDirectory", DefaultSaveDirectory(CaptureType.Screenshot));
         set => _settings.Set("screenshotSaveDirectory", value);
     }
 
     public string VideoSaveDirectory
     {
-        get => _settings.Get("videoSaveDirectory", string.Empty);
+        get => _settings.Get("videoSaveDirectory", DefaultSaveDirectory(CaptureType.Video));
         set => _settings.Set("videoSaveDirectory", value);
     }
 
     public string GifSaveDirectory
     {
-        get => _settings.Get("gifSaveDirectory", string.Empty);
+        get => _settings.Get("gifSaveDirectory", DefaultSaveDirectory(CaptureType.Gif));
         set => _settings.Set("gifSaveDirectory", value);
+    }
+
+    public static string DefaultSaveDirectory(CaptureType type)
+    {
+        var folder = type == CaptureType.Screenshot
+            ? Environment.GetFolderPath(Environment.SpecialFolder.MyPictures)
+            : Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            folder = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+        }
+
+        return Path.Combine(folder, "TinyClips");
     }
 
     public AppTheme Theme
@@ -631,9 +645,9 @@ public sealed class CaptureSettings : ICaptureSettings
     {
         SaveDirectory = string.Empty;
         UseDefaultSaveDirectories = true;
-        ScreenshotSaveDirectory = string.Empty;
-        VideoSaveDirectory = string.Empty;
-        GifSaveDirectory = string.Empty;
+        ScreenshotSaveDirectory = DefaultSaveDirectory(CaptureType.Screenshot);
+        VideoSaveDirectory = DefaultSaveDirectory(CaptureType.Video);
+        GifSaveDirectory = DefaultSaveDirectory(CaptureType.Gif);
         Theme = AppTheme.Default;
         CopyScreenshotToClipboard = true;
         CopyVideoToClipboard = false;
@@ -718,6 +732,7 @@ public sealed class CaptureSettings : ICaptureSettings
     {
         if (_settings.Get("saveDirectoryFoldersMigrated", false))
         {
+            EnsureSaveDirectoryDefaults();
             return;
         }
 
@@ -730,7 +745,26 @@ public sealed class CaptureSettings : ICaptureSettings
             GifSaveDirectory = legacyDirectory;
         }
 
+        EnsureSaveDirectoryDefaults();
         _settings.Set("saveDirectoryFoldersMigrated", true);
+    }
+
+    private void EnsureSaveDirectoryDefaults()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.Get("screenshotSaveDirectory", string.Empty)))
+        {
+            ScreenshotSaveDirectory = DefaultSaveDirectory(CaptureType.Screenshot);
+        }
+
+        if (string.IsNullOrWhiteSpace(_settings.Get("videoSaveDirectory", string.Empty)))
+        {
+            VideoSaveDirectory = DefaultSaveDirectory(CaptureType.Video);
+        }
+
+        if (string.IsNullOrWhiteSpace(_settings.Get("gifSaveDirectory", string.Empty)))
+        {
+            GifSaveDirectory = DefaultSaveDirectory(CaptureType.Gif);
+        }
     }
 
     private static WebcamShape ParseWebcamShape(string value) =>        (value ?? string.Empty).ToLowerInvariant() switch

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -55,6 +55,21 @@ public sealed class CaptureSettings : ICaptureSettings
             folder = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
         }
 
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        }
+
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            folder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            folder = AppContext.BaseDirectory;
+        }
+
         return Path.Combine(folder, "TinyClips");
     }
 

--- a/windows/src/TinyClips.Core/Services/ClipStorageService.cs
+++ b/windows/src/TinyClips.Core/Services/ClipStorageService.cs
@@ -45,7 +45,9 @@ public sealed class ClipStorageService : IClipStorageService
             folder = _fileSystem.GetFolderPath(Environment.SpecialFolder.MyPictures);
         }
 
-        return Path.Combine(folder, "TinyClips");
+        return string.IsNullOrWhiteSpace(folder)
+            ? CaptureSettings.DefaultSaveDirectory(type)
+            : Path.Combine(folder, "TinyClips");
     }
 
     public string GenerateFilePath(CaptureType type, string? fileExtension = null, string? stemSuffix = null)

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -12,9 +12,9 @@ public sealed class CaptureSettingsTests
 
         Assert.True(settings.CopyScreenshotToClipboard);
         Assert.True(settings.UseDefaultSaveDirectories);
-        Assert.Equal(string.Empty, settings.ScreenshotSaveDirectory);
-        Assert.Equal(string.Empty, settings.VideoSaveDirectory);
-        Assert.Equal(string.Empty, settings.GifSaveDirectory);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot), settings.ScreenshotSaveDirectory);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Video), settings.VideoSaveDirectory);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Gif), settings.GifSaveDirectory);
         Assert.Equal(10.0, settings.GifFrameRate);
         Assert.Equal(30, settings.VideoFrameRate);
         Assert.Equal(100, settings.ScreenshotScale);
@@ -31,6 +31,25 @@ public sealed class CaptureSettingsTests
         Assert.Equal(string.Empty, settings.UploadcarePublicKey);
         Assert.False(settings.UploadcareAutoUpload);
         Assert.False(settings.UploadcareCopyUrl);
+    }
+
+    [Fact]
+    public void SaveDirectoryDefaults_ArePersistedForExistingSettings()
+    {
+        var settingsService = new TestSettingsService();
+        settingsService.Set("saveDirectoryFoldersMigrated", true);
+
+        _ = new CaptureSettings(settingsService);
+
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot),
+            settingsService.Get("screenshotSaveDirectory", string.Empty));
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Video),
+            settingsService.Get("videoSaveDirectory", string.Empty));
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Gif),
+            settingsService.Get("gifSaveDirectory", string.Empty));
     }
 
     [Fact]
@@ -61,6 +80,9 @@ public sealed class CaptureSettingsTests
         Assert.Equal(6, settings.VideoHotKeyModifiers);
         Assert.Equal(55, settings.GifHotKeyCode);
         Assert.Equal(6, settings.GifHotKeyModifiers);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot), settings.ScreenshotSaveDirectory);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Video), settings.VideoSaveDirectory);
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Gif), settings.GifSaveDirectory);
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Screenshot));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Video));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Gif));

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -8,13 +8,23 @@ public sealed class CaptureSettingsTests
     [Fact]
     public void Defaults_ReturnDocumentedValues()
     {
-        var settings = CreateSettings();
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
 
         Assert.True(settings.CopyScreenshotToClipboard);
         Assert.True(settings.UseDefaultSaveDirectories);
         Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot), settings.ScreenshotSaveDirectory);
         Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Video), settings.VideoSaveDirectory);
         Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Gif), settings.GifSaveDirectory);
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot),
+            settingsService.Get("screenshotSaveDirectory", string.Empty));
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Video),
+            settingsService.Get("videoSaveDirectory", string.Empty));
+        Assert.Equal(
+            CaptureSettings.DefaultSaveDirectory(CaptureType.Gif),
+            settingsService.Get("gifSaveDirectory", string.Empty));
         Assert.Equal(10.0, settings.GifFrameRate);
         Assert.Equal(30, settings.VideoFrameRate);
         Assert.Equal(100, settings.ScreenshotScale);

--- a/windows/tests/TinyClips.Core.Tests/ClipStorageServiceTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/ClipStorageServiceTests.cs
@@ -52,6 +52,18 @@ public sealed class ClipStorageServiceTests
     }
 
     [Fact]
+    public void OutputDirectory_UsesAbsoluteFallbackWhenUserFoldersAreUnavailable()
+    {
+        var settings = CreateSettings();
+        var service = CreateService(settings, new FakeFileSystem());
+
+        var directory = service.OutputDirectory(CaptureType.Screenshot);
+
+        Assert.Equal(CaptureSettings.DefaultSaveDirectory(CaptureType.Screenshot), directory);
+        Assert.True(Path.IsPathFullyQualified(directory));
+    }
+
+    [Fact]
     public void GenerateFilePath_UsesUniqueSuffixesAndStemSuffix()
     {
         var fakeFileSystem = new FakeFileSystem();


### PR DESCRIPTION
The per-type folder settings should always hold usable destinations instead of empty placeholders when the default toggle is disabled.

This follow-up persists each platform's concrete defaults for screenshots, videos, and GIFs during initialization, migration, and settings reset. The custom-folder UI therefore begins with populated folder values, while the default toggle retains its platform-specific behavior.

Windows regression coverage verifies defaults are persisted for both fresh and existing settings.