### PR TITLE
Harden teleprompter preview controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - macOS capture folders now default to Pictures/TinyClips for screenshots and Movies/TinyClips for videos and GIFs. Turning off "Use default folders" reveals separate folders for screenshots, videos, and GIFs.
-- macOS teleprompter preview now starts only on demand with a reliable Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, small/medium/large text-size and panel-height presets, and plain-text transcript file loading.
+- macOS teleprompter preview now starts only on demand with a reliable Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, small/medium/large text-size and panel-height presets, and plain-text transcript file loading up to 1 MB.
 - Updated macOS in-app Terms of Use links to open Apple's Standard EULA directly.
 - macOS capture settings now offer matching before/after picker controls for screenshots, video recordings, and GIF recordings.
 - macOS multi-monitor capture settings now let you choose to ask every time, capture the display under the cursor, or capture the main display.

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct TeleprompterSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
+    @State private var transcriptLoadGeneration = 0
 
     // Keeps the AppStorage-backed transcript small enough for UserDefaults.
     private static let maximumTranscriptByteCount = 1_000_000
@@ -115,18 +116,24 @@ struct TeleprompterSettingsSection: View {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
+        transcriptLoadGeneration += 1
+        let loadGeneration = transcriptLoadGeneration
+
         Task { @MainActor in
             do {
-                settings.teleprompterTranscript = try await Task.detached(priority: .userInitiated) {
+                let transcript = try await Task.detached(priority: .userInitiated) {
                     try Self.transcriptContents(from: url)
                 }.value
+                guard loadGeneration == transcriptLoadGeneration else { return }
+                settings.teleprompterTranscript = transcript
             } catch {
+                guard loadGeneration == transcriptLoadGeneration else { return }
                 NSAlert(error: error).runModal()
             }
         }
     }
 
-    private static func transcriptContents(from url: URL) throws -> String {
+    nonisolated private static func transcriptContents(from url: URL) throws -> String {
         let didAccessSecurityScopedResource = url.startAccessingSecurityScopedResource()
         defer {
             if didAccessSecurityScopedResource {
@@ -134,28 +141,25 @@ struct TeleprompterSettingsSection: View {
             }
         }
 
-        let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
-        guard let fileSize = resourceValues.fileSize else {
-            throw TranscriptLoadError.unavailableFileSize
-        }
-        guard fileSize <= maximumTranscriptByteCount else {
+        let fileHandle = try FileHandle(forReadingFrom: url)
+        defer { try? fileHandle.close() }
+
+        let data = try fileHandle.read(upToCount: maximumTranscriptByteCount + 1) ?? Data()
+        guard data.count <= maximumTranscriptByteCount else {
             throw TranscriptLoadError.fileTooLarge
         }
 
-        return try String(contentsOf: url)
+        return String(decoding: data, as: UTF8.self)
     }
 }
 
 private enum TranscriptLoadError: LocalizedError {
     case fileTooLarge
-    case unavailableFileSize
 
     var errorDescription: String? {
         switch self {
         case .fileTooLarge:
             "The selected transcript is larger than 1 MB."
-        case .unavailableFileSize:
-            "TinyClips could not determine the selected transcript's size."
         }
     }
 
@@ -163,8 +167,6 @@ private enum TranscriptLoadError: LocalizedError {
         switch self {
         case .fileTooLarge:
             "Choose a plain-text transcript file that is 1 MB or smaller."
-        case .unavailableFileSize:
-            "Choose a different plain-text transcript file."
         }
     }
 }

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -5,6 +5,9 @@ import UniformTypeIdentifiers
 struct TeleprompterSettingsSection: View {
     @ObservedObject var settings: CaptureSettings
 
+    // Keeps the AppStorage-backed transcript small enough for UserDefaults.
+    private static let maximumTranscriptByteCount = 1_000_000
+
     private var fontSize: TeleprompterDisplaySize {
         TeleprompterDisplaySize(rawValue: settings.teleprompterFontSize) ?? .medium
     }
@@ -108,10 +111,22 @@ struct TeleprompterSettingsSection: View {
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
         panel.title = "Load Teleprompter Transcript"
-        panel.message = "Choose a plain-text file to use as the transcript."
+        panel.message = "Choose a plain-text file up to 1 MB to use as the transcript."
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
+        Task { @MainActor in
+            do {
+                settings.teleprompterTranscript = try await Task.detached(priority: .userInitiated) {
+                    try Self.transcriptContents(from: url)
+                }.value
+            } catch {
+                NSAlert(error: error).runModal()
+            }
+        }
+    }
+
+    private static func transcriptContents(from url: URL) throws -> String {
         let didAccessSecurityScopedResource = url.startAccessingSecurityScopedResource()
         defer {
             if didAccessSecurityScopedResource {
@@ -119,10 +134,37 @@ struct TeleprompterSettingsSection: View {
             }
         }
 
-        do {
-            settings.teleprompterTranscript = try String(contentsOf: url)
-        } catch {
-            NSAlert(error: error).runModal()
+        let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
+        guard let fileSize = resourceValues.fileSize else {
+            throw TranscriptLoadError.unavailableFileSize
+        }
+        guard fileSize <= maximumTranscriptByteCount else {
+            throw TranscriptLoadError.fileTooLarge
+        }
+
+        return try String(contentsOf: url)
+    }
+}
+
+private enum TranscriptLoadError: LocalizedError {
+    case fileTooLarge
+    case unavailableFileSize
+
+    var errorDescription: String? {
+        switch self {
+        case .fileTooLarge:
+            "The selected transcript is larger than 1 MB."
+        case .unavailableFileSize:
+            "TinyClips could not determine the selected transcript's size."
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .fileTooLarge:
+            "Choose a plain-text transcript file that is 1 MB or smaller."
+        case .unavailableFileSize:
+            "Choose a different plain-text transcript file."
         }
     }
 }
@@ -135,7 +177,8 @@ private struct TeleprompterScrollPreview: View {
 
     @State private var contentHeight: CGFloat = 0
     @State private var isPreviewing = false
-    @State private var previewStartedAt: Date?
+    @State private var previewOffset: CGFloat = 0
+    @State private var lastTimelineDate: Date?
 
     private var previewTranscript: String {
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -157,19 +200,33 @@ private struct TeleprompterScrollPreview: View {
         isPreviewing && canScroll
     }
 
-    private func scrollOffset(at date: Date) -> CGFloat {
-        guard isScrolling, let previewStartedAt else { return 0 }
-        let elapsed = max(0, date.timeIntervalSince(previewStartedAt))
-        return CGFloat(elapsed * scrollSpeed).truncatingRemainder(dividingBy: maximumOffset)
+    private var currentScrollOffset: CGFloat {
+        guard isPreviewing, maximumOffset > 0 else { return 0 }
+        return previewOffset.truncatingRemainder(dividingBy: maximumOffset)
+    }
+
+    private func advancePreview(to date: Date) {
+        guard isScrolling else {
+            lastTimelineDate = nil
+            return
+        }
+        defer { lastTimelineDate = date }
+
+        guard let lastTimelineDate else { return }
+        let elapsed = max(0, date.timeIntervalSince(lastTimelineDate))
+        previewOffset = (previewOffset + CGFloat(elapsed * scrollSpeed))
+            .truncatingRemainder(dividingBy: maximumOffset)
     }
 
     private func togglePreview() {
         if isPreviewing {
             isPreviewing = false
-            previewStartedAt = nil
+            previewOffset = 0
+            lastTimelineDate = nil
         } else {
             guard canScroll else { return }
-            previewStartedAt = .now
+            previewOffset = 0
+            lastTimelineDate = nil
             isPreviewing = true
         }
     }
@@ -194,7 +251,9 @@ private struct TeleprompterScrollPreview: View {
                         ? "Stops and resets the preview."
                         : canScroll
                             ? "Starts the preview from the beginning."
-                            : "Set a scroll speed above zero to start the preview."
+                            : scrollSpeed <= 0
+                                ? "Set a scroll speed above zero to start the preview."
+                                : "The transcript is too short to scroll at the selected panel height. Add more text or choose a smaller panel height."
                 )
             }
 
@@ -216,7 +275,7 @@ private struct TeleprompterScrollPreview: View {
                                 )
                             }
                         }
-                        .offset(y: -scrollOffset(at: context.date))
+                        .offset(y: -currentScrollOffset)
                 }
                 .frame(height: viewportHeight)
                 .clipped()
@@ -235,9 +294,17 @@ private struct TeleprompterScrollPreview: View {
                         ? "Scrolling at \(Int(scrollSpeed)) points per second"
                         : "Stopped"
                 )
+                .onChange(of: context.date) { _, date in
+                    advancePreview(to: date)
+                }
             }
         }
         .onPreferenceChange(PreviewContentHeightKey.self) { contentHeight = $0 }
+        .onChange(of: isScrolling) { _, isScrolling in
+            if !isScrolling {
+                lastTimelineDate = nil
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The prior playback and import additions needed safeguards for changing settings during playback and for loading user-provided transcript files. This follow-up makes those interactions stable, accessible, and safe for persisted settings.

- Accumulate preview movement between timeline ticks so speed changes preserve the current offset.
- Explain whether a disabled preview needs a positive speed or more transcript content.
- Limit imported plain-text transcripts to 1 MB, read files off the main actor, and surface targeted import errors.
- Document the transcript limit in the macOS changelog.