### PR TITLE
Fix macOS teleprompter preview interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed the macOS teleprompter settings preview blocking its Stop button and other controls while the transcript scrolls, and ensured scrolling stops when leaving Teleprompter settings.
 - Fixed the macOS teleprompter preview viewport height and VoiceOver scrolling-status announcement.
 - Fixed the macOS and Windows settings sidebars to keep Video and Teleprompter as separate entries, cleaned up the Support label wording, and prevented the screenshot editor’s Horizontal/Vertical alignment labels from being clipped when the window is narrow.
 - Fixed macOS capture actions staying disabled after canceling a capture picker, target selection, or recording setup, and after a pre-capture countdown completes.

--- a/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
+++ b/mac/TinyClips/Views/Settings/TeleprompterSettingsSection.swift
@@ -209,13 +209,17 @@ private struct TeleprompterScrollPreview: View {
 
     private func togglePreview() {
         if isPreviewing {
-            isPreviewing = false
-            previewStartedAt = nil
+            stopPreview()
         } else {
             guard canScroll else { return }
             previewStartedAt = .now
             isPreviewing = true
         }
+    }
+
+    private func stopPreview() {
+        isPreviewing = false
+        previewStartedAt = nil
     }
 
     var body: some View {
@@ -263,6 +267,7 @@ private struct TeleprompterScrollPreview: View {
                             }
                         }
                         .offset(y: -scrollOffset(at: context.date))
+                        .allowsHitTesting(false)
                 }
                 .frame(height: viewportHeight)
                 .clipped()
@@ -284,6 +289,7 @@ private struct TeleprompterScrollPreview: View {
             }
         }
         .onPreferenceChange(PreviewContentHeightKey.self) { contentHeight = $0 }
+        .onDisappear { stopPreview() }
     }
 }
 


### PR DESCRIPTION
The scrolling teleprompter preview could intercept pointer events outside its visible viewport, preventing users from stopping playback or interacting with other settings.

This change makes the scrolling transcript non-interactive while preserving the preview controls, and resets preview playback whenever the Teleprompter settings view disappears so it cannot continue after switching sections or closing Settings.

Validated both the TinyClips and TinyClipsMAS macOS schemes.