### PR TITLE
Add macOS unit tests for capture logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,13 +33,15 @@ Do not mix platform-specific implementation patterns:
 ### macOS (always validate both schemes for mac changes)
 
 ```bash
+xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug \
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configuration Debug \
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 ```
 
-- mac has no test target.
+- mac unit tests cover deterministic logic only; do not add permission, hardware, or UI dependencies.
 - If sandbox blocks `xcodebuild` (for example `Operation not permitted` or SwiftPM write errors), rerun unsandboxed.
 
 ### Windows (required for `windows/**` changes)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,16 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
 
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -project mac/${{ env.SCHEME }}.xcodeproj \
+            -scheme ${{ env.SCHEME }} \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
   no-macos-changes:
     name: Build skipped (no macOS changes)
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
+- Added deterministic macOS unit-test coverage for capture and Retina coordinate math, recording pause timelines, settings and hotkeys, save-file naming, and capture analytics.
 - Added a macOS teleprompter overlay for video recordings: configure it from the dedicated Settings → Video → Teleprompter screen, preview the selected scroll speed, and read from an auto-scrolling, draggable, never-captured panel with a remembered position.
 - Added macOS OCR region capture to recognize selected screen text and copy it to the clipboard.
 - Video recording controls now offer session-only microphone and system-audio mute buttons for sources that started with the recording.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClipsMAS -configur
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 ```
 
+### Running macOS unit tests
+
+The `TinyClipsTests` target covers deterministic capture math, settings, hotkey,
+filename, and analytics behavior without requiring capture permissions or hardware:
+
+```bash
+xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
 ### Permissions
 
 TinyClips requires **Screen Recording** permission at runtime. On first launch, macOS will prompt you to grant access in **System Settings → Privacy & Security → Screen Recording**.
@@ -153,8 +163,11 @@ Accessibility is treated as a release gate. When adding or changing UI:
    git checkout -b feature/short-description
    ```
 4. **Make your changes** following the code style guidelines below.
-5. **Build both schemes** to confirm nothing is broken:
+5. **Run unit tests and build both schemes** to confirm nothing is broken:
    ```bash
+   xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug \
+     CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
    xcodebuild build -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug \
      CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -122,7 +122,22 @@
 		B2000000000000000000002C /* MouseClicksSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000002F /* MouseClicksSettingsSection.swift */; };
 		B2000000000000000000002D /* SettingsViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000030 /* SettingsViewHelpers.swift */; };
 		B3EB92CF2F3FCA0B002723CD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B3EB92CE2F3FCA0B002723CD /* Sparkle */; };
+		B30000000000000000000001 /* CaptureMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000001 /* CaptureMathTests.swift */; };
+		B30000000000000000000002 /* HotKeyBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000002 /* HotKeyBindingTests.swift */; };
+		B30000000000000000000003 /* CaptureSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000003 /* CaptureSettingsTests.swift */; };
+		B30000000000000000000004 /* SaveServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000004 /* SaveServiceTests.swift */; };
+		B30000000000000000000005 /* CaptureAnalyticsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000005 /* CaptureAnalyticsStoreTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A31000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F10000000000000000000007 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E10000000000000000000001;
+			remoteInfo = TinyClips;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		A10000000000000000000001 /* TinyClipsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinyClipsApp.swift; sourceTree = "<group>"; };
@@ -188,6 +203,12 @@
 		A2000000000000000000000C /* Info-MAS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-MAS.plist"; sourceTree = "<group>"; };
 		A2000000000000000000000D /* TinyClipsMAS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TinyClipsMAS.entitlements; sourceTree = "<group>"; };
 		A2000000000000000000000E /* TinyClipsMAS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinyClipsMAS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A30000000000000000000001 /* CaptureMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMathTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000002 /* HotKeyBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyBindingTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000003 /* CaptureSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSettingsTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000004 /* SaveServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveServiceTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000005 /* CaptureAnalyticsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureAnalyticsStoreTests.swift; sourceTree = "<group>"; };
+		A30000000000000000000006 /* TinyClipsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinyClipsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +227,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D30000000000000000000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -213,6 +241,7 @@
 			isa = PBXGroup;
 			children = (
 				C10000000000000000000002 /* TinyClips */,
+				C30000000000000000000001 /* TinyClipsTests */,
 				C10000000000000000000007 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -330,8 +359,21 @@
 			children = (
 				A1000000000000000000000E /* TinyClips.app */,
 				A2000000000000000000000E /* TinyClipsMAS.app */,
+				A30000000000000000000006 /* TinyClipsTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C30000000000000000000001 /* TinyClipsTests */ = {
+			isa = PBXGroup;
+			children = (
+				A30000000000000000000001 /* CaptureMathTests.swift */,
+				A30000000000000000000002 /* HotKeyBindingTests.swift */,
+				A30000000000000000000003 /* CaptureSettingsTests.swift */,
+				A30000000000000000000004 /* SaveServiceTests.swift */,
+				A30000000000000000000005 /* CaptureAnalyticsStoreTests.swift */,
+			);
+			path = TinyClipsTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -371,6 +413,23 @@
 			productReference = A2000000000000000000000E /* TinyClipsMAS.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E30000000000000000000001 /* TinyClipsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F30000000000000000000003 /* Build configuration list for PBXNativeTarget "TinyClipsTests" */;
+			buildPhases = (
+				D30000000000000000000001 /* Sources */,
+				D30000000000000000000002 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A31000000000000000000002 /* PBXTargetDependency */,
+			);
+			name = TinyClipsTests;
+			productName = TinyClipsTests;
+			productReference = A30000000000000000000006 /* TinyClipsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -386,6 +445,10 @@
 					};
 					E20000000000000000000001 = {
 						CreatedOnToolsVersion = 15.0;
+					};
+					E30000000000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = E10000000000000000000001;
 					};
 				};
 			};
@@ -407,6 +470,7 @@
 			targets = (
 				E10000000000000000000001 /* TinyClips */,
 				E20000000000000000000001 /* TinyClipsMAS */,
+				E30000000000000000000001 /* TinyClipsTests */,
 			);
 		};
 /* End PBXProject section */
@@ -557,7 +621,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D30000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B30000000000000000000001 /* CaptureMathTests.swift in Sources */,
+				B30000000000000000000002 /* HotKeyBindingTests.swift in Sources */,
+				B30000000000000000000003 /* CaptureSettingsTests.swift in Sources */,
+				B30000000000000000000004 /* SaveServiceTests.swift in Sources */,
+				B30000000000000000000005 /* CaptureAnalyticsStoreTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A31000000000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E10000000000000000000001 /* TinyClips */;
+			targetProxy = A31000000000000000000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		F10000000000000000000001 /* Debug */ = {
@@ -791,6 +875,48 @@
 			};
 			name = Release;
 		};
+		F30000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tinyclips.app.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TinyClips.app/Contents/MacOS/TinyClips";
+			};
+			name = Debug;
+		};
+		F30000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tinyclips.app.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TinyClips.app/Contents/MacOS/TinyClips";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -817,6 +943,15 @@
 			buildConfigurations = (
 				F20000000000000000000003 /* Debug */,
 				F20000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F30000000000000000000003 /* Build configuration list for PBXNativeTarget "TinyClipsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F30000000000000000000001 /* Debug */,
+				F30000000000000000000002 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/mac/TinyClips.xcodeproj/xcshareddata/xcschemes/TinyClips.xcscheme
+++ b/mac/TinyClips.xcodeproj/xcshareddata/xcschemes/TinyClips.xcscheme
@@ -9,6 +9,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E30000000000000000000001"
+               BuildableName = "TinyClipsTests.xctest"
+               BlueprintName = "TinyClipsTests"
+               ReferencedContainer = "container:TinyClips.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -28,7 +42,28 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldAutocreateTestPlan = "NO">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E30000000000000000000001"
+               BuildableName = "TinyClipsTests.xctest"
+               BlueprintName = "TinyClipsTests"
+               ReferencedContainer = "container:TinyClips.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E10000000000000000000001"
+            BuildableName = "TinyClips.app"
+            BlueprintName = "TinyClips"
+            ReferencedContainer = "container:TinyClips.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/mac/TinyClips/Capture/MouseClickOverlayProcessor.swift
+++ b/mac/TinyClips/Capture/MouseClickOverlayProcessor.swift
@@ -294,17 +294,12 @@ enum MouseClickOverlayProcessor {
             return nil
         }
 
-        let localX = globalPoint.x - screen.frame.minX
-        let localY = screen.frame.maxY - globalPoint.y
-        let localPoint = CGPoint(x: localX, y: localY)
-
-        guard region.sourceRect.contains(localPoint) else {
-            return nil
-        }
-
-        let relativeX = (localX - region.sourceRect.minX) * region.scaleFactor
-        let relativeY = (localY - region.sourceRect.minY) * region.scaleFactor
-        return CGPoint(x: relativeX, y: relativeY)
+        return CaptureCoordinateMath.capturePoint(
+            for: globalPoint,
+            screenFrame: screen.frame,
+            sourceRect: region.sourceRect,
+            scaleFactor: region.scaleFactor
+        )
     }
 
     private static func screen(for displayID: CGDirectDisplayID) -> NSScreen? {

--- a/mac/TinyClips/Capture/ScreenshotCapture.swift
+++ b/mac/TinyClips/Capture/ScreenshotCapture.swift
@@ -28,11 +28,15 @@ enum CaptureCoordinateMath {
             primaryDisplayHeight: primaryDisplayHeight
         )
         return displays
-            .max {
-                $0.frame.intersection(appKitFrame).width <
-                    $1.frame.intersection(appKitFrame).width
-            }?
-            .scaleFactor ?? 1.0
+            .compactMap { display -> (geometry: CaptureDisplayGeometry, area: CGFloat)? in
+                let intersection = display.frame.intersection(appKitFrame)
+                guard !intersection.isNull, intersection.width > 0, intersection.height > 0 else {
+                    return nil
+                }
+                return (display, intersection.width * intersection.height)
+            }
+            .max { $0.area < $1.area }?
+            .geometry.scaleFactor ?? 1.0
     }
 
     static func capturePoint(

--- a/mac/TinyClips/Capture/ScreenshotCapture.swift
+++ b/mac/TinyClips/Capture/ScreenshotCapture.swift
@@ -3,6 +3,59 @@ import ImageIO
 import UniformTypeIdentifiers
 import AppKit
 
+struct CaptureDisplayGeometry {
+    let frame: CGRect
+    let scaleFactor: CGFloat
+}
+
+enum CaptureCoordinateMath {
+    static func appKitFrame(for screenCaptureFrame: CGRect, primaryDisplayHeight: CGFloat) -> CGRect {
+        CGRect(
+            x: screenCaptureFrame.origin.x,
+            y: primaryDisplayHeight - screenCaptureFrame.maxY,
+            width: screenCaptureFrame.width,
+            height: screenCaptureFrame.height
+        )
+    }
+
+    static func scaleFactor(
+        forWindowFrame windowFrame: CGRect,
+        primaryDisplayHeight: CGFloat,
+        displays: [CaptureDisplayGeometry]
+    ) -> CGFloat {
+        let appKitFrame = appKitFrame(
+            for: windowFrame,
+            primaryDisplayHeight: primaryDisplayHeight
+        )
+        return displays
+            .max {
+                $0.frame.intersection(appKitFrame).width <
+                    $1.frame.intersection(appKitFrame).width
+            }?
+            .scaleFactor ?? 1.0
+    }
+
+    static func capturePoint(
+        for globalPoint: CGPoint,
+        screenFrame: CGRect,
+        sourceRect: CGRect,
+        scaleFactor: CGFloat
+    ) -> CGPoint? {
+        let localPoint = CGPoint(
+            x: globalPoint.x - screenFrame.minX,
+            y: screenFrame.maxY - globalPoint.y
+        )
+        guard sourceRect.contains(localPoint) else {
+            return nil
+        }
+
+        return CGPoint(
+            x: (localPoint.x - sourceRect.minX) * scaleFactor,
+            y: (localPoint.y - sourceRect.minY) * scaleFactor
+        )
+    }
+}
+
 struct ScreenshotCapture {
     static func capture(region: CaptureRegion) async throws -> URL {
         let destinationURL = SaveService.shared.generateURL(for: .screenshot)
@@ -77,16 +130,13 @@ struct ScreenshotCapture {
     /// Returns the backing scale factor of the screen that most overlaps the given SCWindow.
     private static func scaleFactorForWindow(_ window: SCWindow) -> CGFloat {
         let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
-        let appKitFrame = CGRect(
-            x: window.frame.origin.x,
-            y: primaryHeight - window.frame.maxY,
-            width: window.frame.width,
-            height: window.frame.height
+        let displays = NSScreen.screens.map {
+            CaptureDisplayGeometry(frame: $0.frame, scaleFactor: $0.backingScaleFactor)
+        }
+        return CaptureCoordinateMath.scaleFactor(
+            forWindowFrame: window.frame,
+            primaryDisplayHeight: primaryHeight,
+            displays: displays
         )
-        return NSScreen.screens
-            .max { a, b in
-                a.frame.intersection(appKitFrame).width < b.frame.intersection(appKitFrame).width
-            }?
-            .backingScaleFactor ?? 1.0
     }
 }

--- a/mac/TinyClips/Capture/VideoRecorder.swift
+++ b/mac/TinyClips/Capture/VideoRecorder.swift
@@ -4,6 +4,41 @@ import CoreMedia
 import CoreVideo
 import AudioToolbox
 
+enum RecordingTimelineMath {
+    static func accumulatedPauseDuration(
+        _ accumulated: CMTime,
+        pauseStartedAt: CMTime?,
+        resumedAt: CMTime
+    ) -> CMTime {
+        guard let pauseStartedAt else { return accumulated }
+        return CMTimeAdd(accumulated, CMTimeSubtract(resumedAt, pauseStartedAt))
+    }
+
+    static func timelineTime(
+        now: CMTime,
+        firstSampleTime: CMTime?,
+        totalPausedDuration: CMTime,
+        pauseStartedAt: CMTime?
+    ) -> CMTime {
+        guard let firstSampleTime else { return .zero }
+        let activePauseDuration = pauseStartedAt.map {
+            CMTimeSubtract(now, $0)
+        } ?? .zero
+        return CMTimeMaximum(
+            .zero,
+            CMTimeSubtract(
+                CMTimeSubtract(now, totalPausedDuration),
+                CMTimeAdd(firstSampleTime, activePauseDuration)
+            )
+        )
+    }
+
+    static func adjustedTimestamp(_ timestamp: CMTime, totalPausedDuration: CMTime) -> CMTime {
+        guard timestamp.isValid else { return timestamp }
+        return CMTimeSubtract(timestamp, totalPausedDuration)
+    }
+}
+
 private func isPositiveNumericTime(_ time: CMTime) -> Bool {
     time.isNumeric && CMTimeCompare(time, .zero) > 0
 }
@@ -302,7 +337,11 @@ final class WebcamRecorder: NSObject, @unchecked Sendable {
             guard self.isPaused else { return }
             if let pauseStartedAt = self.pauseStartedAt {
                 let now = CMClockGetTime(CMClockGetHostTimeClock())
-                self.totalPausedDuration = CMTimeAdd(self.totalPausedDuration, CMTimeSubtract(now, pauseStartedAt))
+                self.totalPausedDuration = RecordingTimelineMath.accumulatedPauseDuration(
+                    self.totalPausedDuration,
+                    pauseStartedAt: pauseStartedAt,
+                    resumedAt: now
+                )
             }
             self.pauseStartedAt = nil
             self.isPaused = false
@@ -404,10 +443,16 @@ extension WebcamRecorder: AVCaptureVideoDataOutputSampleBufferDelegate {
             return sampleBuffer
         }
         if timing.presentationTimeStamp.isValid {
-            timing.presentationTimeStamp = CMTimeSubtract(timing.presentationTimeStamp, totalPausedDuration)
+            timing.presentationTimeStamp = RecordingTimelineMath.adjustedTimestamp(
+                timing.presentationTimeStamp,
+                totalPausedDuration: totalPausedDuration
+            )
         }
         if timing.decodeTimeStamp.isValid {
-            timing.decodeTimeStamp = CMTimeSubtract(timing.decodeTimeStamp, totalPausedDuration)
+            timing.decodeTimeStamp = RecordingTimelineMath.adjustedTimestamp(
+                timing.decodeTimeStamp,
+                totalPausedDuration: totalPausedDuration
+            )
         }
         var adjusted: CMSampleBuffer?
         let status = CMSampleBufferCreateCopyWithNewTiming(
@@ -480,12 +525,12 @@ class VideoRecorder: NSObject, @unchecked Sendable {
 
     func currentTimelineTime() -> CMTime {
         writingQueue.sync {
-            guard let firstScreenSampleTime else { return .zero }
             let now = CMClockGetTime(CMClockGetHostTimeClock())
-            let activePauseDuration = pauseStartedAt.map { CMTimeSubtract(now, $0) } ?? .zero
-            return CMTimeMaximum(
-                .zero,
-                CMTimeSubtract(CMTimeSubtract(now, totalPausedDuration), CMTimeAdd(firstScreenSampleTime, activePauseDuration))
+            return RecordingTimelineMath.timelineTime(
+                now: now,
+                firstSampleTime: firstScreenSampleTime,
+                totalPausedDuration: totalPausedDuration,
+                pauseStartedAt: pauseStartedAt
             )
         }
     }
@@ -1023,7 +1068,11 @@ class VideoRecorder: NSObject, @unchecked Sendable {
             guard self.isPaused else { return }
             if let pauseStartedAt = self.pauseStartedAt {
                 let now = CMClockGetTime(CMClockGetHostTimeClock())
-                self.totalPausedDuration = CMTimeAdd(self.totalPausedDuration, CMTimeSubtract(now, pauseStartedAt))
+                self.totalPausedDuration = RecordingTimelineMath.accumulatedPauseDuration(
+                    self.totalPausedDuration,
+                    pauseStartedAt: pauseStartedAt,
+                    resumedAt: now
+                )
             }
             self.pauseStartedAt = nil
             self.isPaused = false
@@ -1209,10 +1258,16 @@ extension VideoRecorder: SCStreamOutput, SCStreamDelegate {
 
         for index in 0..<timingCount {
             if timing[index].presentationTimeStamp.isValid {
-                timing[index].presentationTimeStamp = CMTimeSubtract(timing[index].presentationTimeStamp, totalPausedDuration)
+                timing[index].presentationTimeStamp = RecordingTimelineMath.adjustedTimestamp(
+                    timing[index].presentationTimeStamp,
+                    totalPausedDuration: totalPausedDuration
+                )
             }
             if timing[index].decodeTimeStamp.isValid {
-                timing[index].decodeTimeStamp = CMTimeSubtract(timing[index].decodeTimeStamp, totalPausedDuration)
+                timing[index].decodeTimeStamp = RecordingTimelineMath.adjustedTimestamp(
+                    timing[index].decodeTimeStamp,
+                    totalPausedDuration: totalPausedDuration
+                )
             }
         }
 

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -205,6 +205,8 @@ class CaptureManager: ObservableObject {
     private var shouldIgnoreNextHotKeySettingsChange = false
 
     init() {
+        guard !TinyClipsRuntime.isRunningUnitTests else { return }
+
         configureGlobalHotKeys()
 
         // Re-register capture hotkeys whenever shortcut settings change.

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -252,6 +252,7 @@ extension NSColor {
 
 class CaptureSettings: ObservableObject {
     static let shared = CaptureSettings()
+    private let defaults: UserDefaults
 
     @AppStorage("saveDirectory") var saveDirectory: String = NSHomeDirectory() + "/Desktop"
     @AppStorage("screenshotSaveDirectory") var screenshotSaveDirectory: String = defaultSaveDirectoryURL(for: .screenshot).path
@@ -545,45 +546,12 @@ class CaptureSettings: ObservableObject {
     }
 
     func hotKeyBinding(for action: HotKeyAction) -> HotKeyBinding {
-        switch action {
-        case .screenshot:
-            return HotKeyBinding(
-                keyCode: screenshotHotKeyCode,
-                carbonModifiers: screenshotHotKeyModifiers
-            )
-        case .recordVideo:
-            return HotKeyBinding(
-                keyCode: videoHotKeyCode,
-                carbonModifiers: videoHotKeyModifiers
-            )
-        case .recordGif:
-            return HotKeyBinding(
-                keyCode: gifHotKeyCode,
-                carbonModifiers: gifHotKeyModifiers
-            )
-        case .copyTextFromRegion:
-            return HotKeyBinding(
-                keyCode: copyTextFromRegionHotKeyCode,
-                carbonModifiers: copyTextFromRegionHotKeyModifiers
-            )
-        }
+        Self.hotKeyBinding(for: action, defaults: defaults)
     }
 
     func setHotKeyBinding(_ binding: HotKeyBinding, for action: HotKeyAction) {
-        switch action {
-        case .screenshot:
-            screenshotHotKeyCode = binding.keyCode
-            screenshotHotKeyModifiers = binding.carbonModifiers
-        case .recordVideo:
-            videoHotKeyCode = binding.keyCode
-            videoHotKeyModifiers = binding.carbonModifiers
-        case .recordGif:
-            gifHotKeyCode = binding.keyCode
-            gifHotKeyModifiers = binding.carbonModifiers
-        case .copyTextFromRegion:
-            copyTextFromRegionHotKeyCode = binding.keyCode
-            copyTextFromRegionHotKeyModifiers = binding.carbonModifiers
-        }
+        Self.setHotKeyBinding(binding, for: action, defaults: defaults)
+        objectWillChange.send()
     }
 
     var hotKeyBindings: [HotKeyAction: HotKeyBinding] {
@@ -762,8 +730,10 @@ class CaptureSettings: ObservableObject {
         objectWillChange.send()
     }
 
-    private init() {
-        let defaults = UserDefaults.standard
+    init(defaults: UserDefaults = .standard, performMigrations: Bool = true) {
+        self.defaults = defaults
+        guard performMigrations else { return }
+
         migrateSaveDirectorySettings(defaults)
         ensureSaveDirectoryDefaults(defaults)
 

--- a/mac/TinyClips/Models/CaptureSettings.swift
+++ b/mac/TinyClips/Models/CaptureSettings.swift
@@ -491,8 +491,46 @@ class CaptureSettings: ObservableObject {
 #endif
 
     var imageFormat: ImageFormat {
-        get { ImageFormat(rawValue: screenshotFormat) ?? .jpeg }
+        get { Self.imageFormat(from: screenshotFormat) }
         set { screenshotFormat = newValue.rawValue }
+    }
+
+    static func imageFormat(from rawValue: String) -> ImageFormat {
+        ImageFormat(rawValue: rawValue) ?? .jpeg
+    }
+
+    static func hotKeyBinding(for action: HotKeyAction, defaults: UserDefaults) -> HotKeyBinding {
+        let fallback = HotKeyBinding.defaultBinding(for: action)
+        let keys = hotKeyDefaultsKeys(for: action)
+        return HotKeyBinding(
+            keyCode: defaults.object(forKey: keys.keyCode) as? Int ?? fallback.keyCode,
+            carbonModifiers: defaults.object(forKey: keys.modifiers) as? Int ?? fallback.carbonModifiers
+        )
+    }
+
+    static func setHotKeyBinding(
+        _ binding: HotKeyBinding,
+        for action: HotKeyAction,
+        defaults: UserDefaults
+    ) {
+        let keys = hotKeyDefaultsKeys(for: action)
+        defaults.set(binding.keyCode, forKey: keys.keyCode)
+        defaults.set(binding.carbonModifiers, forKey: keys.modifiers)
+    }
+
+    private static func hotKeyDefaultsKeys(
+        for action: HotKeyAction
+    ) -> (keyCode: String, modifiers: String) {
+        switch action {
+        case .screenshot:
+            return ("screenshotHotKeyCode", "screenshotHotKeyModifiers")
+        case .recordVideo:
+            return ("videoHotKeyCode", "videoHotKeyModifiers")
+        case .recordGif:
+            return ("gifHotKeyCode", "gifHotKeyModifiers")
+        case .copyTextFromRegion:
+            return ("copyTextFromRegionHotKeyCode", "copyTextFromRegionHotKeyModifiers")
+        }
     }
 
     func shouldCopyToClipboard(for type: CaptureType) -> Bool {

--- a/mac/TinyClips/Models/HotKeyBinding.swift
+++ b/mac/TinyClips/Models/HotKeyBinding.swift
@@ -131,6 +131,12 @@ struct HotKeyBinding: Equatable {
 
     /// Converts a Carbon/CGKeyCode to a display string using the current keyboard layout.
     static func keyCodeToDisplayString(_ code: Int) -> String? {
+        if let fallback = fallbackKeyCodeString(code) {
+            return fallback
+        }
+        guard let keyCode = UInt16(exactly: code) else {
+            return nil
+        }
         guard let rawSource = TISCopyCurrentKeyboardLayoutInputSource() else {
             return fallbackKeyCodeString(code)
         }
@@ -148,7 +154,7 @@ struct HotKeyBinding: Equatable {
             var length = 0
             let result = UCKeyTranslate(
                 layout,
-                UInt16(code),
+                keyCode,
                 UInt16(kUCKeyActionDisplay),
                 0,
                 UInt32(LMGetKbdType()),

--- a/mac/TinyClips/Services/CaptureAnalyticsStore.swift
+++ b/mac/TinyClips/Services/CaptureAnalyticsStore.swift
@@ -86,7 +86,7 @@ final class CaptureAnalyticsStore: ObservableObject {
         return formatter
     }()
 
-    private init(
+    init(
         userDefaults: UserDefaults = .standard,
         calendar: Calendar = .autoupdatingCurrent
     ) {

--- a/mac/TinyClips/Services/SaveService.swift
+++ b/mac/TinyClips/Services/SaveService.swift
@@ -218,14 +218,9 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         )
 
         var filename = generatedFileName(for: type, fileExtension: fileExtension)
-        if let stemSuffix,
-           !stemSuffix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let ext = (filename as NSString).pathExtension
-            let stem = (filename as NSString).deletingPathExtension
-            filename = ext.isEmpty ? "\(stem) \(stemSuffix)" : "\(stem) \(stemSuffix).\(ext)"
-        }
+        filename = Self.appendingStemSuffix(stemSuffix, to: filename)
 
-        return uniqueURL(in: directoryURL, filename: filename)
+        return Self.uniqueURL(in: directoryURL, filename: filename)
     }
 
     func outputDirectoryURL(for type: CaptureType) -> URL {
@@ -245,8 +240,21 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     func generatedFileName(for type: CaptureType, fileExtension: String, date: Date = Date()) -> String {
-        let settings = CaptureSettings.shared
-        let rawTemplate = settings.fileNameTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+        Self.generatedFileName(
+            for: type,
+            fileExtension: fileExtension,
+            template: CaptureSettings.shared.fileNameTemplate,
+            date: date
+        )
+    }
+
+    static func generatedFileName(
+        for type: CaptureType,
+        fileExtension: String,
+        template rawTemplate: String,
+        date: Date
+    ) -> String {
+        let rawTemplate = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
         let template = rawTemplate.isEmpty ? "TinyClips {date} at {time}" : rawTemplate
 
         var stem = template
@@ -264,17 +272,28 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         return cleanExtension.isEmpty ? stem : "\(stem).\(cleanExtension)"
     }
 
+    static func appendingStemSuffix(_ suffix: String?, to filename: String) -> String {
+        guard let suffix,
+              !suffix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return filename
+        }
+
+        let ext = (filename as NSString).pathExtension
+        let stem = (filename as NSString).deletingPathExtension
+        return ext.isEmpty ? "\(stem) \(suffix)" : "\(stem) \(suffix).\(ext)"
+    }
+
     func namingPreview(for type: CaptureType = .screenshot) -> String {
         generatedFileName(for: type, fileExtension: type.fileExtension)
     }
 
-    private func formatted(_ date: Date, format: String) -> String {
+    private static func formatted(_ date: Date, format: String) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
         return formatter.string(from: date)
     }
 
-    private func sanitizedFilenameStem(_ stem: String, fallbackDate: Date) -> String {
+    private static func sanitizedFilenameStem(_ stem: String, fallbackDate: Date) -> String {
         let invalidCharacters = CharacterSet(charactersIn: "/\\:?*\"<>|")
         var cleaned = stem
             .components(separatedBy: invalidCharacters)
@@ -289,7 +308,7 @@ class SaveService: NSObject, UNUserNotificationCenterDelegate {
         return cleaned
     }
 
-    private func uniqueURL(in directoryURL: URL, filename: String) -> URL {
+    static func uniqueURL(in directoryURL: URL, filename: String) -> URL {
         let initialURL = directoryURL.appendingPathComponent(filename)
         guard FileManager.default.fileExists(atPath: initialURL.path) else {
             return initialURL

--- a/mac/TinyClips/TinyClipsApp.swift
+++ b/mac/TinyClips/TinyClipsApp.swift
@@ -4,6 +4,12 @@ import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
 
+enum TinyClipsRuntime {
+    static var isRunningUnitTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+}
+
 final class TinyClipsAppDelegate: NSObject, NSApplicationDelegate {
     func application(_ application: NSApplication, open urls: [URL]) {
         ExternalImageOpenCoordinator.shared.handleOpen(urls: urls)
@@ -32,6 +38,11 @@ struct TinyClipsApp: App {
     @ObservedObject private var singleInstanceCoordinator = SingleInstanceCoordinator.shared
 
     init() {
+        if TinyClipsRuntime.isRunningUnitTests {
+            _captureManager = StateObject(wrappedValue: CaptureManager())
+            return
+        }
+
         switch SingleInstanceCoordinator.shared.acquire() {
         case .primary:
             _ = try? TinyClipsTemporaryFiles.removeStaleFiles(

--- a/mac/TinyClipsTests/CaptureAnalyticsStoreTests.swift
+++ b/mac/TinyClipsTests/CaptureAnalyticsStoreTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import TinyClips
+
+@MainActor
+final class CaptureAnalyticsStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var calendar: Calendar!
+
+    override func setUpWithError() throws {
+        suiteName = "TinyClipsTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        calendar = nil
+        suiteName = nil
+    }
+
+    func testAggregationAndPersistenceWithIsolatedDefaults() throws {
+        let store = CaptureAnalyticsStore(userDefaults: defaults, calendar: calendar)
+        let date = try XCTUnwrap(
+            calendar.date(from: DateComponents(
+                year: 2026,
+                month: 8,
+                day: 12,
+                hour: 14
+            ))
+        )
+
+        store.recordCapture(.screenshot, on: date)
+        store.recordCapture(.screenshot, on: date)
+        store.recordCapture(.video, on: date)
+
+        XCTAssertEqual(store.totalCount(for: .screenshot, days: 1, referenceDate: date), 2)
+        XCTAssertEqual(store.lifetimeTotal(for: .video), 1)
+        XCTAssertEqual(store.mostActiveHour()?.hour, 14)
+        XCTAssertEqual(store.mostActiveHour()?.count, 3)
+
+        let reloaded = CaptureAnalyticsStore(userDefaults: defaults, calendar: calendar)
+        XCTAssertEqual(reloaded.lifetimeTotal(for: .screenshot), 2)
+        XCTAssertEqual(reloaded.hourlyBreakdown()[14].count, 3)
+    }
+}

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -3,6 +3,10 @@ import XCTest
 @testable import TinyClips
 
 final class CaptureMathTests: XCTestCase {
+    func testHostedAppDetectsUnitTestRuntime() {
+        XCTAssertTrue(TinyClipsRuntime.isRunningUnitTests)
+    }
+
     func testCaptureRegionConvertsPointsToRetinaPixels() {
         let region = CaptureRegion(
             sourceRect: CGRect(x: 10, y: 20, width: 100.25, height: 50.75),
@@ -48,6 +52,42 @@ final class CaptureMathTests: XCTestCase {
             forWindowFrame: CGRect(x: 1300, y: 100, width: 500, height: 400),
             primaryDisplayHeight: 900,
             displays: displays
+        )
+
+        XCTAssertEqual(scale, 1)
+    }
+
+    func testWindowScaleUsesOverlapAreaForVerticallyStackedDisplays() {
+        let displays = [
+            CaptureDisplayGeometry(
+                frame: CGRect(x: 0, y: 0, width: 1000, height: 800),
+                scaleFactor: 2
+            ),
+            CaptureDisplayGeometry(
+                frame: CGRect(x: 0, y: 800, width: 1000, height: 800),
+                scaleFactor: 1
+            ),
+        ]
+
+        let scale = CaptureCoordinateMath.scaleFactor(
+            forWindowFrame: CGRect(x: 100, y: -500, width: 800, height: 600),
+            primaryDisplayHeight: 800,
+            displays: displays
+        )
+
+        XCTAssertEqual(scale, 1)
+    }
+
+    func testWindowScaleFallsBackWhenNoDisplayOverlaps() {
+        let scale = CaptureCoordinateMath.scaleFactor(
+            forWindowFrame: CGRect(x: 2000, y: 2000, width: 100, height: 100),
+            primaryDisplayHeight: 800,
+            displays: [
+                CaptureDisplayGeometry(
+                    frame: CGRect(x: 0, y: 0, width: 1000, height: 800),
+                    scaleFactor: 2
+                ),
+            ]
         )
 
         XCTAssertEqual(scale, 1)

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -1,0 +1,103 @@
+import CoreMedia
+import XCTest
+@testable import TinyClips
+
+final class CaptureMathTests: XCTestCase {
+    func testCaptureRegionConvertsPointsToRetinaPixels() {
+        let region = CaptureRegion(
+            sourceRect: CGRect(x: 10, y: 20, width: 100.25, height: 50.75),
+            displayID: 7,
+            scaleFactor: 2
+        )
+
+        XCTAssertEqual(region.pixelWidth, 201)
+        XCTAssertEqual(region.pixelHeight, 102)
+
+        let config = region.makeStreamConfig()
+        XCTAssertEqual(config.sourceRect, region.sourceRect)
+        XCTAssertEqual(config.width, 201)
+        XCTAssertEqual(config.height, 102)
+        XCTAssertTrue(config.scalesToFit)
+        XCTAssertTrue(config.showsCursor)
+    }
+
+    func testCaptureRegionClampsPixelDimensionsToOne() {
+        let region = CaptureRegion(
+            sourceRect: CGRect(x: 0, y: 0, width: 0, height: 0),
+            displayID: 1,
+            scaleFactor: 2
+        )
+
+        XCTAssertEqual(region.pixelWidth, 1)
+        XCTAssertEqual(region.pixelHeight, 1)
+    }
+
+    func testWindowFrameConversionChoosesMostOverlappingDisplayScale() {
+        let displays = [
+            CaptureDisplayGeometry(
+                frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+                scaleFactor: 2
+            ),
+            CaptureDisplayGeometry(
+                frame: CGRect(x: 1440, y: 0, width: 1920, height: 1080),
+                scaleFactor: 1
+            ),
+        ]
+
+        let scale = CaptureCoordinateMath.scaleFactor(
+            forWindowFrame: CGRect(x: 1300, y: 100, width: 500, height: 400),
+            primaryDisplayHeight: 900,
+            displays: displays
+        )
+
+        XCTAssertEqual(scale, 1)
+    }
+
+    func testMousePointMapsIntoCapturePixelsAndRejectsOutsidePoint() {
+        let screenFrame = CGRect(x: 100, y: 50, width: 800, height: 600)
+        let sourceRect = CGRect(x: 100, y: 50, width: 300, height: 200)
+
+        let mapped = CaptureCoordinateMath.capturePoint(
+            for: CGPoint(x: 250, y: 500),
+            screenFrame: screenFrame,
+            sourceRect: sourceRect,
+            scaleFactor: 2
+        )
+
+        XCTAssertEqual(mapped, CGPoint(x: 100, y: 200))
+        XCTAssertNil(
+            CaptureCoordinateMath.capturePoint(
+                for: CGPoint(x: 899, y: 649),
+                screenFrame: screenFrame,
+                sourceRect: sourceRect,
+                scaleFactor: 2
+            )
+        )
+    }
+
+    func testTimelineExcludesCompletedAndActivePauses() {
+        let timeline = RecordingTimelineMath.timelineTime(
+            now: CMTime(seconds: 20, preferredTimescale: 600),
+            firstSampleTime: CMTime(seconds: 5, preferredTimescale: 600),
+            totalPausedDuration: CMTime(seconds: 3, preferredTimescale: 600),
+            pauseStartedAt: CMTime(seconds: 18, preferredTimescale: 600)
+        )
+
+        XCTAssertEqual(timeline.seconds, 10, accuracy: 0.0001)
+    }
+
+    func testTimelinePauseAccumulationAndTimestampAdjustment() {
+        let accumulated = RecordingTimelineMath.accumulatedPauseDuration(
+            CMTime(seconds: 2, preferredTimescale: 600),
+            pauseStartedAt: CMTime(seconds: 10, preferredTimescale: 600),
+            resumedAt: CMTime(seconds: 14.5, preferredTimescale: 600)
+        )
+        let adjusted = RecordingTimelineMath.adjustedTimestamp(
+            CMTime(seconds: 20, preferredTimescale: 600),
+            totalPausedDuration: accumulated
+        )
+
+        XCTAssertEqual(accumulated.seconds, 6.5, accuracy: 0.0001)
+        XCTAssertEqual(adjusted.seconds, 13.5, accuracy: 0.0001)
+    }
+}

--- a/mac/TinyClipsTests/CaptureSettingsTests.swift
+++ b/mac/TinyClipsTests/CaptureSettingsTests.swift
@@ -24,9 +24,11 @@ final class CaptureSettingsTests: XCTestCase {
     }
 
     func testHotKeyDefaultsAndRoundTripUseIsolatedDefaults() {
+        let settings = CaptureSettings(defaults: defaults, performMigrations: false)
+
         for action in HotKeyAction.allCases {
             XCTAssertEqual(
-                CaptureSettings.hotKeyBinding(for: action, defaults: defaults),
+                settings.hotKeyBinding(for: action),
                 HotKeyBinding.defaultBinding(for: action)
             )
 
@@ -34,10 +36,10 @@ final class CaptureSettingsTests: XCTestCase {
                 keyCode: kVK_ANSI_A + Int(action.rawValue),
                 carbonModifiers: Int(cmdKey | shiftKey)
             )
-            CaptureSettings.setHotKeyBinding(custom, for: action, defaults: defaults)
+            settings.setHotKeyBinding(custom, for: action)
 
             XCTAssertEqual(
-                CaptureSettings.hotKeyBinding(for: action, defaults: defaults),
+                settings.hotKeyBinding(for: action),
                 custom
             )
         }

--- a/mac/TinyClipsTests/CaptureSettingsTests.swift
+++ b/mac/TinyClipsTests/CaptureSettingsTests.swift
@@ -1,0 +1,45 @@
+import Carbon.HIToolbox
+import XCTest
+@testable import TinyClips
+
+final class CaptureSettingsTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "TinyClipsTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+    }
+
+    func testImageFormatFallsBackToJpeg() {
+        XCTAssertEqual(CaptureSettings.imageFormat(from: "png"), .png)
+        XCTAssertEqual(CaptureSettings.imageFormat(from: "invalid"), .jpeg)
+    }
+
+    func testHotKeyDefaultsAndRoundTripUseIsolatedDefaults() {
+        for action in HotKeyAction.allCases {
+            XCTAssertEqual(
+                CaptureSettings.hotKeyBinding(for: action, defaults: defaults),
+                HotKeyBinding.defaultBinding(for: action)
+            )
+
+            let custom = HotKeyBinding(
+                keyCode: kVK_ANSI_A + Int(action.rawValue),
+                carbonModifiers: Int(cmdKey | shiftKey)
+            )
+            CaptureSettings.setHotKeyBinding(custom, for: action, defaults: defaults)
+
+            XCTAssertEqual(
+                CaptureSettings.hotKeyBinding(for: action, defaults: defaults),
+                custom
+            )
+        }
+    }
+}

--- a/mac/TinyClipsTests/HotKeyBindingTests.swift
+++ b/mac/TinyClipsTests/HotKeyBindingTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+import XCTest
+@testable import TinyClips
+
+final class HotKeyBindingTests: XCTestCase {
+    func testDefaultBindingsUseExpectedKeysAndModifiers() {
+        XCTAssertEqual(
+            HotKeyBinding.defaultBinding(for: .screenshot),
+            HotKeyBinding(keyCode: 23, carbonModifiers: HotKeyBinding.defaultCaptureModifiers)
+        )
+        XCTAssertEqual(
+            HotKeyBinding.defaultBinding(for: .copyTextFromRegion),
+            HotKeyBinding(keyCode: 28, carbonModifiers: HotKeyBinding.defaultCaptureModifiers)
+        )
+    }
+
+    func testCarbonAndSwiftUIModifierConversions() {
+        let carbon = HotKeyBinding.carbonModifiers(
+            from: [.command, .shift, .option, .control, .capsLock]
+        )
+        let binding = HotKeyBinding(keyCode: kVK_ANSI_5, carbonModifiers: carbon)
+
+        XCTAssertEqual(
+            carbon,
+            Int(cmdKey | shiftKey | optionKey | controlKey)
+        )
+        XCTAssertTrue(binding.swiftUIModifiers.contains(.command))
+        XCTAssertTrue(binding.swiftUIModifiers.contains(.shift))
+        XCTAssertTrue(binding.swiftUIModifiers.contains(.option))
+        XCTAssertTrue(binding.swiftUIModifiers.contains(.control))
+        XCTAssertEqual(binding.modifiersString, "⌃⌥⇧⌘")
+    }
+
+    func testValidationRejectsUnmodifiedReservedAndConflictingBindings() {
+        let unmodified = HotKeyBinding(keyCode: kVK_ANSI_A, carbonModifiers: 0)
+        XCTAssertNotNil(
+            HotKeyBinding.validationError(
+                for: unmodified,
+                action: .screenshot,
+                bindings: [:]
+            )
+        )
+
+        XCTAssertTrue(
+            HotKeyBinding.validationError(
+                for: .stopRecording,
+                action: .screenshot,
+                bindings: [:]
+            )?.contains("reserved") == true
+        )
+
+        let duplicate = HotKeyBinding.defaultBinding(for: .recordVideo)
+        XCTAssertTrue(
+            HotKeyBinding.validationError(
+                for: duplicate,
+                action: .screenshot,
+                bindings: [.recordVideo: duplicate]
+            )?.contains("Record Video") == true
+        )
+    }
+
+    func testSpecialAndUnknownKeyDisplayFallbacks() {
+        XCTAssertEqual(
+            HotKeyBinding(keyCode: kVK_F5, carbonModifiers: Int(cmdKey)).keyString,
+            "F5"
+        )
+        XCTAssertEqual(
+            HotKeyBinding(keyCode: Int.max, carbonModifiers: Int(cmdKey)).displayString,
+            "⌘?"
+        )
+    }
+}

--- a/mac/TinyClipsTests/SaveServiceTests.swift
+++ b/mac/TinyClipsTests/SaveServiceTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import TinyClips
+
+final class SaveServiceTests: XCTestCase {
+    private var directoryURL: URL!
+
+    override func setUpWithError() throws {
+        directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TinyClipsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let directoryURL {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        directoryURL = nil
+    }
+
+    func testFilenameTokensSanitizationAndExtensionNormalization() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let date = try XCTUnwrap(
+            calendar.date(from: DateComponents(
+                year: 2026,
+                month: 8,
+                day: 12,
+                hour: 9,
+                minute: 7,
+                second: 5
+            ))
+        )
+
+        let filename = SaveService.generatedFileName(
+            for: .video,
+            fileExtension: " .MP4 ",
+            template: "{app}: {type} / {datetime}",
+            date: date
+        )
+
+        XCTAssertEqual(filename, "TinyClips- Video - 2026-08-12_09.07.05.mp4")
+    }
+
+    func testEmptyTemplateAndStemFallBackToStableNames() {
+        let date = Date(timeIntervalSince1970: 0)
+        let defaultName = SaveService.generatedFileName(
+            for: .screenshot,
+            fileExtension: "png",
+            template: " ",
+            date: date
+        )
+        let sanitizedFallback = SaveService.generatedFileName(
+            for: .screenshot,
+            fileExtension: "",
+            template: ".",
+            date: date
+        )
+
+        XCTAssertTrue(defaultName.hasPrefix("TinyClips "))
+        XCTAssertTrue(defaultName.hasSuffix(".png"))
+        XCTAssertTrue(sanitizedFallback.hasPrefix("TinyClips "))
+    }
+
+    func testStemSuffixPreservesExtension() {
+        XCTAssertEqual(
+            SaveService.appendingStemSuffix("edited", to: "capture.png"),
+            "capture edited.png"
+        )
+        XCTAssertEqual(
+            SaveService.appendingStemSuffix("edited", to: "capture"),
+            "capture edited"
+        )
+        XCTAssertEqual(
+            SaveService.appendingStemSuffix(" ", to: "capture.png"),
+            "capture.png"
+        )
+    }
+
+    func testCollisionNumberingUsesNextAvailableSuffix() {
+        let original = directoryURL.appendingPathComponent("capture.png")
+        let second = directoryURL.appendingPathComponent("capture 2.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: original.path, contents: Data()))
+        XCTAssertTrue(FileManager.default.createFile(atPath: second.path, contents: Data()))
+
+        let unique = SaveService.uniqueURL(in: directoryURL, filename: "capture.png")
+
+        XCTAssertEqual(unique.lastPathComponent, "capture 3.png")
+    }
+}


### PR DESCRIPTION
## Summary

TinyClips had no macOS test target, leaving deterministic capture math, recording timelines, settings, and hotkey behavior vulnerable to silent regressions.

- Adds the `TinyClipsTests` XCTest target to the shared `TinyClips` scheme with 17 deterministic unit tests.
- Covers Retina and display coordinate math, capture dimensions, pause-adjusted timelines, hotkey validation and persistence, filename generation and collision handling, and analytics aggregation.
- Extracts small production helper seams so tests avoid live ScreenCaptureKit sessions, permissions, global hotkey registration, hardware, StoreKit, Sparkle, and UI automation.
- Runs the macOS test command in CI and documents it in contributor and agent guidance.

## Validation

- `xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Both `TinyClips` and `TinyClipsMAS` Debug schemes build without code signing.

Fixes: #223