### PR TITLE
Add macOS scrolling panorama capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Fixed macOS video and GIF recordings leaving capture controls active after ScreenCaptureKit unexpectedly stops a stream; recordings now save available partial frames and explain how to recover.
 
 ### Added
+- Added macOS vertical scrolling capture for selected regions, with bounded ScreenCaptureKit sampling, duplicate-frame rejection, automatic stitching, keyboard stop/cancel controls, and existing screenshot editor/save integration.
 - Added deterministic macOS unit-test coverage for capture and Retina coordinate math, recording pause timelines, settings and hotkeys, save-file naming, and capture analytics.
 - Added a macOS teleprompter overlay for video recordings: configure it from the dedicated Settings → Video → Teleprompter screen, preview the selected scroll speed, and read from an auto-scrolling, draggable, never-captured panel with a remembered position.
 - Added macOS OCR region capture to recognize selected screen text and copy it to the clipboard.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		B10000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B1000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
 		B1000000000000000000003B /* TextRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003B /* TextRecognitionService.swift */; };
+		B1000000000000000000003E /* ScrollingPanoramaCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003E /* ScrollingPanoramaCapture.swift */; };
+		B1000000000000000000003F /* ScrollingCapturePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003F /* ScrollingCapturePanel.swift */; };
 		B20000000000000000000001 /* TinyClipsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000001 /* TinyClipsApp.swift */; };
 		B20000000000000000000002 /* CaptureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* CaptureSettings.swift */; };
 		B20000000000000000000003 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* SettingsView.swift */; };
@@ -93,6 +95,8 @@
 		B20000000000000000000039 /* IdleSleepAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000039 /* IdleSleepAssertion.swift */; };
 		B2000000000000000000003A /* SingleInstanceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003A /* SingleInstanceCoordinator.swift */; };
 		B2000000000000000000003B /* TextRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003B /* TextRecognitionService.swift */; };
+		B2000000000000000000003E /* ScrollingPanoramaCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003E /* ScrollingPanoramaCapture.swift */; };
+		B2000000000000000000003F /* ScrollingCapturePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000003F /* ScrollingCapturePanel.swift */; };
 		B10000000000000000000021 /* CaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000024 /* CaptureManager.swift */; };
 		B10000000000000000000022 /* MenuBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000025 /* MenuBarViews.swift */; };
 		B10000000000000000000023 /* ProcessingIndicatorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000026 /* ProcessingIndicatorWindow.swift */; };
@@ -157,6 +161,8 @@
 		A1000000000000000000000F /* SparkleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleController.swift; sourceTree = "<group>"; };
 		A1000000000000000000003A /* SingleInstanceCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceCoordinator.swift; sourceTree = "<group>"; };
 		A1000000000000000000003B /* TextRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognitionService.swift; sourceTree = "<group>"; };
+		A1000000000000000000003E /* ScrollingPanoramaCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingPanoramaCapture.swift; sourceTree = "<group>"; };
+		A1000000000000000000003F /* ScrollingCapturePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingCapturePanel.swift; sourceTree = "<group>"; };
 		A10000000000000000000010 /* VideoTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrimmerWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000011 /* ScreenshotEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotEditorWindow.swift; sourceTree = "<group>"; };
 		A10000000000000000000012 /* GifTrimmerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GifTrimmerWindow.swift; sourceTree = "<group>"; };
@@ -300,6 +306,7 @@
 				A10000000000000000000022 /* ShortcutRecorderField.swift */,
 				A10000000000000000000025 /* MenuBarViews.swift */,
 				A10000000000000000000026 /* ProcessingIndicatorWindow.swift */,
+				A1000000000000000000003F /* ScrollingCapturePanel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -333,6 +340,7 @@
 				A10000000000000000000023 /* MouseClickOverlayProcessor.swift */,
 				A10000000000000000000031 /* BrandingOverlayProcessor.swift */,
 				A1000000000000000000001E /* WindowSelector.swift */,
+				A1000000000000000000003E /* ScrollingPanoramaCapture.swift */,
 			);
 			path = Capture;
 			sourceTree = "<group>";
@@ -555,6 +563,8 @@
 				B1000000000000000000002C /* MouseClicksSettingsSection.swift in Sources */,
 				B1000000000000000000002D /* SettingsViewHelpers.swift in Sources */,
 				B10000000000000000000033 /* AnalyticsSettingsSection.swift in Sources */,
+				B1000000000000000000003E /* ScrollingPanoramaCapture.swift in Sources */,
+				B1000000000000000000003F /* ScrollingCapturePanel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -618,6 +628,8 @@
 				B2000000000000000000002C /* MouseClicksSettingsSection.swift in Sources */,
 				B2000000000000000000002D /* SettingsViewHelpers.swift in Sources */,
 				B20000000000000000000033 /* AnalyticsSettingsSection.swift in Sources */,
+				B2000000000000000000003E /* ScrollingPanoramaCapture.swift in Sources */,
+				B2000000000000000000003F /* ScrollingCapturePanel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
+++ b/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
@@ -1,7 +1,6 @@
-import AppKit
 import CoreImage
 import CoreMedia
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 
 struct PanoramaCaptureLimits: Sendable {
     let maxFrames: Int
@@ -12,12 +11,12 @@ struct PanoramaCaptureLimits: Sendable {
     static let `default` = PanoramaCaptureLimits(
         maxFrames: 120,
         maxOutputHeight: 30_000,
-        maxMemoryBytes: 1_200_000_000,
+        maxMemoryBytes: 600_000_000,
         noMovementTimeout: 8
     )
 }
 
-enum PanoramaCaptureError: LocalizedError {
+enum PanoramaCaptureError: LocalizedError, Equatable {
     case cancelled
     case noMovement
     case outputTooLarge
@@ -37,6 +36,43 @@ enum PanoramaCaptureError: LocalizedError {
     }
 }
 
+struct PanoramaFrame: Sendable {
+    let width: Int
+    let height: Int
+    let pixels: [UInt8]
+
+    var byteCount: Int64 {
+        Int64(pixels.count)
+    }
+
+    init(image: CGImage) throws {
+        width = image.width
+        height = image.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard width > 0,
+              height > 0,
+              let context = CGContext(
+                data: &pixels,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            throw PanoramaCaptureError.noFrames
+        }
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        self.pixels = pixels
+    }
+
+    init(width: Int, height: Int, pixels: [UInt8]) {
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+}
+
 struct PanoramaStitcher {
     struct Result {
         let image: CGImage
@@ -44,130 +80,207 @@ struct PanoramaStitcher {
         let outputHeight: Int
     }
 
+    private struct Alignment {
+        let shift: Int
+        let score: Double
+        let fixedBottomHeight: Int
+    }
+
     let limits: PanoramaCaptureLimits
 
-    func stitch(_ frames: [CGImage]) throws -> Result {
+    func stitch(_ frames: [PanoramaFrame]) throws -> Result {
         guard let first = frames.first else { throw PanoramaCaptureError.noFrames }
-        let width = first.width
-        let height = first.height
-        guard width > 0, height > 0 else { throw PanoramaCaptureError.noFrames }
+        guard first.width > 0, first.height > 0 else { throw PanoramaCaptureError.noFrames }
 
-        var images: [[UInt8]] = []
-        images.reserveCapacity(frames.count)
-        let bytesPerImage = Int64(width) * Int64(height) * 4
-        for frame in frames {
-            guard frame.width == width, frame.height == height else {
+        var acceptedFrames = [first]
+        var alignments: [Alignment] = []
+        var outputHeight = first.height
+
+        for frame in frames.dropFirst() {
+            guard frame.width == first.width, frame.height == first.height else {
                 throw PanoramaCaptureError.alignmentFailed
             }
-            guard Int64(images.count + 1) * bytesPerImage <= limits.maxMemoryBytes else {
-                throw PanoramaCaptureError.memoryLimit
+            guard let alignment = estimateVerticalShift(previous: acceptedFrames.last!, current: frame) else {
+                continue
             }
-            images.append(try rgbaBytes(for: frame))
-        }
-
-        var outputHeight = height
-        var placements: [(image: [UInt8], y: Int)] = [(images[0], 0)]
-        for index in 1..<images.count {
-            let previous = placements.last!.image
-            let current = images[index]
-            let shift = estimateVerticalShift(previous: previous, current: current, width: width, height: height)
-            guard shift > 0 else { continue }
-            outputHeight += shift
+            outputHeight += alignment.shift
             guard outputHeight <= limits.maxOutputHeight else {
                 throw PanoramaCaptureError.outputTooLarge
             }
-            placements.append((current, outputHeight - height))
+            acceptedFrames.append(frame)
+            alignments.append(alignment)
         }
 
-        guard placements.count > 1 else { throw PanoramaCaptureError.noMovement }
-        guard let context = CGContext(
-            data: nil,
-            width: width,
-            height: outputHeight,
-            bitsPerComponent: 8,
-            bytesPerRow: width * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
+        guard acceptedFrames.count > 1 else {
+            throw frames.count > 1 ? PanoramaCaptureError.alignmentFailed : PanoramaCaptureError.noMovement
+        }
+
+        let frameBytes = frames.reduce(Int64(0)) { $0 + $1.byteCount }
+        let outputBytes = Int64(first.width) * Int64(outputHeight) * 4
+        // The final CGImage provider may copy the output Data, so budget two output buffers.
+        guard frameBytes + outputBytes * 2 <= limits.maxMemoryBytes else {
+            throw PanoramaCaptureError.memoryLimit
+        }
+
+        let fixedBottomHeight = alignments.map(\.fixedBottomHeight).max() ?? 0
+        var output = [UInt8](repeating: 0, count: Int(outputBytes))
+        copyRows(
+            from: first,
+            sourceStartRow: 0,
+            rowCount: first.height - fixedBottomHeight,
+            to: &output,
+            destinationStartRow: 0
+        )
+        var destinationRow = first.height - fixedBottomHeight
+        for (index, alignment) in alignments.enumerated() {
+            let frame = acceptedFrames[index + 1]
+            let rowCount = alignment.shift
+            copyRows(
+                from: frame,
+                sourceStartRow: frame.height - fixedBottomHeight - alignment.shift,
+                rowCount: rowCount,
+                to: &output,
+                destinationStartRow: destinationRow
+            )
+            destinationRow += rowCount
+        }
+        if fixedBottomHeight > 0, let last = acceptedFrames.last {
+            copyRows(
+                from: last,
+                sourceStartRow: last.height - fixedBottomHeight,
+                rowCount: fixedBottomHeight,
+                to: &output,
+                destinationStartRow: destinationRow
+            )
+        }
+
+        let data = Data(output) as CFData
+        guard let provider = CGDataProvider(data: data),
+              let image = CGImage(
+                width: first.width,
+                height: outputHeight,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: first.width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent
+              ) else {
             throw PanoramaCaptureError.alignmentFailed
         }
+        return Result(image: image, frameCount: acceptedFrames.count, outputHeight: outputHeight)
+    }
 
-        context.setBlendMode(.copy)
-        for placement in placements {
-            placement.image.withUnsafeBytes { bytes in
-                guard let baseAddress = bytes.baseAddress,
-                      let image = CGImage(
-                        width: width,
-                        height: height,
-                        bitsPerComponent: 8,
-                        bitsPerPixel: 32,
-                        bytesPerRow: width * 4,
-                        space: CGColorSpaceCreateDeviceRGB(),
-                        bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
-                        provider: CGDataProvider(data: Data(bytes: baseAddress, count: bytes.count) as CFData)!,
-                        decode: nil,
-                        shouldInterpolate: false,
-                        intent: .defaultIntent
-                      ) else { return }
-                context.draw(image, in: CGRect(x: 0, y: outputHeight - placement.y - height, width: width, height: height))
+    func areMeaningfullyDifferent(_ first: PanoramaFrame, _ second: PanoramaFrame) -> Bool {
+        guard first.width == second.width, first.height == second.height else { return true }
+        let rowStep = max(1, first.height / 80)
+        let columnStep = max(1, first.width / 80)
+        var difference = 0.0
+        var samples = 0
+        for y in stride(from: 0, to: first.height, by: rowStep) {
+            for x in stride(from: 0, to: first.width, by: columnStep) {
+                let index = (y * first.width + x) * 4
+                difference += abs(luma(first.pixels, index) - luma(second.pixels, index))
+                samples += 1
             }
         }
-
-        guard let result = context.makeImage() else { throw PanoramaCaptureError.alignmentFailed }
-        return Result(image: result, frameCount: placements.count, outputHeight: outputHeight)
+        return samples == 0 || difference / Double(samples) > 2.5
     }
 
-    private func rgbaBytes(for image: CGImage) throws -> [UInt8] {
-        var bytes = [UInt8](repeating: 0, count: image.width * image.height * 4)
-        guard let context = CGContext(
-            data: &bytes,
-            width: image.width,
-            height: image.height,
-            bitsPerComponent: 8,
-            bytesPerRow: image.width * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            throw PanoramaCaptureError.alignmentFailed
-        }
-        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
-        return bytes
-    }
-
-    private func estimateVerticalShift(previous: [UInt8], current: [UInt8], width: Int, height: Int) -> Int {
+    private func estimateVerticalShift(previous: PanoramaFrame, current: PanoramaFrame) -> Alignment? {
+        let height = previous.height
+        let width = previous.width
         let minimumShift = max(2, height / 40)
         let maximumShift = max(minimumShift, height - height / 10)
-        let band = max(1, height / 10)
-        let sampleStep = max(1, width / 160)
+        let ignoredTopBand = max(1, height / 10)
+        let columnStep = max(1, width / 160)
         var bestShift = 0
         var bestScore = Double.greatestFiniteMagnitude
 
         for shift in stride(from: minimumShift, through: maximumShift, by: max(1, height / 120)) {
             let overlap = height - shift
+            let comparisonEnd = overlap - ignoredTopBand
+            guard comparisonEnd > ignoredTopBand else { continue }
             var score = 0.0
             var samples = 0
-            for y in stride(from: band, to: overlap - band, by: max(1, overlap / 80)) {
-                let previousY = y + shift
-                for x in stride(from: 0, to: width, by: sampleStep) {
-                    let previousIndex = (previousY * width + x) * 4
+            for y in stride(from: ignoredTopBand, to: comparisonEnd, by: max(1, overlap / 80)) {
+                for x in stride(from: 0, to: width, by: columnStep) {
+                    let previousIndex = ((y + shift) * width + x) * 4
                     let currentIndex = (y * width + x) * 4
-                    score += abs(luma(previous, previousIndex) - luma(current, currentIndex))
+                    score += abs(luma(previous.pixels, previousIndex) - luma(current.pixels, currentIndex))
                     samples += 1
                 }
             }
-            if samples > 0 {
-                let normalizedScore = score / Double(samples)
-                if normalizedScore < bestScore {
-                    bestScore = normalizedScore
-                    bestShift = shift
-                }
+            guard samples > 0 else { continue }
+            let normalizedScore = score / Double(samples)
+            if normalizedScore < bestScore {
+                bestScore = normalizedScore
+                bestShift = shift
             }
         }
-        return bestShift
+
+        guard bestShift > 0, bestScore <= 18 else { return nil }
+        let fixedBottomHeight = stationaryBottomBand(
+            previous: previous,
+            current: current,
+            maximumHeight: bestShift / 2
+        )
+        guard bestShift + fixedBottomHeight <= height else { return nil }
+        return Alignment(
+            shift: bestShift,
+            score: bestScore,
+            fixedBottomHeight: fixedBottomHeight
+        )
+    }
+
+    private func stationaryBottomBand(
+        previous: PanoramaFrame,
+        current: PanoramaFrame,
+        maximumHeight: Int
+    ) -> Int {
+        let maximum = min(maximumHeight, previous.height / 4)
+        guard maximum > 0 else { return 0 }
+        let columnStep = max(1, previous.width / 160)
+        var stationaryRows = 0
+        for offset in 0..<maximum {
+            let y = previous.height - 1 - offset
+            var difference = 0.0
+            var samples = 0
+            for x in stride(from: 0, to: previous.width, by: columnStep) {
+                let index = (y * previous.width + x) * 4
+                difference += abs(luma(previous.pixels, index) - luma(current.pixels, index))
+                samples += 1
+            }
+            guard samples > 0, difference / Double(samples) <= 2 else { break }
+            stationaryRows += 1
+        }
+        return stationaryRows
+    }
+
+    private func copyRows(
+        from frame: PanoramaFrame,
+        sourceStartRow: Int,
+        rowCount: Int,
+        to output: inout [UInt8],
+        destinationStartRow: Int
+    ) {
+        let bytesPerRow = frame.width * 4
+        let sourceStart = sourceStartRow * bytesPerRow
+        let sourceEnd = sourceStart + rowCount * bytesPerRow
+        let destinationStart = destinationStartRow * bytesPerRow
+        output.replaceSubrange(
+            destinationStart..<(destinationStart + rowCount * bytesPerRow),
+            with: frame.pixels[sourceStart..<sourceEnd]
+        )
     }
 
     private func luma(_ bytes: [UInt8], _ index: Int) -> Double {
-        (0.299 * Double(bytes[index])) + (0.587 * Double(bytes[index + 1])) + (0.114 * Double(bytes[index + 2]))
+        (0.299 * Double(bytes[index]))
+            + (0.587 * Double(bytes[index + 1]))
+            + (0.114 * Double(bytes[index + 2]))
     }
 }
 
@@ -179,10 +292,12 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
     private let processingQueue = DispatchQueue(label: "com.tinyclips.scrolling-panorama")
     private let context = CIContext()
     private var stream: SCStream?
-    private var frames: [CGImage] = []
+    private var frames: [PanoramaFrame] = []
+    private var retainedFrameBytes: Int64 = 0
     private var lastFrameDate = Date()
     private var stopContinuation: CheckedContinuation<CGImage, Error>?
     private var didFinish = false
+    private var didReportFailure = false
 
     init(limits: PanoramaCaptureLimits = .default) {
         self.limits = limits
@@ -195,9 +310,40 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         configuration.minimumFrameInterval = CMTime(value: 1, timescale: 12)
         let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: processingQueue)
-        try await stream.startCapture()
-        self.stream = stream
-        lastFrameDate = Date()
+
+        let mayStart = await withCheckedContinuation { continuation in
+            processingQueue.async {
+                guard !self.didFinish else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                self.stream = stream
+                continuation.resume(returning: true)
+            }
+        }
+        guard mayStart else { throw PanoramaCaptureError.cancelled }
+
+        do {
+            try await stream.startCapture()
+        } catch {
+            processingQueue.async {
+                if self.stream === stream {
+                    self.stream = nil
+                }
+            }
+            throw error
+        }
+
+        let cancelledDuringStartup = await withCheckedContinuation { continuation in
+            processingQueue.async {
+                self.lastFrameDate = Date()
+                continuation.resume(returning: self.didFinish)
+            }
+        }
+        if cancelledDuringStartup {
+            try? await stream.stopCapture()
+            throw PanoramaCaptureError.cancelled
+        }
     }
 
     func stop() async throws -> CGImage {
@@ -208,9 +354,12 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
                     return
                 }
                 self.stopContinuation = continuation
+                let stream = self.stream
                 Task {
-                    try? await self.stream?.stopCapture()
-                    self.finish()
+                    try? await stream?.stopCapture()
+                    self.processingQueue.async {
+                        self.finish()
+                    }
                 }
             }
         }
@@ -220,11 +369,15 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         processingQueue.async {
             guard !self.didFinish else { return }
             self.didFinish = true
-            self.stream?.stopCapture { _ in }
+            let stream = self.stream
+            self.stream = nil
             self.stopContinuation?.resume(throwing: PanoramaCaptureError.cancelled)
             self.stopContinuation = nil
-            self.stream = nil
             self.frames.removeAll()
+            self.retainedFrameBytes = 0
+            Task {
+                try? await stream?.stopCapture()
+            }
         }
     }
 
@@ -240,52 +393,43 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         }
         stopContinuation = nil
         frames.removeAll()
+        retainedFrameBytes = 0
     }
 
     private func process(_ sampleBuffer: CMSampleBuffer) {
         guard !didFinish,
-              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
-              let image = context.createCGImage(CIImage(cvPixelBuffer: pixelBuffer), from: CIImage(cvPixelBuffer: pixelBuffer).extent) else {
+              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
             return
         }
-        let frameBytes: Int64 = Int64(image.width) * Int64(image.height) * 4
-        guard Int64(frames.count + 1) * frameBytes <= limits.maxMemoryBytes else {
-            onFailure?(PanoramaCaptureError.memoryLimit)
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        guard let image = context.createCGImage(ciImage, from: ciImage.extent),
+              let frame = try? PanoramaFrame(image: image) else {
             return
         }
-        if let previous = frames.last, !isMeaningfullyDifferent(previous, image) {
+        guard retainedFrameBytes + frame.byteCount <= limits.maxMemoryBytes / 2 else {
+            reportFailure(PanoramaCaptureError.memoryLimit)
+            return
+        }
+        if let previous = frames.last,
+           !PanoramaStitcher(limits: limits).areMeaningfullyDifferent(previous, frame) {
             if Date().timeIntervalSince(lastFrameDate) > limits.noMovementTimeout {
-                onFailure?(PanoramaCaptureError.noMovement)
+                reportFailure(PanoramaCaptureError.noMovement)
             }
             return
         }
-        frames.append(image)
+        frames.append(frame)
+        retainedFrameBytes += frame.byteCount
         lastFrameDate = Date()
         onProgress?(frames.count)
         if frames.count >= limits.maxFrames {
-            onFailure?(PanoramaCaptureError.outputTooLarge)
+            reportFailure(PanoramaCaptureError.outputTooLarge)
         }
     }
 
-    private func isMeaningfullyDifferent(_ first: CGImage, _ second: CGImage) -> Bool {
-        guard let firstData = try? PanoramaStitcher(limits: limits).rgbaBytesForComparison(first),
-              let secondData = try? PanoramaStitcher(limits: limits).rgbaBytesForComparison(second) else {
-            return true
-        }
-        let sampleStride = max(4, first.width / 80) * 4
-        var difference = 0
-        var samples = 0
-        for index in Swift.stride(from: 0, to: min(firstData.count, secondData.count), by: sampleStride) {
-            difference += abs(Int(firstData[index]) - Int(secondData[index]))
-            samples += 1
-        }
-        return samples == 0 || Double(difference) / Double(samples) > 2.5
-    }
-}
-
-private extension PanoramaStitcher {
-    func rgbaBytesForComparison(_ image: CGImage) throws -> [UInt8] {
-        try rgbaBytes(for: image)
+    private func reportFailure(_ error: Error) {
+        guard !didReportFailure else { return }
+        didReportFailure = true
+        onFailure?(error)
     }
 }
 
@@ -297,7 +441,7 @@ extension ScrollingPanoramaCapture: SCStreamOutput, SCStreamDelegate {
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
         processingQueue.async {
-            self.onFailure?(error)
+            self.reportFailure(error)
         }
     }
 }

--- a/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
+++ b/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
@@ -1,0 +1,303 @@
+import AppKit
+import CoreImage
+import CoreMedia
+import ScreenCaptureKit
+
+struct PanoramaCaptureLimits: Sendable {
+    let maxFrames: Int
+    let maxOutputHeight: Int
+    let maxMemoryBytes: Int64
+    let noMovementTimeout: TimeInterval
+
+    static let `default` = PanoramaCaptureLimits(
+        maxFrames: 120,
+        maxOutputHeight: 30_000,
+        maxMemoryBytes: 1_200_000_000,
+        noMovementTimeout: 8
+    )
+}
+
+enum PanoramaCaptureError: LocalizedError {
+    case cancelled
+    case noMovement
+    case outputTooLarge
+    case memoryLimit
+    case noFrames
+    case alignmentFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled: return "Scrolling capture was cancelled."
+        case .noMovement: return "Scrolling capture stopped because no movement was detected."
+        case .outputTooLarge: return "Scrolling capture reached its maximum output size."
+        case .memoryLimit: return "Scrolling capture reached its memory limit."
+        case .noFrames: return "No frames were captured."
+        case .alignmentFailed: return "Could not align the scrolling frames."
+        }
+    }
+}
+
+struct PanoramaStitcher {
+    struct Result {
+        let image: CGImage
+        let frameCount: Int
+        let outputHeight: Int
+    }
+
+    let limits: PanoramaCaptureLimits
+
+    func stitch(_ frames: [CGImage]) throws -> Result {
+        guard let first = frames.first else { throw PanoramaCaptureError.noFrames }
+        let width = first.width
+        let height = first.height
+        guard width > 0, height > 0 else { throw PanoramaCaptureError.noFrames }
+
+        var images: [[UInt8]] = []
+        images.reserveCapacity(frames.count)
+        let bytesPerImage = Int64(width) * Int64(height) * 4
+        for frame in frames {
+            guard frame.width == width, frame.height == height else {
+                throw PanoramaCaptureError.alignmentFailed
+            }
+            guard Int64(images.count + 1) * bytesPerImage <= limits.maxMemoryBytes else {
+                throw PanoramaCaptureError.memoryLimit
+            }
+            images.append(try rgbaBytes(for: frame))
+        }
+
+        var outputHeight = height
+        var placements: [(image: [UInt8], y: Int)] = [(images[0], 0)]
+        for index in 1..<images.count {
+            let previous = placements.last!.image
+            let current = images[index]
+            let shift = estimateVerticalShift(previous: previous, current: current, width: width, height: height)
+            guard shift > 0 else { continue }
+            outputHeight += shift
+            guard outputHeight <= limits.maxOutputHeight else {
+                throw PanoramaCaptureError.outputTooLarge
+            }
+            placements.append((current, outputHeight - height))
+        }
+
+        guard placements.count > 1 else { throw PanoramaCaptureError.noMovement }
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: outputHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw PanoramaCaptureError.alignmentFailed
+        }
+
+        context.setBlendMode(.copy)
+        for placement in placements {
+            placement.image.withUnsafeBytes { bytes in
+                guard let baseAddress = bytes.baseAddress,
+                      let image = CGImage(
+                        width: width,
+                        height: height,
+                        bitsPerComponent: 8,
+                        bitsPerPixel: 32,
+                        bytesPerRow: width * 4,
+                        space: CGColorSpaceCreateDeviceRGB(),
+                        bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+                        provider: CGDataProvider(data: Data(bytes: baseAddress, count: bytes.count) as CFData)!,
+                        decode: nil,
+                        shouldInterpolate: false,
+                        intent: .defaultIntent
+                      ) else { return }
+                context.draw(image, in: CGRect(x: 0, y: outputHeight - placement.y - height, width: width, height: height))
+            }
+        }
+
+        guard let result = context.makeImage() else { throw PanoramaCaptureError.alignmentFailed }
+        return Result(image: result, frameCount: placements.count, outputHeight: outputHeight)
+    }
+
+    private func rgbaBytes(for image: CGImage) throws -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: image.width * image.height * 4)
+        guard let context = CGContext(
+            data: &bytes,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: image.width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw PanoramaCaptureError.alignmentFailed
+        }
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        return bytes
+    }
+
+    private func estimateVerticalShift(previous: [UInt8], current: [UInt8], width: Int, height: Int) -> Int {
+        let minimumShift = max(2, height / 40)
+        let maximumShift = max(minimumShift, height - height / 10)
+        let band = max(1, height / 10)
+        let sampleStep = max(1, width / 160)
+        var bestShift = 0
+        var bestScore = Double.greatestFiniteMagnitude
+
+        for shift in stride(from: minimumShift, through: maximumShift, by: max(1, height / 120)) {
+            let overlap = height - shift
+            var score = 0.0
+            var samples = 0
+            for y in stride(from: band, to: overlap - band, by: max(1, overlap / 80)) {
+                let previousY = y + shift
+                for x in stride(from: 0, to: width, by: sampleStep) {
+                    let previousIndex = (previousY * width + x) * 4
+                    let currentIndex = (y * width + x) * 4
+                    score += abs(luma(previous, previousIndex) - luma(current, currentIndex))
+                    samples += 1
+                }
+            }
+            if samples > 0 {
+                let normalizedScore = score / Double(samples)
+                if normalizedScore < bestScore {
+                    bestScore = normalizedScore
+                    bestShift = shift
+                }
+            }
+        }
+        return bestShift
+    }
+
+    private func luma(_ bytes: [UInt8], _ index: Int) -> Double {
+        (0.299 * Double(bytes[index])) + (0.587 * Double(bytes[index + 1])) + (0.114 * Double(bytes[index + 2]))
+    }
+}
+
+final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
+    var onProgress: ((Int) -> Void)?
+    var onFailure: ((Error) -> Void)?
+
+    private let limits: PanoramaCaptureLimits
+    private let processingQueue = DispatchQueue(label: "com.tinyclips.scrolling-panorama")
+    private let context = CIContext()
+    private var stream: SCStream?
+    private var frames: [CGImage] = []
+    private var lastFrameDate = Date()
+    private var stopContinuation: CheckedContinuation<CGImage, Error>?
+    private var didFinish = false
+
+    init(limits: PanoramaCaptureLimits = .default) {
+        self.limits = limits
+    }
+
+    func start(region: CaptureRegion) async throws {
+        let filter = try await region.makeFilter()
+        let configuration = region.makeStreamConfig()
+        configuration.showsCursor = false
+        configuration.minimumFrameInterval = CMTime(value: 1, timescale: 12)
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: processingQueue)
+        try await stream.startCapture()
+        self.stream = stream
+        lastFrameDate = Date()
+    }
+
+    func stop() async throws -> CGImage {
+        try await withCheckedThrowingContinuation { continuation in
+            processingQueue.async {
+                guard !self.didFinish else {
+                    continuation.resume(throwing: PanoramaCaptureError.cancelled)
+                    return
+                }
+                self.stopContinuation = continuation
+                Task {
+                    try? await self.stream?.stopCapture()
+                    self.finish()
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        processingQueue.async {
+            guard !self.didFinish else { return }
+            self.didFinish = true
+            self.stream?.stopCapture { _ in }
+            self.stopContinuation?.resume(throwing: PanoramaCaptureError.cancelled)
+            self.stopContinuation = nil
+            self.stream = nil
+            self.frames.removeAll()
+        }
+    }
+
+    private func finish() {
+        guard !didFinish else { return }
+        didFinish = true
+        stream = nil
+        do {
+            let image = try PanoramaStitcher(limits: limits).stitch(frames).image
+            stopContinuation?.resume(returning: image)
+        } catch {
+            stopContinuation?.resume(throwing: error)
+        }
+        stopContinuation = nil
+        frames.removeAll()
+    }
+
+    private func process(_ sampleBuffer: CMSampleBuffer) {
+        guard !didFinish,
+              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let image = context.createCGImage(CIImage(cvPixelBuffer: pixelBuffer), from: CIImage(cvPixelBuffer: pixelBuffer).extent) else {
+            return
+        }
+        let frameBytes: Int64 = Int64(image.width) * Int64(image.height) * 4
+        guard Int64(frames.count + 1) * frameBytes <= limits.maxMemoryBytes else {
+            onFailure?(PanoramaCaptureError.memoryLimit)
+            return
+        }
+        if let previous = frames.last, !isMeaningfullyDifferent(previous, image) {
+            if Date().timeIntervalSince(lastFrameDate) > limits.noMovementTimeout {
+                onFailure?(PanoramaCaptureError.noMovement)
+            }
+            return
+        }
+        frames.append(image)
+        lastFrameDate = Date()
+        onProgress?(frames.count)
+        if frames.count >= limits.maxFrames {
+            onFailure?(PanoramaCaptureError.outputTooLarge)
+        }
+    }
+
+    private func isMeaningfullyDifferent(_ first: CGImage, _ second: CGImage) -> Bool {
+        guard let firstData = try? PanoramaStitcher(limits: limits).rgbaBytesForComparison(first),
+              let secondData = try? PanoramaStitcher(limits: limits).rgbaBytesForComparison(second) else {
+            return true
+        }
+        let sampleStride = max(4, first.width / 80) * 4
+        var difference = 0
+        var samples = 0
+        for index in Swift.stride(from: 0, to: min(firstData.count, secondData.count), by: sampleStride) {
+            difference += abs(Int(firstData[index]) - Int(secondData[index]))
+            samples += 1
+        }
+        return samples == 0 || Double(difference) / Double(samples) > 2.5
+    }
+}
+
+private extension PanoramaStitcher {
+    func rgbaBytesForComparison(_ image: CGImage) throws -> [UInt8] {
+        try rgbaBytes(for: image)
+    }
+}
+
+extension ScrollingPanoramaCapture: SCStreamOutput, SCStreamDelegate {
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .screen else { return }
+        process(sampleBuffer)
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        processingQueue.async {
+            self.onFailure?(error)
+        }
+    }
+}

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -155,6 +155,7 @@ class CaptureManager: ObservableObject {
             || startPanel != nil
             || countdownWindow != nil
             || screenPickerWindow != nil
+            || scrollingCapturePanel != nil
     }
 
     private var videoRecorder: VideoRecorder?
@@ -183,6 +184,8 @@ class CaptureManager: ObservableObject {
     private var gifTrimmerWindow: GifTrimmerWindow?
     @Published private var countdownWindow: CountdownWindow?
     private var processingIndicatorWindow: ProcessingIndicatorWindow?
+    @Published private var scrollingCapturePanel: ScrollingCapturePanel?
+    private var scrollingCaptureSession: ScrollingPanoramaCapture?
     private var processingIndicatorShownAt: Date?
     private var isStoppingRecording = false
     private var stopRecordingTask: Task<Void, Never>?
@@ -518,6 +521,129 @@ class CaptureManager: ObservableObject {
                 countdownDuration: countdownDuration,
                 shouldReturnToPickerAfterCapture: shouldReturnToPicker
             )
+
+        case .scrolling:
+            guard let region = await RegionSelector.selectRegion() else {
+                if shouldReturnToPicker {
+                    showScreenshotPicker(cursorScreen: cursorScreen)
+                }
+                return
+            }
+            startScrollingCapture(region: region, shouldReturnToPickerAfterCapture: shouldReturnToPicker)
+        }
+    }
+
+    private func startScrollingCapture(region: CaptureRegion, shouldReturnToPickerAfterCapture: Bool) {
+        guard scrollingCaptureSession == nil else { return }
+        isScreenshotCaptureInProgress = true
+        AccessibilityAnnouncementService.shared.announce(
+            "Scrolling capture started. Scroll the page, then press Return to finish.",
+            priority: .high
+        )
+
+        let session = ScrollingPanoramaCapture()
+        scrollingCaptureSession = session
+        session.onFailure = { [weak self, weak session] error in
+            Task { @MainActor [weak self, weak session] in
+                guard let self, self.scrollingCaptureSession === session else { return }
+                session?.cancel()
+                self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+            }
+        }
+        let panel = ScrollingCapturePanel(
+            onStop: { [weak self, weak session] in
+                guard let self, let session else { return }
+                Task {
+                    do {
+                        let image = try await session.stop()
+                        await self.finishScrollingCapture(image: image, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                    } catch {
+                        await self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                    }
+                }
+            },
+            onCancel: { [weak self, weak session] in
+                session?.cancel()
+                self?.finishScrollingCapture(with: PanoramaCaptureError.cancelled, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+            }
+        )
+        scrollingCapturePanel = panel
+        panel.show()
+
+        Task {
+            do {
+                try await session.start(region: region)
+            } catch {
+                await self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+            }
+        }
+    }
+
+    @MainActor
+    private func finishScrollingCapture(
+        image: CGImage? = nil,
+        with error: Error? = nil,
+        shouldReturnToPicker: Bool
+    ) {
+        scrollingCapturePanel?.dismiss()
+        scrollingCapturePanel = nil
+        scrollingCaptureSession = nil
+        isScreenshotCaptureInProgress = false
+
+        if let error {
+            let wasCancelled: Bool
+            if let panoramaError = error as? PanoramaCaptureError {
+                if case .cancelled = panoramaError {
+                    wasCancelled = true
+                } else {
+                    wasCancelled = false
+                }
+            } else {
+                wasCancelled = false
+            }
+            if !wasCancelled {
+                SaveService.shared.showError("Scrolling capture failed: \(error.localizedDescription)")
+            }
+            if shouldReturnToPicker,
+               CaptureSettings.shared.shouldShowCapturePickerAfterCapture(for: .screenshot) {
+                showScreenshotPicker()
+            }
+            return
+        }
+        guard let image else { return }
+
+        Task {
+            do {
+                let settings = CaptureSettings.shared
+                let shouldSaveImmediately = !settings.showScreenshotEditor || settings.saveImmediatelyScreenshot
+                let outputURL = shouldSaveImmediately
+                    ? SaveService.shared.generateURL(for: .screenshot)
+                    : TinyClipsTemporaryFiles.makeURL(fileExtension: settings.imageFormat.rawValue)
+                let url = try ScreenshotCapture.saveImage(image, to: outputURL)
+                CaptureAnalyticsStore.shared.recordCapture(.screenshot)
+                if settings.showScreenshotEditor {
+                    if shouldSaveImmediately {
+                        SaveService.shared.handleSavedFile(url: url, type: .screenshot)
+                    }
+                    let initialSaveURL = shouldSaveImmediately
+                        ? url
+                        : SaveService.shared.generateURL(for: .screenshot, fileExtension: settings.imageFormat.rawValue)
+                    showScreenshotEditor(
+                        for: url,
+                        initialSaveURL: initialSaveURL,
+                        deleteSourceOnCancel: !shouldSaveImmediately,
+                        reopenPickerAfterClose: shouldReturnToPicker
+                    )
+                } else {
+                    SaveService.shared.handleSavedFile(url: url, type: .screenshot)
+                }
+            } catch {
+                SaveService.shared.showError("Scrolling capture failed: \(error.localizedDescription)")
+            }
+            if shouldReturnToPicker,
+               CaptureSettings.shared.shouldShowCapturePickerAfterCapture(for: .screenshot) {
+                showScreenshotPicker()
+            }
         }
     }
 
@@ -2165,6 +2291,8 @@ class CaptureManager: ObservableObject {
                 return nil
             }
             return CaptureTarget(region: region)
+        case .scrolling:
+            return nil
         }
     }
 

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -186,6 +186,7 @@ class CaptureManager: ObservableObject {
     private var processingIndicatorWindow: ProcessingIndicatorWindow?
     @Published private var scrollingCapturePanel: ScrollingCapturePanel?
     private var scrollingCaptureSession: ScrollingPanoramaCapture?
+    private var scrollingCapturePanelPosition: NSPoint?
     private var processingIndicatorShownAt: Date?
     private var isStoppingRecording = false
     private var stopRecordingTask: Task<Void, Never>?
@@ -547,7 +548,12 @@ class CaptureManager: ObservableObject {
             Task { @MainActor [weak self, weak session] in
                 guard let self, self.scrollingCaptureSession === session else { return }
                 session?.cancel()
-                self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                guard let session else { return }
+                self.finishScrollingCapture(
+                    session: session,
+                    with: error,
+                    shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                )
             }
         }
         let panel = ScrollingCapturePanel(
@@ -556,35 +562,57 @@ class CaptureManager: ObservableObject {
                 Task {
                     do {
                         let image = try await session.stop()
-                        await self.finishScrollingCapture(image: image, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                        self.finishScrollingCapture(
+                            session: session,
+                            image: image,
+                            shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                        )
                     } catch {
-                        await self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                        self.finishScrollingCapture(
+                            session: session,
+                            with: error,
+                            shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                        )
                     }
                 }
             },
             onCancel: { [weak self, weak session] in
-                session?.cancel()
-                self?.finishScrollingCapture(with: PanoramaCaptureError.cancelled, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                guard let self, let session else { return }
+                session.cancel()
+                self.finishScrollingCapture(
+                    session: session,
+                    with: PanoramaCaptureError.cancelled,
+                    shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                )
             }
         )
         scrollingCapturePanel = panel
-        panel.show()
+        panel.show(at: scrollingCapturePanelPosition)
 
         Task {
             do {
                 try await session.start(region: region)
             } catch {
-                await self.finishScrollingCapture(with: error, shouldReturnToPicker: shouldReturnToPickerAfterCapture)
+                self.finishScrollingCapture(
+                    session: session,
+                    with: error,
+                    shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                )
             }
         }
     }
 
     @MainActor
     private func finishScrollingCapture(
+        session: ScrollingPanoramaCapture,
         image: CGImage? = nil,
         with error: Error? = nil,
         shouldReturnToPicker: Bool
     ) {
+        guard scrollingCaptureSession === session else { return }
+        if let panel = scrollingCapturePanel {
+            scrollingCapturePanelPosition = panel.frame.origin
+        }
         scrollingCapturePanel?.dismiss()
         scrollingCapturePanel = nil
         scrollingCaptureSession = nil
@@ -613,6 +641,7 @@ class CaptureManager: ObservableObject {
         guard let image else { return }
 
         Task {
+            var didPresentEditor = false
             do {
                 let settings = CaptureSettings.shared
                 let shouldSaveImmediately = !settings.showScreenshotEditor || settings.saveImmediatelyScreenshot
@@ -634,13 +663,15 @@ class CaptureManager: ObservableObject {
                         deleteSourceOnCancel: !shouldSaveImmediately,
                         reopenPickerAfterClose: shouldReturnToPicker
                     )
+                    didPresentEditor = true
                 } else {
                     SaveService.shared.handleSavedFile(url: url, type: .screenshot)
                 }
             } catch {
                 SaveService.shared.showError("Scrolling capture failed: \(error.localizedDescription)")
             }
-            if shouldReturnToPicker,
+            if !didPresentEditor,
+               shouldReturnToPicker,
                CaptureSettings.shared.shouldShowCapturePickerAfterCapture(for: .screenshot) {
                 showScreenshotPicker()
             }

--- a/mac/TinyClips/Views/CapturePickerPanel.swift
+++ b/mac/TinyClips/Views/CapturePickerPanel.swift
@@ -7,6 +7,7 @@ enum CapturePickerMode {
     case region
     case screen
     case window
+    case scrolling
 }
 
 @MainActor
@@ -33,6 +34,7 @@ class CapturePickerPanel: NSPanel {
     private var onCapture: ((CapturePickerMode, Bool, Int, Int) -> Void)?
     private var onCancel: (() -> Void)?
     private let state: CapturePickerState
+    private var captureType: CaptureType = .screenshot
 
     override var canBecomeKey: Bool { true }
 
@@ -63,6 +65,7 @@ class CapturePickerPanel: NSPanel {
         self.state.countdownEnabled = countdownEnabled
         self.state.countdownDuration = countdownDuration
         self.state.videoTimeLimitMinutes = videoTimeLimitMinutes
+        self.captureType = captureType
         self.onCapture = onCapture
         self.onCancel = onCancel
         self.isReleasedWhenClosed = false
@@ -183,6 +186,17 @@ class CapturePickerPanel: NSPanel {
                 videoTimeLimitMinutes: state.videoTimeLimitMinutes
             )
             return true
+        case "p":
+            if captureType == .screenshot {
+                finishCapture(
+                    mode: .scrolling,
+                    countdownEnabled: false,
+                    countdownDuration: 0,
+                    videoTimeLimitMinutes: 0
+                )
+                return true
+            }
+            return false
         default:
             return false
         }
@@ -328,6 +342,27 @@ private struct CapturePickerView: View {
             .help("Select a window (W)")
             .keyboardShortcut("w", modifiers: [])
             .accessibilityHint("Starts window capture.")
+
+            if captureType == .screenshot {
+                Button { onCapture(.scrolling, false, 0, 0) } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "arrow.down.doc")
+                            .font(.system(size: 12))
+                        Text("Scroll")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(.primary.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .help("Scrolling capture (P)")
+                .keyboardShortcut("p", modifiers: [])
+                .accessibilityLabel("Scrolling capture")
+                .accessibilityHint("Select a region and stitch a long page while you scroll.")
+            }
 
             Divider()
                 .frame(height: 20)

--- a/mac/TinyClips/Views/ScrollingCapturePanel.swift
+++ b/mac/TinyClips/Views/ScrollingCapturePanel.swift
@@ -1,0 +1,122 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class ScrollingCapturePanel: NSPanel {
+    private var didComplete = false
+    private var localMonitor: Any?
+    private var globalMonitor: Any?
+    private let onStop: () -> Void
+    private let onCancel: () -> Void
+
+    init(onStop: @escaping () -> Void, onCancel: @escaping () -> Void) {
+        self.onStop = onStop
+        self.onCancel = onCancel
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 280, height: 88),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        isReleasedWhenClosed = false
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        contentView = NSHostingView(rootView: ScrollingCapturePanelView(
+            onStop: { [weak self] in self?.finish(stop: true) },
+            onCancel: { [weak self] in self?.finish(stop: false) }
+        ))
+    }
+
+    override var canBecomeKey: Bool { true }
+
+    func show() {
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main else {
+            return
+        }
+        setFrameOrigin(NSPoint(x: screen.visibleFrame.midX - frame.width / 2, y: screen.visibleFrame.minY + 32))
+        makeKeyAndOrderFront(nil)
+        NSApp.activate()
+        installMonitors()
+    }
+
+    func dismiss() {
+        removeMonitors()
+        orderOut(nil)
+    }
+
+    private func finish(stop: Bool) {
+        guard !didComplete else { return }
+        didComplete = true
+        removeMonitors()
+        orderOut(nil)
+        if stop {
+            onStop()
+        } else {
+            onCancel()
+        }
+    }
+
+    private func installMonitors() {
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            if event.keyCode == 53 {
+                self.finish(stop: false)
+                return nil
+            }
+            if event.keyCode == 36 || event.keyCode == 76 {
+                self.finish(stop: true)
+                return nil
+            }
+            return event
+        }
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 {
+                self?.finish(stop: false)
+            }
+        }
+    }
+
+    private func removeMonitors() {
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+        if let globalMonitor {
+            NSEvent.removeMonitor(globalMonitor)
+            self.globalMonitor = nil
+        }
+    }
+}
+
+private struct ScrollingCapturePanelView: View {
+    let onStop: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Scrolling capture")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Scroll normally, then press Return to finish")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            Button("Stop", action: onStop)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityHint("Stops scrolling capture and stitches the frames.")
+            Button("Cancel", action: onCancel)
+                .keyboardShortcut(.cancelAction)
+                .accessibilityHint("Cancels without saving a partial capture.")
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .shadow(radius: 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Scrolling capture in progress")
+    }
+}

--- a/mac/TinyClips/Views/ScrollingCapturePanel.swift
+++ b/mac/TinyClips/Views/ScrollingCapturePanel.swift
@@ -24,6 +24,7 @@ final class ScrollingCapturePanel: NSPanel {
         backgroundColor = .clear
         hasShadow = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isMovableByWindowBackground = true
         contentView = NSHostingView(rootView: ScrollingCapturePanelView(
             onStop: { [weak self] in self?.finish(stop: true) },
             onCancel: { [weak self] in self?.finish(stop: false) }
@@ -32,11 +33,15 @@ final class ScrollingCapturePanel: NSPanel {
 
     override var canBecomeKey: Bool { true }
 
-    func show() {
-        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main else {
-            return
+    func show(at position: NSPoint? = nil) {
+        if let position {
+            setFrameOrigin(position)
+        } else {
+            guard let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) }) ?? NSScreen.main else {
+                return
+            }
+            setFrameOrigin(NSPoint(x: screen.visibleFrame.midX - frame.width / 2, y: screen.visibleFrame.minY + 32))
         }
-        setFrameOrigin(NSPoint(x: screen.visibleFrame.midX - frame.width / 2, y: screen.visibleFrame.minY + 32))
         makeKeyAndOrderFront(nil)
         NSApp.activate()
         installMonitors()
@@ -75,6 +80,8 @@ final class ScrollingCapturePanel: NSPanel {
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 {
                 self?.finish(stop: false)
+            } else if event.keyCode == 36 || event.keyCode == 76 {
+                self?.finish(stop: true)
             }
         }
     }

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -115,6 +115,57 @@ final class CaptureMathTests: XCTestCase {
         )
     }
 
+    func testPanoramaStitchesKnownVerticalShift() throws {
+        let first = panoramaFrame(globalStartRow: 0)
+        let second = panoramaFrame(globalStartRow: 20)
+
+        let result = try PanoramaStitcher(limits: panoramaLimits()).stitch([first, second])
+
+        XCTAssertEqual(result.frameCount, 2)
+        XCTAssertEqual(result.outputHeight, 120)
+    }
+
+    func testPanoramaRejectsFramesWithoutCredibleAlignment() {
+        let first = panoramaFrame(globalStartRow: 0)
+        let unrelated = PanoramaFrame(
+            width: 40,
+            height: 100,
+            pixels: [UInt8](repeating: 255, count: 40 * 100 * 4)
+        )
+
+        XCTAssertThrowsError(
+            try PanoramaStitcher(limits: panoramaLimits()).stitch([first, unrelated])
+        ) { error in
+            XCTAssertEqual(error as? PanoramaCaptureError, .alignmentFailed)
+        }
+    }
+
+    func testPanoramaSuppressesStationaryFooterCopies() throws {
+        let first = panoramaFrame(globalStartRow: 0, fixedFooterHeight: 5)
+        let second = panoramaFrame(globalStartRow: 20, fixedFooterHeight: 5)
+
+        let result = try PanoramaStitcher(limits: panoramaLimits()).stitch([first, second])
+
+        XCTAssertEqual(result.outputHeight, 120)
+        XCTAssertEqual(redValue(in: result.image, x: 0, y: 95), UInt8((95 * 7) % 251))
+        XCTAssertEqual(redValue(in: result.image, x: 0, y: 119), 32)
+    }
+
+    func testPanoramaEnforcesPeakMemoryBudget() {
+        let first = panoramaFrame(globalStartRow: 0)
+        let second = panoramaFrame(globalStartRow: 20)
+        let limits = PanoramaCaptureLimits(
+            maxFrames: 10,
+            maxOutputHeight: 1_000,
+            maxMemoryBytes: 50_000,
+            noMovementTimeout: 8
+        )
+
+        XCTAssertThrowsError(try PanoramaStitcher(limits: limits).stitch([first, second])) { error in
+            XCTAssertEqual(error as? PanoramaCaptureError, .memoryLimit)
+        }
+    }
+
     func testTimelineExcludesCompletedAndActivePauses() {
         let timeline = RecordingTimelineMath.timelineTime(
             now: CMTime(seconds: 20, preferredTimescale: 600),
@@ -139,5 +190,42 @@ final class CaptureMathTests: XCTestCase {
 
         XCTAssertEqual(accumulated.seconds, 6.5, accuracy: 0.0001)
         XCTAssertEqual(adjusted.seconds, 13.5, accuracy: 0.0001)
+    }
+
+    private func panoramaFrame(globalStartRow: Int, fixedFooterHeight: Int = 0) -> PanoramaFrame {
+        let width = 40
+        let height = 100
+        var pixels = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let index = (y * width + x) * 4
+                let isFooter = fixedFooterHeight > 0 && y >= height - fixedFooterHeight
+                let value = isFooter
+                    ? UInt8(32)
+                    : UInt8(((globalStartRow + y) * 7 + x * 13) % 251)
+                pixels[index] = value
+                pixels[index + 1] = value
+                pixels[index + 2] = value
+                pixels[index + 3] = 255
+            }
+        }
+        return PanoramaFrame(width: width, height: height, pixels: pixels)
+    }
+
+    private func panoramaLimits() -> PanoramaCaptureLimits {
+        PanoramaCaptureLimits(
+            maxFrames: 10,
+            maxOutputHeight: 1_000,
+            maxMemoryBytes: 2_000_000,
+            noMovementTimeout: 8
+        )
+    }
+
+    private func redValue(in image: CGImage, x: Int, y: Int) -> UInt8? {
+        guard let data = image.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            return nil
+        }
+        return bytes[(y * image.width + x) * 4]
     }
 }


### PR DESCRIPTION
## Why

Long web pages, chat threads, and documents currently require multiple manual screenshots and stitching. This adds a first vertical, region-based scrolling capture flow for macOS.

## What changed

- Adds a Scroll mode to the screenshot picker with `P` keyboard support.
- Streams the selected region with ScreenCaptureKit while the user scrolls normally.
- Rejects near-duplicate frames and stitches aligned frames into one bounded panorama.
- Adds memory, frame-count, output-height, and no-movement guardrails.
- Adds a floating Stop/Cancel panel with Return and Esc keyboard controls.
- Reuses the existing screenshot editor, save settings, branding, analytics, and output pipeline.
- Builds the feature into both direct-distribution and Mac App Store targets without adding Sparkle dependencies to MAS.

The initial implementation is intentionally vertical and region-only; horizontal stitching, window capture, and browser-specific automation remain follow-up work.

## Validation

- macOS unit tests passed.
- TinyClips and TinyClipsMAS Debug builds passed.

Fixes: #222