### PR TITLE
Fix scrolling capture memory limits and restyle its control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed macOS scrolling capture running out of memory on modest regions by stitching frames incrementally, and guardrails now stop and save the panorama captured so far instead of discarding it.
+- Fixed the macOS scrolling capture control panel to match the other capture bars, with a live frame count and enough room for its status text.
 - Fixed the macOS teleprompter settings preview blocking its Stop button and other controls while the transcript scrolls, and ensured scrolling stops when leaving Teleprompter settings.
 - Fixed the macOS teleprompter preview viewport height and VoiceOver scrolling-status announcement.
 - Fixed the macOS and Windows settings sidebars to keep Video and Teleprompter as separate entries, cleaned up the Support label wording, and prevented the screenshot editor’s Horizontal/Vertical alignment labels from being clipped when the window is narrow.

--- a/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
+++ b/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
@@ -9,9 +9,9 @@ struct PanoramaCaptureLimits: Sendable {
     let noMovementTimeout: TimeInterval
 
     static let `default` = PanoramaCaptureLimits(
-        maxFrames: 120,
-        maxOutputHeight: 30_000,
-        maxMemoryBytes: 600_000_000,
+        maxFrames: 600,
+        maxOutputHeight: 50_000,
+        maxMemoryBytes: 1_500_000_000,
         noMovementTimeout: 8
     )
 }
@@ -32,6 +32,21 @@ enum PanoramaCaptureError: LocalizedError, Equatable {
         case .memoryLimit: return "Scrolling capture reached its memory limit."
         case .noFrames: return "No frames were captured."
         case .alignmentFailed: return "Could not align the scrolling frames."
+        }
+    }
+}
+
+/// Reason a capture stopped growing before the user asked it to.
+enum PanoramaCaptureLimitReason: Equatable {
+    case memory
+    case outputHeight
+    case frameCount
+
+    var message: String {
+        switch self {
+        case .memory: return "Memory limit reached, saving what was captured"
+        case .outputHeight: return "Maximum height reached, saving what was captured"
+        case .frameCount: return "Frame limit reached, saving what was captured"
         }
     }
 }
@@ -73,95 +88,142 @@ struct PanoramaFrame: Sendable {
     }
 }
 
-struct PanoramaStitcher {
+/// Stitches frames into the output buffer as they arrive so that peak memory tracks
+/// the size of the panorama instead of the number of captured frames.
+struct PanoramaAccumulator {
     struct Result {
         let image: CGImage
         let frameCount: Int
         let outputHeight: Int
+        let reachedLimit: Bool
     }
 
-    private struct Alignment {
+    struct Alignment {
         let shift: Int
         let score: Double
         let fixedBottomHeight: Int
     }
 
+    enum Outcome: Equatable {
+        case accepted
+        case skipped
+        case limitReached(PanoramaCaptureLimitReason)
+    }
+
     let limits: PanoramaCaptureLimits
 
-    func stitch(_ frames: [PanoramaFrame]) throws -> Result {
-        guard let first = frames.first else { throw PanoramaCaptureError.noFrames }
-        guard first.width > 0, first.height > 0 else { throw PanoramaCaptureError.noFrames }
+    private(set) var previousFrame: PanoramaFrame?
+    private(set) var acceptedFrameCount = 0
+    private(set) var limitReason: PanoramaCaptureLimitReason?
 
-        var acceptedFrames = [first]
-        var alignments: [Alignment] = []
-        var outputHeight = first.height
+    private var output: [UInt8] = []
+    private var committedRows = 0
+    private var heldBottomBand = 0
+    private var rejectedFrameCount = 0
 
-        for frame in frames.dropFirst() {
-            guard frame.width == first.width, frame.height == first.height else {
-                throw PanoramaCaptureError.alignmentFailed
+    init(limits: PanoramaCaptureLimits) {
+        self.limits = limits
+    }
+
+    var reachedLimit: Bool { limitReason != nil }
+
+    /// Height the panorama would have if the capture stopped right now.
+    var pendingOutputHeight: Int {
+        guard let previousFrame else { return 0 }
+        return committedRows == 0 ? previousFrame.height : committedRows + heldBottomBand
+    }
+
+    mutating func append(_ frame: PanoramaFrame) -> Outcome {
+        guard limitReason == nil else { return .skipped }
+
+        guard let previous = previousFrame else {
+            guard fits(outputHeight: frame.height, width: frame.width, frame: frame) else {
+                limitReason = .memory
+                return .limitReached(.memory)
             }
-            guard let alignment = estimateVerticalShift(previous: acceptedFrames.last!, current: frame) else {
-                continue
+            previousFrame = frame
+            acceptedFrameCount = 1
+            return .accepted
+        }
+
+        guard frame.width == previous.width, frame.height == previous.height else {
+            rejectedFrameCount += 1
+            return .skipped
+        }
+        guard let alignment = Self.estimateVerticalShift(previous: previous, current: frame) else {
+            rejectedFrameCount += 1
+            return .skipped
+        }
+
+        let height = frame.height
+        let isFirstCommit = committedRows == 0
+        let baseRows = isFirstCommit ? height - alignment.fixedBottomHeight : committedRows
+        let previousBand = isFirstCommit ? alignment.fixedBottomHeight : heldBottomBand
+        let appendCount = alignment.shift + previousBand - alignment.fixedBottomHeight
+        let sourceStartRow = height - previousBand - alignment.shift
+        guard appendCount > 0, sourceStartRow >= 0, baseRows >= 0 else {
+            rejectedFrameCount += 1
+            return .skipped
+        }
+
+        let prospectiveHeight = baseRows + appendCount + alignment.fixedBottomHeight
+        guard prospectiveHeight <= limits.maxOutputHeight else {
+            limitReason = .outputHeight
+            return .limitReached(.outputHeight)
+        }
+        guard fits(outputHeight: prospectiveHeight, width: frame.width, frame: frame) else {
+            limitReason = .memory
+            return .limitReached(.memory)
+        }
+
+        if isFirstCommit {
+            output.reserveCapacity(baseRows * frame.width * 4)
+            appendRows(from: previous, startRow: 0, rowCount: baseRows)
+            committedRows = baseRows
+        }
+        appendRows(from: frame, startRow: sourceStartRow, rowCount: appendCount)
+        committedRows += appendCount
+        heldBottomBand = alignment.fixedBottomHeight
+        previousFrame = frame
+        acceptedFrameCount += 1
+
+        if acceptedFrameCount >= limits.maxFrames {
+            limitReason = .frameCount
+            return .limitReached(.frameCount)
+        }
+        return .accepted
+    }
+
+    /// Flushes the held footer band and materializes the panorama image.
+    func finish() throws -> Result {
+        guard let last = previousFrame else { throw PanoramaCaptureError.noFrames }
+        guard committedRows > 0 else {
+            if let limitReason {
+                throw limitReason == .memory
+                    ? PanoramaCaptureError.memoryLimit
+                    : PanoramaCaptureError.outputTooLarge
             }
-            outputHeight += alignment.shift
-            guard outputHeight <= limits.maxOutputHeight else {
-                throw PanoramaCaptureError.outputTooLarge
-            }
-            acceptedFrames.append(frame)
-            alignments.append(alignment)
+            throw rejectedFrameCount > 0
+                ? PanoramaCaptureError.alignmentFailed
+                : PanoramaCaptureError.noMovement
         }
 
-        guard acceptedFrames.count > 1 else {
-            throw frames.count > 1 ? PanoramaCaptureError.alignmentFailed : PanoramaCaptureError.noMovement
+        var pixels = output
+        if heldBottomBand > 0 {
+            let bytesPerRow = last.width * 4
+            let start = (last.height - heldBottomBand) * bytesPerRow
+            pixels.append(contentsOf: last.pixels[start..<last.pixels.count])
         }
+        let outputHeight = committedRows + heldBottomBand
 
-        let frameBytes = frames.reduce(Int64(0)) { $0 + $1.byteCount }
-        let outputBytes = Int64(first.width) * Int64(outputHeight) * 4
-        // The final CGImage provider may copy the output Data, so budget two output buffers.
-        guard frameBytes + outputBytes * 2 <= limits.maxMemoryBytes else {
-            throw PanoramaCaptureError.memoryLimit
-        }
-
-        let fixedBottomHeight = alignments.map(\.fixedBottomHeight).max() ?? 0
-        var output = [UInt8](repeating: 0, count: Int(outputBytes))
-        copyRows(
-            from: first,
-            sourceStartRow: 0,
-            rowCount: first.height - fixedBottomHeight,
-            to: &output,
-            destinationStartRow: 0
-        )
-        var destinationRow = first.height - fixedBottomHeight
-        for (index, alignment) in alignments.enumerated() {
-            let frame = acceptedFrames[index + 1]
-            let rowCount = alignment.shift
-            copyRows(
-                from: frame,
-                sourceStartRow: frame.height - fixedBottomHeight - alignment.shift,
-                rowCount: rowCount,
-                to: &output,
-                destinationStartRow: destinationRow
-            )
-            destinationRow += rowCount
-        }
-        if fixedBottomHeight > 0, let last = acceptedFrames.last {
-            copyRows(
-                from: last,
-                sourceStartRow: last.height - fixedBottomHeight,
-                rowCount: fixedBottomHeight,
-                to: &output,
-                destinationStartRow: destinationRow
-            )
-        }
-
-        let data = Data(output) as CFData
+        let data = Data(pixels) as CFData
         guard let provider = CGDataProvider(data: data),
               let image = CGImage(
-                width: first.width,
+                width: last.width,
                 height: outputHeight,
                 bitsPerComponent: 8,
                 bitsPerPixel: 32,
-                bytesPerRow: first.width * 4,
+                bytesPerRow: last.width * 4,
                 space: CGColorSpaceCreateDeviceRGB(),
                 bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
                 provider: provider,
@@ -171,10 +233,28 @@ struct PanoramaStitcher {
               ) else {
             throw PanoramaCaptureError.alignmentFailed
         }
-        return Result(image: image, frameCount: acceptedFrames.count, outputHeight: outputHeight)
+        return Result(
+            image: image,
+            frameCount: acceptedFrameCount,
+            outputHeight: outputHeight,
+            reachedLimit: limitReason != nil
+        )
     }
 
-    func areMeaningfullyDifferent(_ first: PanoramaFrame, _ second: PanoramaFrame) -> Bool {
+    private mutating func appendRows(from frame: PanoramaFrame, startRow: Int, rowCount: Int) {
+        let bytesPerRow = frame.width * 4
+        let start = startRow * bytesPerRow
+        let end = start + rowCount * bytesPerRow
+        output.append(contentsOf: frame.pixels[start..<end])
+    }
+
+    /// Peak memory is the output buffer plus the copy made for the final image, plus one live frame.
+    private func fits(outputHeight: Int, width: Int, frame: PanoramaFrame) -> Bool {
+        let outputBytes = Int64(width) * Int64(outputHeight) * 4
+        return outputBytes * 2 + frame.byteCount <= limits.maxMemoryBytes
+    }
+
+    static func areMeaningfullyDifferent(_ first: PanoramaFrame, _ second: PanoramaFrame) -> Bool {
         guard first.width == second.width, first.height == second.height else { return true }
         let rowStep = max(1, first.height / 80)
         let columnStep = max(1, first.width / 80)
@@ -190,7 +270,7 @@ struct PanoramaStitcher {
         return samples == 0 || difference / Double(samples) > 2.5
     }
 
-    private func estimateVerticalShift(previous: PanoramaFrame, current: PanoramaFrame) -> Alignment? {
+    static func estimateVerticalShift(previous: PanoramaFrame, current: PanoramaFrame) -> Alignment? {
         let height = previous.height
         let width = previous.width
         let minimumShift = max(2, height / 40)
@@ -229,14 +309,10 @@ struct PanoramaStitcher {
             maximumHeight: bestShift / 2
         )
         guard bestShift + fixedBottomHeight <= height else { return nil }
-        return Alignment(
-            shift: bestShift,
-            score: bestScore,
-            fixedBottomHeight: fixedBottomHeight
-        )
+        return Alignment(shift: bestShift, score: bestScore, fixedBottomHeight: fixedBottomHeight)
     }
 
-    private func stationaryBottomBand(
+    private static func stationaryBottomBand(
         previous: PanoramaFrame,
         current: PanoramaFrame,
         maximumHeight: Int
@@ -260,47 +336,46 @@ struct PanoramaStitcher {
         return stationaryRows
     }
 
-    private func copyRows(
-        from frame: PanoramaFrame,
-        sourceStartRow: Int,
-        rowCount: Int,
-        to output: inout [UInt8],
-        destinationStartRow: Int
-    ) {
-        let bytesPerRow = frame.width * 4
-        let sourceStart = sourceStartRow * bytesPerRow
-        let sourceEnd = sourceStart + rowCount * bytesPerRow
-        let destinationStart = destinationStartRow * bytesPerRow
-        output.replaceSubrange(
-            destinationStart..<(destinationStart + rowCount * bytesPerRow),
-            with: frame.pixels[sourceStart..<sourceEnd]
-        )
-    }
-
-    private func luma(_ bytes: [UInt8], _ index: Int) -> Double {
+    private static func luma(_ bytes: [UInt8], _ index: Int) -> Double {
         (0.299 * Double(bytes[index]))
             + (0.587 * Double(bytes[index + 1]))
             + (0.114 * Double(bytes[index + 2]))
     }
 }
 
+/// Convenience wrapper that stitches an already-captured sequence of frames.
+struct PanoramaStitcher {
+    let limits: PanoramaCaptureLimits
+
+    func stitch(_ frames: [PanoramaFrame]) throws -> PanoramaAccumulator.Result {
+        var accumulator = PanoramaAccumulator(limits: limits)
+        for frame in frames {
+            if case .limitReached = accumulator.append(frame) { break }
+        }
+        return try accumulator.finish()
+    }
+}
+
 final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
     var onProgress: ((Int) -> Void)?
     var onFailure: ((Error) -> Void)?
+    /// Fired once when a guardrail stops growth; the caller should stop and keep what exists.
+    var onLimitReached: ((PanoramaCaptureLimitReason) -> Void)?
 
     private let limits: PanoramaCaptureLimits
     private let processingQueue = DispatchQueue(label: "com.tinyclips.scrolling-panorama")
     private let context = CIContext()
     private var stream: SCStream?
-    private var frames: [PanoramaFrame] = []
-    private var retainedFrameBytes: Int64 = 0
+    private var accumulator: PanoramaAccumulator
     private var lastFrameDate = Date()
     private var stopContinuation: CheckedContinuation<CGImage, Error>?
     private var didFinish = false
     private var didReportFailure = false
+    private var didReportLimit = false
 
     init(limits: PanoramaCaptureLimits = .default) {
         self.limits = limits
+        self.accumulator = PanoramaAccumulator(limits: limits)
     }
 
     func start(region: CaptureRegion) async throws {
@@ -373,8 +448,7 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
             self.stream = nil
             self.stopContinuation?.resume(throwing: PanoramaCaptureError.cancelled)
             self.stopContinuation = nil
-            self.frames.removeAll()
-            self.retainedFrameBytes = 0
+            self.accumulator = PanoramaAccumulator(limits: self.limits)
             Task {
                 try? await stream?.stopCapture()
             }
@@ -386,18 +460,18 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         didFinish = true
         stream = nil
         do {
-            let image = try PanoramaStitcher(limits: limits).stitch(frames).image
+            let image = try accumulator.finish().image
             stopContinuation?.resume(returning: image)
         } catch {
             stopContinuation?.resume(throwing: error)
         }
         stopContinuation = nil
-        frames.removeAll()
-        retainedFrameBytes = 0
+        accumulator = PanoramaAccumulator(limits: limits)
     }
 
     private func process(_ sampleBuffer: CMSampleBuffer) {
         guard !didFinish,
+              !accumulator.reachedLimit,
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
             return
         }
@@ -406,23 +480,21 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
               let frame = try? PanoramaFrame(image: image) else {
             return
         }
-        guard retainedFrameBytes + frame.byteCount <= limits.maxMemoryBytes / 2 else {
-            reportFailure(PanoramaCaptureError.memoryLimit)
-            return
-        }
-        if let previous = frames.last,
-           !PanoramaStitcher(limits: limits).areMeaningfullyDifferent(previous, frame) {
+        if let previous = accumulator.previousFrame,
+           !PanoramaAccumulator.areMeaningfullyDifferent(previous, frame) {
             if Date().timeIntervalSince(lastFrameDate) > limits.noMovementTimeout {
                 reportFailure(PanoramaCaptureError.noMovement)
             }
             return
         }
-        frames.append(frame)
-        retainedFrameBytes += frame.byteCount
-        lastFrameDate = Date()
-        onProgress?(frames.count)
-        if frames.count >= limits.maxFrames {
-            reportFailure(PanoramaCaptureError.outputTooLarge)
+        switch accumulator.append(frame) {
+        case .accepted:
+            lastFrameDate = Date()
+            onProgress?(accumulator.acceptedFrameCount)
+        case .skipped:
+            break
+        case .limitReached(let reason):
+            reportLimit(reason)
         }
     }
 
@@ -430,6 +502,12 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         guard !didReportFailure else { return }
         didReportFailure = true
         onFailure?(error)
+    }
+
+    private func reportLimit(_ reason: PanoramaCaptureLimitReason) {
+        guard !didReportLimit else { return }
+        didReportLimit = true
+        onLimitReached?(reason)
     }
 }
 

--- a/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
+++ b/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
@@ -195,7 +195,7 @@ struct PanoramaAccumulator {
     }
 
     /// Flushes the held footer band and materializes the panorama image.
-    func finish() throws -> Result {
+    mutating func finish() throws -> Result {
         guard let last = previousFrame else { throw PanoramaCaptureError.noFrames }
         guard committedRows > 0 else {
             if let limitReason {
@@ -209,6 +209,7 @@ struct PanoramaAccumulator {
         }
 
         var pixels = output
+        output = []
         if heldBottomBand > 0 {
             let bytesPerRow = last.width * 4
             let start = (last.height - heldBottomBand) * bytesPerRow
@@ -248,10 +249,10 @@ struct PanoramaAccumulator {
         output.append(contentsOf: frame.pixels[start..<end])
     }
 
-    /// Peak memory is the output buffer plus the copy made for the final image, plus one live frame.
+    /// Peak memory is the output buffer plus the copy made for the final image, plus the retained and incoming frames.
     private func fits(outputHeight: Int, width: Int, frame: PanoramaFrame) -> Bool {
         let outputBytes = Int64(width) * Int64(outputHeight) * 4
-        return outputBytes * 2 + frame.byteCount <= limits.maxMemoryBytes
+        return outputBytes * 2 + frame.byteCount * 2 <= limits.maxMemoryBytes
     }
 
     static func areMeaningfullyDifferent(_ first: PanoramaFrame, _ second: PanoramaFrame) -> Bool {
@@ -494,6 +495,7 @@ final class ScrollingPanoramaCapture: NSObject, @unchecked Sendable {
         case .skipped:
             break
         case .limitReached(let reason):
+            onProgress?(accumulator.acceptedFrameCount)
             reportLimit(reason)
         }
     }

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -187,6 +187,7 @@ class CaptureManager: ObservableObject {
     @Published private var scrollingCapturePanel: ScrollingCapturePanel?
     private var scrollingCaptureSession: ScrollingPanoramaCapture?
     private var scrollingCapturePanelPosition: NSPoint?
+    private var isStoppingScrollingCapture = false
     private var processingIndicatorShownAt: Date?
     private var isStoppingRecording = false
     private var stopRecordingTask: Task<Void, Never>?
@@ -537,6 +538,7 @@ class CaptureManager: ObservableObject {
     private func startScrollingCapture(region: CaptureRegion, shouldReturnToPickerAfterCapture: Bool) {
         guard scrollingCaptureSession == nil else { return }
         isScreenshotCaptureInProgress = true
+        isStoppingScrollingCapture = false
         AccessibilityAnnouncementService.shared.announce(
             "Scrolling capture started. Scroll the page, then press Return to finish.",
             priority: .high
@@ -556,25 +558,30 @@ class CaptureManager: ObservableObject {
                 )
             }
         }
+        session.onProgress = { [weak self, weak session] count in
+            Task { @MainActor [weak self, weak session] in
+                guard let self, let session, self.scrollingCaptureSession === session else { return }
+                self.scrollingCapturePanel?.updateFrameCount(count)
+            }
+        }
+        session.onLimitReached = { [weak self, weak session] reason in
+            Task { @MainActor [weak self, weak session] in
+                guard let self, let session, self.scrollingCaptureSession === session else { return }
+                self.scrollingCapturePanel?.showStatus(reason.message)
+                AccessibilityAnnouncementService.shared.announce(reason.message, priority: .high)
+                self.stopScrollingCapture(
+                    session: session,
+                    shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                )
+            }
+        }
         let panel = ScrollingCapturePanel(
             onStop: { [weak self, weak session] in
                 guard let self, let session else { return }
-                Task {
-                    do {
-                        let image = try await session.stop()
-                        self.finishScrollingCapture(
-                            session: session,
-                            image: image,
-                            shouldReturnToPicker: shouldReturnToPickerAfterCapture
-                        )
-                    } catch {
-                        self.finishScrollingCapture(
-                            session: session,
-                            with: error,
-                            shouldReturnToPicker: shouldReturnToPickerAfterCapture
-                        )
-                    }
-                }
+                self.stopScrollingCapture(
+                    session: session,
+                    shouldReturnToPicker: shouldReturnToPickerAfterCapture
+                )
             },
             onCancel: { [weak self, weak session] in
                 guard let self, let session else { return }
@@ -603,6 +610,31 @@ class CaptureManager: ObservableObject {
     }
 
     @MainActor
+    private func stopScrollingCapture(
+        session: ScrollingPanoramaCapture,
+        shouldReturnToPicker: Bool
+    ) {
+        guard scrollingCaptureSession === session, !isStoppingScrollingCapture else { return }
+        isStoppingScrollingCapture = true
+        Task {
+            do {
+                let image = try await session.stop()
+                self.finishScrollingCapture(
+                    session: session,
+                    image: image,
+                    shouldReturnToPicker: shouldReturnToPicker
+                )
+            } catch {
+                self.finishScrollingCapture(
+                    session: session,
+                    with: error,
+                    shouldReturnToPicker: shouldReturnToPicker
+                )
+            }
+        }
+    }
+
+    @MainActor
     private func finishScrollingCapture(
         session: ScrollingPanoramaCapture,
         image: CGImage? = nil,
@@ -616,6 +648,7 @@ class CaptureManager: ObservableObject {
         scrollingCapturePanel?.dismiss()
         scrollingCapturePanel = nil
         scrollingCaptureSession = nil
+        isStoppingScrollingCapture = false
         isScreenshotCaptureInProgress = false
 
         if let error {

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -616,6 +616,7 @@ class CaptureManager: ObservableObject {
     ) {
         guard scrollingCaptureSession === session, !isStoppingScrollingCapture else { return }
         isStoppingScrollingCapture = true
+        scrollingCapturePanel?.markCompleted()
         Task {
             do {
                 let image = try await session.stop()

--- a/mac/TinyClips/Views/ScrollingCapturePanel.swift
+++ b/mac/TinyClips/Views/ScrollingCapturePanel.swift
@@ -2,18 +2,25 @@ import AppKit
 import SwiftUI
 
 @MainActor
+final class ScrollingCaptureState: ObservableObject {
+    @Published var frameCount = 0
+    @Published var statusMessage: String?
+}
+
+@MainActor
 final class ScrollingCapturePanel: NSPanel {
     private var didComplete = false
     private var localMonitor: Any?
     private var globalMonitor: Any?
     private let onStop: () -> Void
     private let onCancel: () -> Void
+    private let state = ScrollingCaptureState()
 
     init(onStop: @escaping () -> Void, onCancel: @escaping () -> Void) {
         self.onStop = onStop
         self.onCancel = onCancel
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 280, height: 88),
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 44),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -25,10 +32,14 @@ final class ScrollingCapturePanel: NSPanel {
         hasShadow = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         isMovableByWindowBackground = true
-        contentView = NSHostingView(rootView: ScrollingCapturePanelView(
+
+        let hostingView = NSHostingView(rootView: ScrollingCapturePanelView(
+            state: state,
             onStop: { [weak self] in self?.finish(stop: true) },
             onCancel: { [weak self] in self?.finish(stop: false) }
         ))
+        setContentSize(hostingView.fittingSize)
+        contentView = hostingView
     }
 
     override var canBecomeKey: Bool { true }
@@ -45,6 +56,14 @@ final class ScrollingCapturePanel: NSPanel {
         makeKeyAndOrderFront(nil)
         NSApp.activate()
         installMonitors()
+    }
+
+    func updateFrameCount(_ count: Int) {
+        state.frameCount = count
+    }
+
+    func showStatus(_ message: String) {
+        state.statusMessage = message
     }
 
     func dismiss() {
@@ -99,30 +118,106 @@ final class ScrollingCapturePanel: NSPanel {
 }
 
 private struct ScrollingCapturePanelView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @ObservedObject var state: ScrollingCaptureState
     let onStop: () -> Void
     let onCancel: () -> Void
 
+    @State private var isPulsing = false
+
+    private var frameLabel: String {
+        state.frameCount == 1 ? "1 frame" : "\(state.frameCount) frames"
+    }
+
     var body: some View {
-        HStack(spacing: 10) {
-            ProgressView()
-                .controlSize(.small)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Scrolling capture")
-                    .font(.system(size: 13, weight: .semibold))
-                Text("Scroll normally, then press Return to finish")
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.down.doc")
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                Text("Scrolling")
+                    .font(.system(size: 12, weight: .semibold))
             }
-            Button("Stop", action: onStop)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityHint("Stops scrolling capture and stitches the frames.")
-            Button("Cancel", action: onCancel)
-                .keyboardShortcut(.cancelAction)
-                .accessibilityHint("Cancels without saving a partial capture.")
+            .foregroundStyle(.secondary)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Scrolling capture mode")
+
+            Divider()
+                .frame(height: 20)
+                .overlay(.primary.opacity(0.2))
+
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(.red)
+                    .frame(width: 8, height: 8)
+                    .opacity(isPulsing ? 0.35 : 1)
+                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isPulsing)
+                Text(frameLabel)
+                    .font(.system(size: 13, weight: .medium))
+                    .monospacedDigit()
+                    .foregroundStyle(.primary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Captured frames")
+            .accessibilityValue(frameLabel)
+
+            Text(state.statusMessage ?? "Scroll the page, then press Return")
+                .font(.system(size: 12))
+                .foregroundStyle(state.statusMessage == nil ? .secondary : Color.orange)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 260, alignment: .leading)
+                .accessibilityLabel(state.statusMessage ?? "Scroll the page, then press Return to finish.")
+
+            Divider()
+                .frame(height: 20)
+                .overlay(.primary.opacity(0.2))
+
+            Button(action: onStop) {
+                HStack(spacing: 5) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12))
+                    Text("Done")
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .background(.blue.opacity(0.8))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .help("Finish scrolling capture (Return)")
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel("Finish scrolling capture")
+            .accessibilityHint("Stops scrolling capture and stitches the captured frames.")
+
+            Button(action: onCancel) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.primary.opacity(0.5))
+                    .frame(width: 24, height: 24)
+                    .background(.primary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .help("Cancel (Esc)")
+            .keyboardShortcut(.cancelAction)
+            .accessibilityLabel("Cancel scrolling capture")
+            .accessibilityHint("Discards the capture without saving.")
         }
-        .padding(12)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-        .shadow(radius: 8)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .fixedSize()
+        .background {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(colorScheme == .dark ? Color.black.opacity(0.8) : Color.white.opacity(0.9))
+                .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(.primary.opacity(0.15), lineWidth: 0.5)
+                }
+        }
+        .onAppear { isPulsing = true }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Scrolling capture in progress")
     }

--- a/mac/TinyClips/Views/ScrollingCapturePanel.swift
+++ b/mac/TinyClips/Views/ScrollingCapturePanel.swift
@@ -5,6 +5,7 @@ import SwiftUI
 final class ScrollingCaptureState: ObservableObject {
     @Published var frameCount = 0
     @Published var statusMessage: String?
+    @Published var isFinishing = false
 }
 
 @MainActor
@@ -66,6 +67,13 @@ final class ScrollingCapturePanel: NSPanel {
         state.statusMessage = message
     }
 
+    func markCompleted() {
+        guard !didComplete else { return }
+        didComplete = true
+        state.isFinishing = true
+        removeMonitors()
+    }
+
     func dismiss() {
         removeMonitors()
         orderOut(nil)
@@ -73,12 +81,13 @@ final class ScrollingCapturePanel: NSPanel {
 
     private func finish(stop: Bool) {
         guard !didComplete else { return }
-        didComplete = true
-        removeMonitors()
-        orderOut(nil)
         if stop {
+            markCompleted()
             onStop()
         } else {
+            didComplete = true
+            removeMonitors()
+            orderOut(nil)
             onCancel()
         }
     }
@@ -129,6 +138,10 @@ private struct ScrollingCapturePanelView: View {
         state.frameCount == 1 ? "1 frame" : "\(state.frameCount) frames"
     }
 
+    private var statusText: String {
+        state.statusMessage ?? (state.isFinishing ? "Saving..." : "Scroll the page, then press Return")
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             HStack(spacing: 4) {
@@ -160,13 +173,13 @@ private struct ScrollingCapturePanelView: View {
             .accessibilityLabel("Captured frames")
             .accessibilityValue(frameLabel)
 
-            Text(state.statusMessage ?? "Scroll the page, then press Return")
+            Text(statusText)
                 .font(.system(size: 12))
                 .foregroundStyle(state.statusMessage == nil ? .secondary : Color.orange)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(width: 260, alignment: .leading)
-                .accessibilityLabel(state.statusMessage ?? "Scroll the page, then press Return to finish.")
+                .accessibilityLabel(state.statusMessage ?? (state.isFinishing ? "Saving scrolling capture." : "Scroll the page, then press Return to finish."))
 
             Divider()
                 .frame(height: 20)
@@ -188,8 +201,10 @@ private struct ScrollingCapturePanelView: View {
             .buttonStyle(.plain)
             .help("Finish scrolling capture (Return)")
             .keyboardShortcut(.defaultAction)
+            .disabled(state.isFinishing)
+            .opacity(state.isFinishing ? 0.45 : 1)
             .accessibilityLabel("Finish scrolling capture")
-            .accessibilityHint("Stops scrolling capture and stitches the captured frames.")
+            .accessibilityHint(state.isFinishing ? "Saving captured frames." : "Stops scrolling capture and stitches the captured frames.")
 
             Button(action: onCancel) {
                 Image(systemName: "xmark")
@@ -202,8 +217,10 @@ private struct ScrollingCapturePanelView: View {
             .buttonStyle(.plain)
             .help("Cancel (Esc)")
             .keyboardShortcut(.cancelAction)
+            .disabled(state.isFinishing)
+            .opacity(state.isFinishing ? 0.45 : 1)
             .accessibilityLabel("Cancel scrolling capture")
-            .accessibilityHint("Discards the capture without saving.")
+            .accessibilityHint(state.isFinishing ? "Saving captured frames." : "Discards the capture without saving.")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
@@ -219,6 +236,6 @@ private struct ScrollingCapturePanelView: View {
         }
         .onAppear { isPulsing = true }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Scrolling capture in progress")
+        .accessibilityLabel(state.isFinishing ? "Scrolling capture saving" : "Scrolling capture in progress")
     }
 }

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -157,7 +157,7 @@ final class CaptureMathTests: XCTestCase {
         let limits = PanoramaCaptureLimits(
             maxFrames: 10,
             maxOutputHeight: 1_000,
-            maxMemoryBytes: 50_000,
+            maxMemoryBytes: 70_000,
             noMovementTimeout: 8
         )
 
@@ -175,7 +175,7 @@ final class CaptureMathTests: XCTestCase {
         let limits = PanoramaCaptureLimits(
             maxFrames: 10,
             maxOutputHeight: 1_000,
-            maxMemoryBytes: 56_000,
+            maxMemoryBytes: 75_000,
             noMovementTimeout: 8
         )
 
@@ -206,7 +206,7 @@ final class CaptureMathTests: XCTestCase {
     }
 
     func testPanoramaMemoryUseDoesNotGrowWithFrameCount() {
-        // Peak memory tracks the stitched output plus a single live frame, so a
+        // Peak memory tracks the stitched output plus the retained and incoming frames, so a
         // long capture of a modest region must stay well inside the default budget.
         let width = 2_400
         let height = 1_800
@@ -216,7 +216,7 @@ final class CaptureMathTests: XCTestCase {
         let outputBytes = Int64(width) * Int64(outputHeight) * 4
 
         XCTAssertLessThanOrEqual(
-            outputBytes * 2 + frameBytes,
+            outputBytes * 2 + frameBytes * 2,
             PanoramaCaptureLimits.default.maxMemoryBytes
         )
         XCTAssertLessThanOrEqual(outputHeight, PanoramaCaptureLimits.default.maxOutputHeight)

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -166,6 +166,62 @@ final class CaptureMathTests: XCTestCase {
         }
     }
 
+    func testPanoramaKeepsPartialResultWhenMemoryLimitIsReached() throws {
+        let frames = [
+            panoramaFrame(globalStartRow: 0),
+            panoramaFrame(globalStartRow: 20),
+            panoramaFrame(globalStartRow: 40)
+        ]
+        let limits = PanoramaCaptureLimits(
+            maxFrames: 10,
+            maxOutputHeight: 1_000,
+            maxMemoryBytes: 56_000,
+            noMovementTimeout: 8
+        )
+
+        let result = try PanoramaStitcher(limits: limits).stitch(frames)
+
+        XCTAssertTrue(result.reachedLimit)
+        XCTAssertEqual(result.frameCount, 2)
+        XCTAssertEqual(result.outputHeight, 120)
+    }
+
+    func testPanoramaKeepsPartialResultWhenOutputHeightIsReached() throws {
+        let frames = [
+            panoramaFrame(globalStartRow: 0),
+            panoramaFrame(globalStartRow: 20),
+            panoramaFrame(globalStartRow: 40)
+        ]
+        let limits = PanoramaCaptureLimits(
+            maxFrames: 10,
+            maxOutputHeight: 130,
+            maxMemoryBytes: 2_000_000,
+            noMovementTimeout: 8
+        )
+
+        let result = try PanoramaStitcher(limits: limits).stitch(frames)
+
+        XCTAssertTrue(result.reachedLimit)
+        XCTAssertEqual(result.outputHeight, 120)
+    }
+
+    func testPanoramaMemoryUseDoesNotGrowWithFrameCount() {
+        // Peak memory tracks the stitched output plus a single live frame, so a
+        // long capture of a modest region must stay well inside the default budget.
+        let width = 2_400
+        let height = 1_800
+        let frameBytes = Int64(width) * Int64(height) * 4
+        let shiftPerFrame = 200
+        let outputHeight = height + shiftPerFrame * 200
+        let outputBytes = Int64(width) * Int64(outputHeight) * 4
+
+        XCTAssertLessThanOrEqual(
+            outputBytes * 2 + frameBytes,
+            PanoramaCaptureLimits.default.maxMemoryBytes
+        )
+        XCTAssertLessThanOrEqual(outputHeight, PanoramaCaptureLimits.default.maxOutputHeight)
+    }
+
     func testTimelineExcludesCompletedAndActivePauses() {
         let timeline = RecordingTimelineMath.timelineTime(
             now: CMTime(seconds: 20, preferredTimescale: 600),


### PR DESCRIPTION
Follow-up to #247. Real-world testing showed scrolling capture hitting "memory limit" on modestly sized regions, and the floating control panel looked out of place next to the other capture bars.

## Why the memory limit tripped

The capture retained every accepted frame in full and only stitched at the end. A Retina region of roughly 1200x900 points is 2400x1800 pixels, about 17 MB per frame, so the retained-frame budget was exhausted after about 20 frames - a few seconds of scrolling.

## Approach

Frames are now stitched incrementally as they arrive. The accumulator keeps one live frame plus the growing output buffer, so peak memory tracks the size of the panorama rather than how long you scrolled. The row math (including stationary footer suppression) is unchanged, it just runs per frame instead of in one pass at the end.

Guardrails changed from fatal to graceful: hitting the memory, output-height, or frame-count ceiling now stops the capture and saves the panorama stitched so far, with a status message on the panel and a VoiceOver announcement. A hard error is only raised when nothing usable was captured. Default ceilings were retuned for the new model (50,000 px tall output, 1.5 GB peak budget).

## Panel

Restyled to match `CapturePickerPanel` and `StopRecordingPanel`: same rounded background, border, shadow, and padding, sized from `fittingSize` instead of a hardcoded 280x88. It now shows a live frame count with a pulsing record dot and has room for the hint / limit status text. Return still finishes, Esc still cancels, and the panel stays movable with a persisted position.

## Notes for review

- `stopScrollingCapture` is now a single path shared by the Done button and the guardrail stop, guarded against double-stop.
- `PanoramaStitcher` is kept as a thin wrapper over the accumulator so batch stitching stays testable.
- Tests cover partial-save on the memory ceiling, partial-save on the height ceiling, the existing "nothing usable" memory error, and a budget check asserting a long capture of a typical Retina region stays inside the defaults.

Validated with `xcodebuild test` (TinyClips) and Debug builds of both `TinyClips` and `TinyClipsMAS`.

Fixes: #222