### PR TITLE
Fix duplicated rows in macOS scrolling capture and show region outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed macOS scrolling capture stitching duplicated rows of content by aligning frames with per-row signatures at single-pixel resolution and preferring the smallest matching scroll distance, which also handles slow scrolls and repeating layouts such as card lists.
+- Fixed the macOS scrolling capture not showing the red region outline while it records.
 - Fixed macOS scrolling capture running out of memory on modest regions by stitching frames incrementally, and guardrails now stop and save the panorama captured so far instead of discarding it.
 - Fixed the macOS scrolling capture control panel to match the other capture bars, with a live frame count and enough room for its status text.
 - Fixed the macOS teleprompter settings preview blocking its Stop button and other controls while the transcript scrolls, and ensured scrolling stops when leaving Teleprompter settings.

--- a/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
+++ b/mac/TinyClips/Capture/ScrollingPanoramaCapture.swift
@@ -1,3 +1,4 @@
+import Accelerate
 import CoreImage
 import CoreMedia
 @preconcurrency import ScreenCaptureKit
@@ -55,6 +56,8 @@ struct PanoramaFrame: Sendable {
     let width: Int
     let height: Int
     let pixels: [UInt8]
+    /// Mean luma per row, used for fast and repeatable vertical alignment.
+    let rowLuma: [Float]
 
     var byteCount: Int64 {
         Int64(pixels.count)
@@ -79,12 +82,39 @@ struct PanoramaFrame: Sendable {
         }
         context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
         self.pixels = pixels
+        self.rowLuma = Self.makeRowLuma(pixels: pixels, width: width, height: height)
     }
 
     init(width: Int, height: Int, pixels: [UInt8]) {
         self.width = width
         self.height = height
         self.pixels = pixels
+        self.rowLuma = Self.makeRowLuma(pixels: pixels, width: width, height: height)
+    }
+
+    private static func makeRowLuma(pixels: [UInt8], width: Int, height: Int) -> [Float] {
+        guard width > 0, height > 0, pixels.count >= width * height * 4 else { return [] }
+        let columnStep = max(1, width / 160)
+        var result = [Float](repeating: 0, count: height)
+        pixels.withUnsafeBufferPointer { buffer in
+            for y in 0..<height {
+                var total = 0
+                var samples = 0
+                var x = 0
+                let rowStart = y * width
+                while x < width {
+                    let index = (rowStart + x) * 4
+                    // Integer approximation of luma keeps this hot loop cheap.
+                    total += (77 * Int(buffer[index]))
+                        + (150 * Int(buffer[index + 1]))
+                        + (29 * Int(buffer[index + 2]))
+                    samples += 1
+                    x += columnStep
+                }
+                result[y] = samples > 0 ? Float(total) / Float(samples * 256) : 0
+            }
+        }
+        return result
     }
 }
 
@@ -273,44 +303,108 @@ struct PanoramaAccumulator {
 
     static func estimateVerticalShift(previous: PanoramaFrame, current: PanoramaFrame) -> Alignment? {
         let height = previous.height
-        let width = previous.width
-        let minimumShift = max(2, height / 40)
+        guard height > 8,
+              previous.rowLuma.count == height,
+              current.rowLuma.count == height else {
+            return nil
+        }
+        // Scrolling content is usually periodic (repeating rows, cards, table
+        // stripes), so the globally lowest score is often a later alias of the
+        // real shift. Overshooting duplicates rows that are already committed,
+        // so the smallest credible shift is always the right choice.
+        let ignoredTopBand = max(1, height / 20)
+        let ignoredBottomBand = max(1, height / 20)
+        let minimumShift = 2
         let maximumShift = max(minimumShift, height - height / 10)
-        let ignoredTopBand = max(1, height / 10)
-        let columnStep = max(1, width / 160)
-        var bestShift = 0
-        var bestScore = Double.greatestFiniteMagnitude
+        let minimumSamples = max(8, height / 8)
 
-        for shift in stride(from: minimumShift, through: maximumShift, by: max(1, height / 120)) {
-            let overlap = height - shift
-            let comparisonEnd = overlap - ignoredTopBand
-            guard comparisonEnd > ignoredTopBand else { continue }
-            var score = 0.0
-            var samples = 0
-            for y in stride(from: ignoredTopBand, to: comparisonEnd, by: max(1, overlap / 80)) {
-                for x in stride(from: 0, to: width, by: columnStep) {
-                    let previousIndex = ((y + shift) * width + x) * 4
-                    let currentIndex = (y * width + x) * 4
-                    score += abs(luma(previous.pixels, previousIndex) - luma(current.pixels, currentIndex))
-                    samples += 1
+        var scores = [Float](repeating: .greatestFiniteMagnitude, count: maximumShift + 1)
+        var bestScore = Float.greatestFiniteMagnitude
+        var differences = [Float](repeating: 0, count: height)
+        previous.rowLuma.withUnsafeBufferPointer { previousRows in
+            current.rowLuma.withUnsafeBufferPointer { currentRows in
+                guard let previousBase = previousRows.baseAddress,
+                      let currentBase = currentRows.baseAddress else { return }
+                differences.withUnsafeMutableBufferPointer { scratch in
+                    guard let scratchBase = scratch.baseAddress else { return }
+                    for shift in minimumShift...maximumShift {
+                        let comparisonEnd = height - ignoredBottomBand - shift
+                        let samples = comparisonEnd - ignoredTopBand
+                        guard samples >= minimumSamples else { continue }
+                        let count = vDSP_Length(samples)
+                        vDSP_vsub(
+                            currentBase + ignoredTopBand, 1,
+                            previousBase + ignoredTopBand + shift, 1,
+                            scratchBase, 1,
+                            count
+                        )
+                        var total: Float = 0
+                        vDSP_svemg(scratchBase, 1, &total, count)
+                        let score = total / Float(samples)
+                        scores[shift] = score
+                        if score < bestScore {
+                            bestScore = score
+                        }
+                    }
                 }
             }
-            guard samples > 0 else { continue }
-            let normalizedScore = score / Double(samples)
-            if normalizedScore < bestScore {
-                bestScore = normalizedScore
-                bestShift = shift
-            }
         }
+        guard bestScore < .greatestFiniteMagnitude else { return nil }
 
-        guard bestShift > 0, bestScore <= 18 else { return nil }
+        // Anything within this band of the best score is statistically the same
+        // match, so prefer the earliest one.
+        let acceptanceScore = max(bestScore * 1.6, bestScore + 0.5)
+        var candidate: Int?
+        var verificationAttempts = 0
+        for shift in minimumShift...maximumShift where scores[shift] <= acceptanceScore {
+            let isLocalMinimum = (shift == minimumShift || scores[shift] <= scores[shift - 1])
+                && (shift == maximumShift || scores[shift] <= scores[shift + 1])
+            guard isLocalMinimum else { continue }
+            if pixelAlignmentScore(previous: previous, current: current, shift: shift) <= 12 {
+                candidate = shift
+                break
+            }
+            verificationAttempts += 1
+            // Verification is the expensive part, so give up rather than scan a
+            // frame that is not a scroll of the previous one.
+            if verificationAttempts >= 6 { break }
+        }
+        guard let bestShift = candidate else { return nil }
+
         let fixedBottomHeight = stationaryBottomBand(
             previous: previous,
             current: current,
             maximumHeight: bestShift / 2
         )
         guard bestShift + fixedBottomHeight <= height else { return nil }
-        return Alignment(shift: bestShift, score: bestScore, fixedBottomHeight: fixedBottomHeight)
+        return Alignment(shift: bestShift, score: Double(scores[bestShift]), fixedBottomHeight: fixedBottomHeight)
+    }
+
+    /// Confirms a row-signature candidate against real pixels, which rejects
+    /// shifts where unrelated rows happen to share the same average brightness.
+    private static func pixelAlignmentScore(
+        previous: PanoramaFrame,
+        current: PanoramaFrame,
+        shift: Int
+    ) -> Double {
+        let height = previous.height
+        let width = previous.width
+        let ignoredTopBand = max(1, height / 20)
+        let comparisonEnd = height - max(1, height / 20) - shift
+        guard comparisonEnd > ignoredTopBand, width > 0 else { return .greatestFiniteMagnitude }
+        let columnStep = max(1, width / 160)
+        let rowStep = max(1, (comparisonEnd - ignoredTopBand) / 80)
+        var score = 0.0
+        var samples = 0
+        for y in stride(from: ignoredTopBand, to: comparisonEnd, by: rowStep) {
+            for x in stride(from: 0, to: width, by: columnStep) {
+                let previousIndex = ((y + shift) * width + x) * 4
+                let currentIndex = (y * width + x) * 4
+                score += abs(luma(previous.pixels, previousIndex) - luma(current.pixels, currentIndex))
+                samples += 1
+            }
+        }
+        return samples > 0 ? score / Double(samples) : .greatestFiniteMagnitude
     }
 
     private static func stationaryBottomBand(

--- a/mac/TinyClips/CaptureManager.swift
+++ b/mac/TinyClips/CaptureManager.swift
@@ -596,6 +596,13 @@ class CaptureManager: ObservableObject {
         scrollingCapturePanel = panel
         panel.show(at: scrollingCapturePanelPosition)
 
+        dismissRegionIndicator()
+        if CaptureSettings.shared.showRegionIndicator {
+            let indicator = RegionIndicatorPanel(region: region)
+            indicator.show()
+            regionIndicatorPanel = indicator
+        }
+
         Task {
             do {
                 try await session.start(region: region)
@@ -648,6 +655,7 @@ class CaptureManager: ObservableObject {
         }
         scrollingCapturePanel?.dismiss()
         scrollingCapturePanel = nil
+        dismissRegionIndicator()
         scrollingCaptureSession = nil
         isStoppingScrollingCapture = false
         isScreenshotCaptureInProgress = false

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -222,6 +222,29 @@ final class CaptureMathTests: XCTestCase {
         XCTAssertLessThanOrEqual(outputHeight, PanoramaCaptureLimits.default.maxOutputHeight)
     }
 
+    func testPanoramaPrefersSmallestShiftOnRepeatingContent() throws {
+        // A page of repeating rows aliases at shift + N * period; picking a later
+        // alias duplicates rows that are already committed.
+        let first = repeatingPanoramaFrame(globalStartRow: 0, period: 30)
+        let second = repeatingPanoramaFrame(globalStartRow: 20, period: 30)
+
+        let result = try PanoramaStitcher(limits: panoramaLimits()).stitch([first, second])
+
+        XCTAssertEqual(result.frameCount, 2)
+        XCTAssertEqual(result.outputHeight, 120)
+    }
+
+    func testPanoramaAlignsSmallScrollSteps() throws {
+        // Slow scrolling advances only a few pixels per frame, which must not be
+        // rounded up to a larger shift.
+        let first = panoramaFrame(globalStartRow: 0)
+        let second = panoramaFrame(globalStartRow: 4)
+
+        let result = try PanoramaStitcher(limits: panoramaLimits()).stitch([first, second])
+
+        XCTAssertEqual(result.outputHeight, 104)
+    }
+
     func testTimelineExcludesCompletedAndActivePauses() {
         let timeline = RecordingTimelineMath.timelineTime(
             now: CMTime(seconds: 20, preferredTimescale: 600),
@@ -259,6 +282,55 @@ final class CaptureMathTests: XCTestCase {
                 let value = isFooter
                     ? UInt8(32)
                     : UInt8(((globalStartRow + y) * 7 + x * 13) % 251)
+                pixels[index] = value
+                pixels[index + 1] = value
+                pixels[index + 2] = value
+                pixels[index + 3] = 255
+            }
+        }
+        return PanoramaFrame(width: width, height: height, pixels: pixels)
+    }
+
+    func testPanoramaAlignsPeriodicContentAcrossShiftSizes() {
+        let width = 320
+        let height = 900
+        let period = 100
+        func makeFrame(globalStartRow: Int) -> PanoramaFrame {
+            var pixels = [UInt8](repeating: 255, count: width * height * 4)
+            for y in 0..<height {
+                let row = globalStartRow + y
+                let band = (row % period) < period / 2 ? 40 : 210
+                for x in 0..<width {
+                    let index = (y * width + x) * 4
+                    let value = UInt8(min(255, max(0, band + ((row % 7) * 3) + ((x % 11) * 2))))
+                    pixels[index] = value
+                    pixels[index + 1] = value
+                    pixels[index + 2] = value
+                    pixels[index + 3] = 255
+                }
+            }
+            return PanoramaFrame(width: width, height: height, pixels: pixels)
+        }
+
+        let base = makeFrame(globalStartRow: 0)
+        for trueShift in [6, 37, 120, 480] {
+            let alignment = PanoramaAccumulator.estimateVerticalShift(
+                previous: base,
+                current: makeFrame(globalStartRow: trueShift)
+            )
+            XCTAssertEqual(alignment?.shift, trueShift, "shift \(trueShift) misaligned")
+        }
+    }
+
+    private func repeatingPanoramaFrame(globalStartRow: Int, period: Int) -> PanoramaFrame {
+        let width = 40
+        let height = 100
+        var pixels = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            let row = (globalStartRow + y) % period
+            for x in 0..<width {
+                let index = (y * width + x) * 4
+                let value = UInt8((row * 8 + x * 3) % 251)
                 pixels[index] = value
                 pixels[index + 1] = value
                 pixels[index + 2] = value


### PR DESCRIPTION
Follow-up to #248. After testing the merged scrolling capture, stitched panoramas were repeating whole rows of content (visible as the same card row appearing three or four times), and the red region outline that every other region-based capture flow shows was missing while scrolling capture was running.

## Duplicated rows

The stitcher was over-estimating how far the page had scrolled between frames, so each append re-committed rows that were already in the output. Three things caused it:

- `minimumShift` was `height / 40`, which is roughly 45 px on a Retina frame. A slow scroll simply could not be represented, so the estimator was forced to overshoot.
- The candidate search stepped in `height / 120` (~15 px) increments and never landed on the true shift.
- It selected the global lowest score. On periodic layouts like a list of cards, that reliably aliases onto `trueShift + N * cardPeriod`.

The estimator now precomputes a per-row luma signature for each frame and scores every candidate shift from 2 px upward at single-pixel resolution using Accelerate (`vDSP_vsub` + `vDSP_svemg`). Rather than taking the global minimum, it walks candidates from smallest to largest and accepts the first local minimum whose score falls inside an acceptance band around the best score, confirming it against real pixels before committing. Preferring the smallest acceptable shift is what breaks the periodic-content aliasing; the pixel verification is what keeps the row signatures from matching unrelated rows that happen to share an average brightness.

Verified at real Retina scale (2400x1800 with periodic content): shifts of 6, 37, 120, and 480 px are now each returned exactly. The vDSP scan also took alignment from 180 ms to 2.6 ms per frame in a Debug build, so the finer search is comfortably faster than the old coarse one and keeps up with the 12 fps sampler.

## Region outline

`startScrollingCapture` now shows `RegionIndicatorPanel` when the "show region indicator" setting is on, and `finishScrollingCapture` dismisses it. The indicator is click-through and draws outside the capture bounds, so it does not interfere with scrolling or appear in the output.

## Notes for review

- Perfectly periodic content is mathematically ambiguous, so the smallest-shift preference is a heuristic that relies on real pages carrying some non-repeating detail. The new test's generator deliberately includes a non-repeating term to model that.
- Pixel verification is capped at 6 attempts so a frame that is not a scroll of its predecessor does not burn CPU before being rejected.

## Validation

- `xcodebuild test` on the `TinyClips` scheme: passing, including a new regression test covering periodic content across small and large shifts.
- Debug builds of both `TinyClips` and `TinyClipsMAS`: succeeding.

Fixes: #222