### PR TITLE
Add Microsoft Store publishing workflow

### DIFF
--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -1,0 +1,149 @@
+name: Windows Store Publish
+
+on:
+  push:
+    tags:
+      - 'v*-windows'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Windows release tag (for example, v1.6.1-windows)'
+        required: true
+        type: string
+      publish:
+        description: 'Publish the package after the protected-environment approval'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-store-publish
+  cancel-in-progress: false
+
+env:
+  APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
+
+jobs:
+  package:
+    name: Package Microsoft Store upload
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Set release version
+        shell: pwsh
+        run: |
+          $tag = if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            "${{ inputs.tag }}"
+          } else {
+            "${{ github.ref_name }}"
+          }
+
+          if ($tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:\.(?<revision>\d+))?-windows$') {
+            throw "Windows release tags must look like v1.2.3-windows or v1.2.3.4-windows. Got '$tag'."
+          }
+
+          $revision = if ($Matches.revision) { $Matches.revision } else { "0" }
+          "PACKAGE_VERSION=$($Matches.base).$revision" >> $env:GITHUB_ENV
+
+      - name: Stamp Store package manifest version
+        shell: pwsh
+        run: |
+          $manifestPath = "windows/src/TinyClips.App/Package.Store.appxmanifest"
+          $content = Get-Content $manifestPath -Raw
+          $content = $content -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$env:PACKAGE_VERSION`${2}"
+          Set-Content -Path $manifestPath -Value $content -Encoding utf8
+
+      - name: Build Store upload package
+        shell: pwsh
+        run: |
+          $packageDir = Join-Path (Resolve-Path ".") "artifacts/store/"
+          New-Item -ItemType Directory -Force -Path $packageDir | Out-Null
+
+          dotnet build $env:APP_PROJECT `
+            -c Release `
+            -p:Platform=x64 `
+            -p:TinyClipsStoreBuild=true `
+            -p:SelfContained=false `
+            -p:WindowsAppSDKSelfContained=false `
+            -p:EnableMsixTooling=true `
+            -p:GenerateAppxPackageOnBuild=true `
+            -p:AppxPackageDir=$packageDir `
+            -p:AppxBundle=Always `
+            -p:AppxBundlePlatforms="x64|ARM64" `
+            -p:UapAppxPackageBuildMode=StoreUpload `
+            -p:AppxPackageSigningEnabled=false `
+            -p:AppxSymbolPackageEnabled=false `
+            -v:minimal
+          if ($LASTEXITCODE -ne 0) { throw "Microsoft Store package build failed." }
+
+          $upload = Get-ChildItem $packageDir -Recurse -Filter *.msixupload | Select-Object -First 1
+          if (-not $upload) {
+            throw "The Store build did not produce an .msixupload package."
+          }
+
+          Copy-Item $upload.FullName "artifacts/store/TinyClips-$env:PACKAGE_VERSION.msixupload" -Force
+
+      - name: Upload Store package
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-store-package
+          path: artifacts/store/TinyClips-*.msixupload
+          if-no-files-found: error
+
+  publish:
+    name: Submit to Microsoft Store
+    needs: package
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: windows-latest
+    environment: microsoft-store
+
+    steps:
+      - name: Download Store package
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-store-package
+          path: artifacts/store
+
+      - name: Validate publishing configuration
+        shell: pwsh
+        env:
+          STORE_PRODUCT_ID: ${{ vars.MICROSOFT_STORE_PRODUCT_ID }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:STORE_PRODUCT_ID)) {
+            throw "Set the MICROSOFT_STORE_PRODUCT_ID repository variable before enabling Store publication."
+          }
+
+      - name: Setup Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.4
+
+      - name: Configure Microsoft Store Developer CLI
+        shell: pwsh
+        run: |
+          msstore reconfigure `
+            --tenantId "${{ secrets.PARTNER_CENTER_TENANT_ID }}" `
+            --sellerId "${{ secrets.PARTNER_CENTER_SELLER_ID }}" `
+            --clientId "${{ secrets.PARTNER_CENTER_CLIENT_ID }}" `
+            --clientSecret "${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}"
+
+      - name: Publish Store package
+        shell: pwsh
+        env:
+          STORE_PRODUCT_ID: ${{ vars.MICROSOFT_STORE_PRODUCT_ID }}
+        run: |
+          $upload = Get-ChildItem artifacts/store -Filter *.msixupload | Select-Object -First 1
+          if (-not $upload) {
+            throw "The downloaded Store package is missing."
+          }
+
+          msstore publish "." --inputFile $upload.FullName --appId $env:STORE_PRODUCT_ID

--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -119,9 +119,24 @@ jobs:
         shell: pwsh
         env:
           STORE_PRODUCT_ID: ${{ vars.MICROSOFT_STORE_PRODUCT_ID }}
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:STORE_PRODUCT_ID)) {
-            throw "Set the MICROSOFT_STORE_PRODUCT_ID repository variable before enabling Store publication."
+          $requiredValues = @{
+            "MICROSOFT_STORE_PRODUCT_ID repository variable" = $env:STORE_PRODUCT_ID
+            "PARTNER_CENTER_TENANT_ID environment secret" = $env:PARTNER_CENTER_TENANT_ID
+            "PARTNER_CENTER_SELLER_ID environment secret" = $env:PARTNER_CENTER_SELLER_ID
+            "PARTNER_CENTER_CLIENT_ID environment secret" = $env:PARTNER_CENTER_CLIENT_ID
+            "PARTNER_CENTER_CLIENT_SECRET environment secret" = $env:PARTNER_CENTER_CLIENT_SECRET
+          }
+          $missing = $requiredValues.GetEnumerator() |
+            Where-Object { [string]::IsNullOrWhiteSpace($_.Value) } |
+            ForEach-Object Key
+
+          if ($missing) {
+            throw "Configure the following before enabling Store publication: $($missing -join ', ')."
           }
 
       - name: Setup Microsoft Store Developer CLI

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,11 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Internal
+- **Microsoft Store release path** — Store builds now use the Partner Center-assigned package
+  identity, and a protected GitHub Actions workflow produces and submits the Store upload package.
+  The Windows Store listing pack documents the submission copy, screenshots, and compliance answers.
+
 ### Changed
 - **Refreshed Clips Library** — The wider media gallery wraps captures into a compact responsive three-column grid. Grid cards and list rows keep Open and Copy visible, with labeled More menus for Reveal, Delete, and Uploadcare actions. A macOS-inspired Sort & Filter flyout adds persisted type and date filters (Today, This week, and This month) without crowding the toolbar.
 - **Clearer Uploadcare setup** — Settings now explains that Uploadcare uses your own account and links directly to the existing account and API-key page.

--- a/windows/README.md
+++ b/windows/README.md
@@ -118,3 +118,6 @@ automation review does not replace the documented hands-on results.
 - **Microsoft Store (planned):** Store auto-update. Feature set matches Direct; no Windows Pro tier.
 
 See the plan for the full phased roadmap, packaging, and signing details.
+
+For the Microsoft Store listing copy, screenshot plan, compliance answers, and protected CI/CD
+setup, see [docs/microsoft-store-listing.md](docs/microsoft-store-listing.md).

--- a/windows/docs/microsoft-store-listing.md
+++ b/windows/docs/microsoft-store-listing.md
@@ -1,0 +1,134 @@
+# Tiny Clips for Windows - Microsoft Store Listing
+
+Use this file as the source of truth for the Microsoft Store listing and first submission of the
+Windows app. It complements the macOS-only `docs/app-store-connect-metadata.md`.
+
+## App identity
+
+| Field | Value |
+| --- | --- |
+| Product name | Tiny Clips |
+| Package identity | `23875RefractoredLLC.TinyClips` |
+| Package family name | `23875RefractoredLLC.TinyClips_jcspp7mzn01xr` |
+| Publisher | Refractored LLC |
+| Primary category | Photo & video |
+| Secondary category | Productivity |
+| Privacy policy | https://tinyclips.app/privacy.html |
+| Support URL | https://github.com/jamesmontemagno/tiny-clips/issues |
+| Marketing URL | https://github.com/jamesmontemagno/tiny-clips |
+| Copyright | Copyright (c) 2026 Refractored LLC |
+
+## en-US listing copy
+
+### Short description
+
+Fast screenshots, video recordings, and GIFs from your Windows system tray.
+
+### Description
+
+Tiny Clips is a lightweight Windows screen-capture tool that is always ready from the system tray.
+
+Capture exactly what you need:
+
+- Screenshots of a region, screen, or window
+- Screen recordings as H.264 MP4 video
+- Short animated GIF captures
+
+Built for speed and focus:
+
+- Keyboard shortcuts for screenshot, video, GIF, and stop-recording actions
+- Optional countdown and region outline before capture
+- Microphone, system-audio, webcam, mouse-click, and branding-overlay controls
+- Screenshot editing plus video and GIF trimming after capture
+- A Clips Library for browsing, opening, copying, and sharing saved captures
+- Configurable folders, formats, quality, themes, notifications, and launch-at-login
+
+Tiny Clips is designed for developers, creators, and anyone who needs to quickly create and share
+visual context without a complicated workflow.
+
+### Search terms
+
+screen capture,screen recorder,screenshot,video recorder,gif recorder,screen recording,productivity
+
+### Release notes
+
+Copy the matching version section from `windows/CHANGELOG.md`. Keep the Store "What's new" text
+focused on user-visible changes and omit internal refactoring notes.
+
+## Screenshot set
+
+Store screenshots must be captured from the released Windows package, with no development tools,
+desktop clutter, or unrelated personal content visible. Capture at least 1366 x 768 pixels;
+1920 x 1080 is preferred. Use the same light or dark theme throughout the first set.
+
+| File | Required content | Capture notes |
+| --- | --- | --- |
+| `01-tray-capture-menu.png` | Tray popup with Screenshot, Video, and GIF actions | Open the tray popup against a clean desktop. |
+| `02-region-picker.png` | Region / Screen / Window picker | Show the target-selection options and countdown control. |
+| `03-screenshot-editor.png` | Screenshot editor with a small, realistic annotation | Use non-sensitive sample content. |
+| `04-video-recording.png` | Recording indicator and selected-region outline | Show elapsed time and the Stop action. |
+| `05-video-trimmer.png` | Video trimmer after a recording | Include the trim range and playback controls. |
+| `06-clips-library.png` | Clips Library grid or list | Show several non-sensitive captures and visible actions. |
+| `07-settings.png` | Settings with capture options | Show the native Windows styling and useful controls. |
+
+Use `windows/docs/store-assets/` as the working directory for the exported PNGs. Do not commit
+screenshots containing personal data, API keys, file paths, or third-party content without rights.
+
+## Store assets
+
+The package logo assets are already in `windows/src/TinyClips.App/Assets/`. Upload the Store-logo
+variants Partner Center requests and verify they render correctly in both light and dark contexts.
+The Store listing screenshots are separate from the package tile assets.
+
+## Compliance answers
+
+### Privacy
+
+- Data collection: No. Tiny Clips stores capture preferences and optional local analytics on the
+  device. It does not use an account, advertising ID, or telemetry service.
+- Tracking: No.
+- Screen, microphone, webcam, and system-audio content are captured only after the user starts a
+  recording. Captures are saved locally unless the user configures their own Uploadcare account.
+
+Recheck these statements whenever analytics, account, cloud, or crash-reporting behavior changes.
+
+### Capability justifications
+
+**runFullTrust:** Tiny Clips is a desktop screen-capture utility. Full trust is required for Windows
+Graphics Capture, WASAPI system-audio capture, global keyboard shortcuts, tray integration,
+desktop capture overlays, and saving user-selected capture files.
+
+**microphone:** Tiny Clips records microphone audio only when the user explicitly enables it for a
+video capture. Audio is written into that local recording and is never collected by the app.
+
+**webcam:** Tiny Clips includes an optional picture-in-picture webcam overlay. Camera access occurs
+only when the user enables the webcam for a video capture.
+
+### Ratings and review notes
+
+- Complete the IARC questionnaire truthfully. Tiny Clips has no user-generated public content,
+  advertising, gambling, mature content, or unrestricted web browsing.
+- The app starts in the system tray and has no main window at launch.
+- No account, login, or in-app purchase is required.
+- Reviewers should test Screenshot, Record Video, and Record GIF from the tray popup. Screen
+  capture permissions are requested by Windows when required; microphone and webcam are optional.
+
+## First submission and CI/CD setup
+
+1. Complete every Partner Center listing, privacy, capability, age-rating, and pricing section,
+   then manually submit the first package for certification. The Microsoft Store Developer CLI
+   supports automated updates only after the free product is live.
+2. Create a Microsoft Entra application, add it under Partner Center **User management** with the
+   **Manager** role, and add these GitHub environment secrets to the protected
+   `microsoft-store` environment:
+   `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_SELLER_ID`, `PARTNER_CENTER_CLIENT_ID`, and
+   `PARTNER_CENTER_CLIENT_SECRET`.
+3. Add the Store Product ID as the repository variable `MICROSOFT_STORE_PRODUCT_ID`. It is not the
+   package identity or package family name; retrieve it with `msstore apps list` after configuring
+   the CLI.
+4. Protect the `microsoft-store` environment with required reviewers. The
+   `windows-store-publish.yml` workflow packages every `v*-windows` tag and pauses before
+   submission. A manual dispatch can package without publishing, or publish after approval.
+
+The workflow builds the Store flavor with its Store-assigned identity and submits the unsigned
+`.msixupload`; Microsoft Store signs the package and delivers updates.

--- a/windows/src/TinyClips.App/Package.Store.appxmanifest
+++ b/windows/src/TinyClips.App/Package.Store.appxmanifest
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap5 rescap">
+
+  <Identity
+    Name="23875RefractoredLLC.TinyClips"
+    Publisher="CN=995C4AD9-3B22-4B61-B30F-3EAB23CDAEAE"
+    Version="1.6.0.0" />
+
+  <Properties>
+    <DisplayName>Tiny Clips</DisplayName>
+    <PublisherDisplayName>Refractored LLC</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.22000.0" MaxVersionTested="10.0.26226.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22000.0" MaxVersionTested="10.0.26226.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="Tiny Clips"
+        Description="Capture screenshots, video, and GIFs of any screen region."
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square71x71Logo="Assets\SmallTile.png" Square310x310Logo="Assets\LargeTile.png"/>
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap5:Extension
+          Category="windows.startupTask"
+          Executable="TinyClips.App.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <uap5:StartupTask
+            TaskId="TinyClipsLaunchAtLogin"
+            Enabled="false"
+            DisplayName="Tiny Clips" />
+        </uap5:Extension>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="image">
+            <uap:DisplayName>Tiny Clips Image</uap:DisplayName>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.png</uap:FileType>
+              <uap:FileType>.jpg</uap:FileType>
+              <uap:FileType>.jpeg</uap:FileType>
+              <uap:FileType>.webp</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <DeviceCapability Name="microphone" />
+    <DeviceCapability Name="webcam" />
+  </Capabilities>
+</Package>

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -38,6 +38,11 @@
     <DefineConstants>$(DefineConstants);TINYCLIPS_STORE_BUILD</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TinyClipsStoreBuild)' == 'true'">
+    <!-- Keep the Store-assigned identity separate from the direct/winget package identity. -->
+    <AppxManifest Include="Package.Store.appxmanifest" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />


### PR DESCRIPTION
## Summary
- add a Store-specific MSIX manifest using the Partner Center identity
- package and submit Store uploads through a protected Microsoft Store environment
- add Windows Store listing copy, screenshot requirements, and compliance guidance

## Validation
- dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64`n- dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64 -p:TinyClipsStoreBuild=true`n- dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Debug`n- verified the Store upload bundle contains the Store identity plus x64 and ARM64 packages