### PR TITLE
Prepare Windows v1.7.0 release

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,8 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.7.0-windows] - 2026-08-13
+
 ### Internal
 - **Microsoft Store release path** — Store builds now use the Partner Center-assigned package
   identity, and a protected GitHub Actions workflow produces and submits the Store upload package.


### PR DESCRIPTION
## Summary
- version the accumulated Windows release notes as 1.7.0-windows`n- enable the Windows release workflow to publish matching GitHub Release and winget notes

This must merge before creating the 1.7.0-windows tag.