### PR TITLE
Replace export alignment pickers with 3x3 grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - The macOS screenshot editor now supports 25%–400% fit-relative zoom with accessible controls, percentage presets, Command shortcuts, focal-point pinch or Command-wheel zoom, scrollbars, trackpad panning, and Space-drag navigation without changing exported image pixels.
+- The macOS screenshot editor now uses a labeled 3×3 image-alignment grid for every export frame placement combination.
 - macOS now persists the concrete per-type capture folder defaults, so custom-folder settings are populated with Pictures/TinyClips or Movies/TinyClips before a folder is selected.
 - macOS capture folders now default to Pictures/TinyClips for screenshots and Movies/TinyClips for videos and GIFs. Turning off "Use default folders" reveals separate folders for screenshots, videos, and GIFs.
 - macOS teleprompter preview now starts only on demand with a reliable Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, small/medium/large text-size and panel-height presets, and plain-text transcript file loading up to 1 MB.

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -302,6 +302,84 @@ private struct ZoomVerticalScrollBar: View {
     }
 }
 
+private struct ExportAlignmentGrid: View {
+    @Binding var horizontalAlignment: ExportHorizontalAlignment
+    @Binding var verticalAlignment: ExportVerticalAlignment
+    let isHorizontalAlignmentAvailable: Bool
+    let isVerticalAlignmentAvailable: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Image alignment")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.fixed(30), spacing: 4), count: 3),
+                spacing: 4
+            ) {
+                ForEach(ExportVerticalAlignment.allCases) { vertical in
+                    ForEach(ExportHorizontalAlignment.allCases) { horizontal in
+                        alignmentButton(horizontal: horizontal, vertical: vertical)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func alignmentButton(
+        horizontal: ExportHorizontalAlignment,
+        vertical: ExportVerticalAlignment
+    ) -> some View {
+        let isSelected = horizontalAlignment == horizontal && verticalAlignment == vertical
+        let isUnavailable = (!isHorizontalAlignmentAvailable && horizontal != horizontalAlignment)
+            || (!isVerticalAlignmentAvailable && vertical != verticalAlignment)
+
+        return Button {
+            horizontalAlignment = horizontal
+            verticalAlignment = vertical
+        } label: {
+            ZStack(alignment: previewAlignment(horizontal: horizontal, vertical: vertical)) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.secondary.opacity(0.14))
+                    .frame(width: 20, height: 16)
+
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(isSelected ? Color.accentColor : .secondary)
+                    .frame(width: 9, height: 6)
+                    .padding(2)
+            }
+            .frame(width: 30, height: 30)
+            .background(isSelected ? Color.accentColor.opacity(0.16) : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(isUnavailable)
+        .help("\(vertical.label) \(horizontal.label)")
+        .accessibilityLabel("\(vertical.label) \(horizontal.label) image alignment")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+
+    private func previewAlignment(
+        horizontal: ExportHorizontalAlignment,
+        vertical: ExportVerticalAlignment
+    ) -> Alignment {
+        switch (horizontal, vertical) {
+        case (.leading, .top): return .topLeading
+        case (.center, .top): return .top
+        case (.trailing, .top): return .topTrailing
+        case (.leading, .center): return .leading
+        case (.center, .center): return .center
+        case (.trailing, .center): return .trailing
+        case (.leading, .bottom): return .bottomLeading
+        case (.center, .bottom): return .bottom
+        case (.trailing, .bottom): return .bottomTrailing
+        }
+    }
+}
+
 // MARK: - Editor View
 
 struct ScreenshotEditorView: View {
@@ -837,26 +915,12 @@ struct ScreenshotEditorView: View {
             }
             .accessibilityHint("Sets the export frame without stretching the screenshot.")
 
-            VStack(alignment: .leading, spacing: 8) {
-                Picker("Horizontal", selection: $viewModel.horizontalExportAlignment) {
-                    ForEach(ExportHorizontalAlignment.allCases) { alignment in
-                        Text(alignment.label).tag(alignment)
-                    }
-                }
-                .labelsHidden()
-                .disabled(!viewModel.hasHorizontalExportFrameSpace)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                Picker("Vertical", selection: $viewModel.verticalExportAlignment) {
-                    ForEach(ExportVerticalAlignment.allCases) { alignment in
-                        Text(alignment.label).tag(alignment)
-                    }
-                }
-                .labelsHidden()
-                .disabled(!viewModel.hasVerticalExportFrameSpace)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .accessibilityElement(children: .contain)
+            ExportAlignmentGrid(
+                horizontalAlignment: $viewModel.horizontalExportAlignment,
+                verticalAlignment: $viewModel.verticalExportAlignment,
+                isHorizontalAlignmentAvailable: viewModel.hasHorizontalExportFrameSpace,
+                isVerticalAlignmentAvailable: viewModel.hasVerticalExportFrameSpace
+            )
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Image corners: \(Int(viewModel.canvasCornerRadius)) px")

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -142,6 +142,45 @@ final class CaptureMathTests: XCTestCase {
         XCTAssertEqual(clamped.height, 30)
     }
 
+    func testExportFrameLayoutPlacesImageAlongAvailableAxis() {
+        let horizontalOrigins: [ExportHorizontalAlignment: CGPoint] = [
+            .leading: CGPoint(x: 10, y: 10),
+            .center: CGPoint(x: 35, y: 10),
+            .trailing: CGPoint(x: 60, y: 10),
+        ]
+        let verticalOrigins: [ExportVerticalAlignment: CGPoint] = [
+            .top: CGPoint(x: 10, y: 10),
+            .center: CGPoint(x: 10, y: 35),
+            .bottom: CGPoint(x: 10, y: 60),
+        ]
+
+        for horizontal in ExportHorizontalAlignment.allCases {
+            let layout = ExportFrameLayout.make(
+                imageSize: CGSize(width: 50, height: 100),
+                padding: 10,
+                preset: .square,
+                horizontalAlignment: horizontal,
+                verticalAlignment: .top
+            )
+
+            XCTAssertEqual(layout.frameSize, CGSize(width: 120, height: 120))
+            XCTAssertEqual(layout.imageRect.origin, horizontalOrigins[horizontal])
+        }
+
+        for vertical in ExportVerticalAlignment.allCases {
+            let layout = ExportFrameLayout.make(
+                imageSize: CGSize(width: 100, height: 50),
+                padding: 10,
+                preset: .square,
+                horizontalAlignment: .leading,
+                verticalAlignment: vertical
+            )
+
+            XCTAssertEqual(layout.frameSize, CGSize(width: 120, height: 120))
+            XCTAssertEqual(layout.imageRect.origin, verticalOrigins[vertical])
+        }
+    }
+
     func testPanoramaStitchesKnownVerticalShift() throws {
         let first = panoramaFrame(globalStartRow: 0)
         let second = panoramaFrame(globalStartRow: 20)


### PR DESCRIPTION
The screenshot editor's separate unlabeled alignment pickers were ambiguous in the narrow inspector. A single placement control makes the available positions understandable at a glance.

## Changes
- Replace the hidden-label Horizontal and Vertical pickers with a labeled 3x3 image-alignment grid.
- Show each top/center/bottom and left/center/right combination with selected state, help text, and VoiceOver labels.
- Preserve axis availability rules when a frame has no extra space on one axis.
- Add deterministic export-placement coverage and update the macOS changelog.

## Validation
- `xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Built `TinyClips` and `TinyClipsMAS` Debug schemes without code signing.