### PR TITLE
Make screenshot export alignment grid interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - The macOS screenshot editor now supports 25%–400% fit-relative zoom with accessible controls, percentage presets, Command shortcuts, focal-point pinch or Command-wheel zoom, scrollbars, trackpad panning, and Space-drag navigation without changing exported image pixels.
-- The macOS screenshot editor now uses a labeled 3×3 image-alignment grid for every export frame placement combination.
+- The macOS screenshot editor now uses a labeled 3×3 image-alignment grid with every export frame placement combination directly selectable.
 - macOS now persists the concrete per-type capture folder defaults, so custom-folder settings are populated with Pictures/TinyClips or Movies/TinyClips before a folder is selected.
 - macOS capture folders now default to Pictures/TinyClips for screenshots and Movies/TinyClips for videos and GIFs. Turning off "Use default folders" reveals separate folders for screenshots, videos, and GIFs.
 - macOS teleprompter preview now starts only on demand with a reliable Start/Stop control, a speed slider that supports 0–100 pt/s in 1 pt/s increments with a larger interaction target, small/medium/large text-size and panel-height presets, and plain-text transcript file loading up to 1 MB.

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -205,16 +205,6 @@ class ScreenshotEditorViewModel: ObservableObject {
         )
     }
 
-    var hasHorizontalExportFrameSpace: Bool {
-        let layout = exportLayout(for: exportImageSize)
-        return layout.frameSize.width > exportImageSize.width + max(0, canvasPadding) * 2
-    }
-
-    var hasVerticalExportFrameSpace: Bool {
-        let layout = exportLayout(for: exportImageSize)
-        return layout.frameSize.height > exportImageSize.height + max(0, canvasPadding) * 2
-    }
-
     /// Returns the text size for an image rendered at `renderedImageWidth`.
     ///
     /// Pass points for the SwiftUI preview and pixels for bitmap export so the

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -305,8 +305,6 @@ private struct ZoomVerticalScrollBar: View {
 private struct ExportAlignmentGrid: View {
     @Binding var horizontalAlignment: ExportHorizontalAlignment
     @Binding var verticalAlignment: ExportVerticalAlignment
-    let isHorizontalAlignmentAvailable: Bool
-    let isVerticalAlignmentAvailable: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -324,6 +322,8 @@ private struct ExportAlignmentGrid: View {
                     }
                 }
             }
+            .padding(4)
+            .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
         }
         .accessibilityElement(children: .contain)
     }
@@ -333,30 +333,23 @@ private struct ExportAlignmentGrid: View {
         vertical: ExportVerticalAlignment
     ) -> some View {
         let isSelected = horizontalAlignment == horizontal && verticalAlignment == vertical
-        let isUnavailable = (!isHorizontalAlignmentAvailable && horizontal != horizontalAlignment)
-            || (!isVerticalAlignmentAvailable && vertical != verticalAlignment)
 
         return Button {
             horizontalAlignment = horizontal
             verticalAlignment = vertical
         } label: {
-            ZStack(alignment: previewAlignment(horizontal: horizontal, vertical: vertical)) {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(.secondary.opacity(0.14))
-                    .frame(width: 20, height: 16)
-
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(isSelected ? Color.accentColor : .secondary)
-                    .frame(width: 9, height: 6)
-                    .padding(2)
-            }
+            RoundedRectangle(cornerRadius: 5)
+            .fill(isSelected ? Color.accentColor : .secondary.opacity(0.14))
             .frame(width: 30, height: 30)
-            .background(isSelected ? Color.accentColor.opacity(0.16) : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .contentShape(RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(isSelected ? .white : .secondary)
+                    .frame(width: 10, height: 6)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: previewAlignment(horizontal: horizontal, vertical: vertical))
+                    .padding(5)
+            }
         }
         .buttonStyle(.plain)
-        .disabled(isUnavailable)
         .help("\(vertical.label) \(horizontal.label)")
         .accessibilityLabel("\(vertical.label) \(horizontal.label) image alignment")
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
@@ -917,9 +910,7 @@ struct ScreenshotEditorView: View {
 
             ExportAlignmentGrid(
                 horizontalAlignment: $viewModel.horizontalExportAlignment,
-                verticalAlignment: $viewModel.verticalExportAlignment,
-                isHorizontalAlignmentAvailable: viewModel.hasHorizontalExportFrameSpace,
-                isVerticalAlignmentAvailable: viewModel.hasVerticalExportFrameSpace
+                verticalAlignment: $viewModel.verticalExportAlignment
             )
 
             VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
The first alignment grid left most placement choices disabled when a frame expanded on only one axis, making the new control look like a few inert icons.

## Changes
- Make all nine image-alignment positions directly selectable.
- Render the control as a clear 3x3 grid of placement cells rather than nested miniature previews.
- Retain selected-state feedback, hover help, and VoiceOver labels.

## Validation
- `xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Built `TinyClips` and `TinyClipsMAS` Debug schemes without code signing.