### PR TITLE
Show all screenshot alignment grid rows

### DIFF
--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -312,18 +312,18 @@ private struct ExportAlignmentGrid: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.fixed(30), spacing: 4), count: 3),
-                spacing: 4
-            ) {
+            VStack(spacing: 4) {
                 ForEach(ExportVerticalAlignment.allCases) { vertical in
-                    ForEach(ExportHorizontalAlignment.allCases) { horizontal in
-                        alignmentButton(horizontal: horizontal, vertical: vertical)
+                    HStack(spacing: 4) {
+                        ForEach(ExportHorizontalAlignment.allCases) { horizontal in
+                            alignmentButton(horizontal: horizontal, vertical: vertical)
+                        }
                     }
                 }
             }
             .padding(4)
             .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            .fixedSize()
         }
         .accessibilityElement(children: .contain)
     }


### PR DESCRIPTION
The interactive alignment grid could collapse to only its first row in the screenshot editor sidebar, leaving the remaining placement choices hidden.

## Changes
- Replace the clipped LazyVGrid with explicit fixed 3x3 rows.
- Give the grid container a fixed size so all nine alignment positions remain visible.

## Validation
- `xcodebuild test -project mac/TinyClips.xcodeproj -scheme TinyClips -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- Built `TinyClips` and `TinyClipsMAS` Debug schemes without code signing.