### PR TITLE
Fix screenshot editor crop alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - macOS Video and GIF settings now let you disable the default behavior that keeps the display awake while recording.
 
 ### Fixed
+- Fixed macOS screenshot editor crops to apply immediately and rebase the annotation canvas, so annotations added after cropping retain their intended position and size. Applying a crop now flattens existing annotations into the image, matching Windows.
 - Fixed macOS scrolling capture stitching duplicated rows of content by aligning frames with per-row signatures at single-pixel resolution and preferring the smallest matching scroll distance, which also handles slow scrolls and repeating layouts such as card lists.
 - Fixed the macOS scrolling capture not showing the red region outline while it records.
 - Fixed macOS scrolling capture running out of memory on modest regions by stitching frames incrementally, and guardrails now stop and save the panorama captured so far instead of discarding it.

--- a/mac/TinyClips.xcodeproj/project.pbxproj
+++ b/mac/TinyClips.xcodeproj/project.pbxproj
@@ -791,7 +791,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tinyclips.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -821,7 +821,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tinyclips.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -849,7 +849,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.refractored.tinyclips;
 				PRODUCT_NAME = "Tiny Clips";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) APPSTORE";
@@ -878,7 +878,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.refractored.tinyclips;
 				PRODUCT_NAME = "Tiny Clips";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) APPSTORE";

--- a/mac/TinyClips/Info-MAS.plist
+++ b/mac/TinyClips/Info-MAS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6</string>
+	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/mac/TinyClips/Info.plist
+++ b/mac/TinyClips/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6</string>
+	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -332,11 +332,15 @@ enum ScreenshotEditorCropMath {
         let top = max(0, min(imageSize.height, normalizedRect.minY * imageSize.height))
         let right = max(0, min(imageSize.width, normalizedRect.maxX * imageSize.width))
         let bottom = max(0, min(imageSize.height, normalizedRect.maxY * imageSize.height))
+        let width = abs(right - left)
+        let height = abs(bottom - top)
+        guard width > 0, height > 0 else { return nil }
+
         let rect = CGRect(
             x: min(left, right),
             y: min(top, bottom),
-            width: abs(right - left),
-            height: abs(bottom - top)
+            width: width,
+            height: height
         ).integral
 
         guard rect.width >= 1, rect.height >= 1 else { return nil }

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -324,6 +324,26 @@ enum ScreenshotEditorZoomMath {
     }
 }
 
+enum ScreenshotEditorCropMath {
+    static func pixelRect(for normalizedRect: CGRect, imageSize: CGSize) -> CGRect? {
+        guard imageSize.width > 0, imageSize.height > 0 else { return nil }
+
+        let left = max(0, min(imageSize.width, normalizedRect.minX * imageSize.width))
+        let top = max(0, min(imageSize.height, normalizedRect.minY * imageSize.height))
+        let right = max(0, min(imageSize.width, normalizedRect.maxX * imageSize.width))
+        let bottom = max(0, min(imageSize.height, normalizedRect.maxY * imageSize.height))
+        let rect = CGRect(
+            x: min(left, right),
+            y: min(top, bottom),
+            width: abs(right - left),
+            height: abs(bottom - top)
+        ).integral
+
+        guard rect.width >= 1, rect.height >= 1 else { return nil }
+        return rect
+    }
+}
+
 struct ExportBackgroundPreset: Identifiable {
     let id: String
     let label: String

--- a/mac/TinyClips/Views/ScreenshotEditorScene.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorScene.swift
@@ -9,12 +9,14 @@ struct ScreenshotEditorCommandActions {
     let redo: () -> Void
     let copy: () -> Void
     let clearAnnotations: () -> Void
+    let applyCrop: () -> Void
     let zoomIn: () -> Void
     let zoomOut: () -> Void
     let fitZoom: () -> Void
     let canUndo: Bool
     let canRedo: Bool
     let hasAnnotations: Bool
+    let canApplyCrop: Bool
     let isEditingText: Bool
     let canZoomIn: Bool
     let canZoomOut: Bool
@@ -111,6 +113,13 @@ private struct ScreenshotEditorMenuCommands: Commands {
         }
 
         CommandGroup(after: .toolbar) {
+            Button("Apply Crop") {
+                editor?.applyCrop()
+            }
+            .disabled(editor?.canApplyCrop != true)
+
+            Divider()
+
             Button("Zoom In") {
                 editor?.zoomIn()
             }

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -349,7 +349,7 @@ class ScreenshotEditorViewModel: ObservableObject {
     }
 
     var canApplyCrop: Bool {
-        guard let cropRect else { return false }
+        guard !isEditingText, let cropRect else { return false }
         return ScreenshotEditorCropMath.pixelRect(for: cropRect, imageSize: imagePixelSize) != nil
     }
 
@@ -822,7 +822,6 @@ class ScreenshotEditorViewModel: ObservableObject {
         selectedAnnotationIndex = nil
         cropRect = nil
         pencilPoints = []
-        nextNumberLabel = 1
         selectedTool = .move
         cancelTextAnnotation()
 

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -348,6 +348,11 @@ class ScreenshotEditorViewModel: ObservableObject {
         !annotations.isEmpty
     }
 
+    var canApplyCrop: Bool {
+        guard let cropRect else { return false }
+        return ScreenshotEditorCropMath.pixelRect(for: cropRect, imageSize: imagePixelSize) != nil
+    }
+
     var hasUnsavedChanges: Bool {
         if hasPendingChanges {
             return true
@@ -794,6 +799,43 @@ class ScreenshotEditorViewModel: ObservableObject {
         markDirty()
     }
 
+    @discardableResult
+    func applyCrop() -> Bool {
+        guard let selectedCropRect = cropRect,
+              let cropPixelRect = ScreenshotEditorCropMath.pixelRect(for: selectedCropRect, imageSize: imagePixelSize),
+              let flattenedCrop = renderFinalImage(
+                croppingTo: cropPixelRect,
+                includesExportDecorations: false
+              ) else {
+            return false
+        }
+
+        let croppedImage = NSImage(
+            size: NSSize(width: flattenedCrop.pixelsWide, height: flattenedCrop.pixelsHigh)
+        )
+        croppedImage.addRepresentation(flattenedCrop)
+        originalImage = croppedImage
+        imagePixelSize = CGSize(width: flattenedCrop.pixelsWide, height: flattenedCrop.pixelsHigh)
+
+        annotations.removeAll()
+        currentAnnotation = nil
+        selectedAnnotationIndex = nil
+        cropRect = nil
+        pencilPoints = []
+        nextNumberLabel = 1
+        selectedTool = .move
+        cancelTextAnnotation()
+
+        // Previous states reference the image before its pixels and coordinate space changed.
+        undoStack.removeAll()
+        redoStack.removeAll()
+        pendingDragHistoryState = nil
+        didChangePendingDrag = false
+        updateHistoryAvailability()
+        markDirty()
+        return true
+    }
+
     func copyToClipboard() {
         guard let output = buildOutputImage() else { return }
 
@@ -943,20 +985,7 @@ class ScreenshotEditorViewModel: ObservableObject {
     // MARK: - Private
 
     private func exportBasePixelSize() -> CGSize {
-        guard imagePixelSize.width > 0, imagePixelSize.height > 0 else { return .zero }
-
-        let cropPixelRect: CGRect
-        if let crop = cropRect {
-            cropPixelRect = CGRect(
-                x: crop.origin.x * imagePixelSize.width,
-                y: crop.origin.y * imagePixelSize.height,
-                width: crop.width * imagePixelSize.width,
-                height: crop.height * imagePixelSize.height
-            )
-        } else {
-            cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
-        }
-
+        guard let cropPixelRect = resolvedCropPixelRect(for: cropRect) else { return .zero }
         return exportLayout(for: cropPixelRect.size).frameSize
     }
 
@@ -1165,28 +1194,25 @@ class ScreenshotEditorViewModel: ObservableObject {
         return true
     }
 
-    private func renderFinalImage() -> NSBitmapImageRep? {
+    private func renderFinalImage(
+        croppingTo explicitCropPixelRect: CGRect? = nil,
+        includesExportDecorations: Bool = true
+    ) -> NSBitmapImageRep? {
         precondition(Thread.isMainThread, "Screenshot export rendering must run on the main thread.")
 
         guard let original = originalImage, imagePixelSize.width > 0 else { return nil }
 
-        let pixelW = imagePixelSize.width
         let pixelH = imagePixelSize.height
 
-        // Determine crop region in pixels
-        let cropPixelRect: CGRect
-        if let crop = cropRect {
-            cropPixelRect = CGRect(
-                x: crop.origin.x * pixelW,
-                y: crop.origin.y * pixelH,
-                width: crop.width * pixelW,
-                height: crop.height * pixelH
-            )
-        } else {
-            cropPixelRect = CGRect(origin: .zero, size: imagePixelSize)
+        guard let cropPixelRect = explicitCropPixelRect ?? resolvedCropPixelRect(for: cropRect) else {
+            return nil
         }
-
-        let layout = exportLayout(for: cropPixelRect.size)
+        let layout = includesExportDecorations
+            ? exportLayout(for: cropPixelRect.size)
+            : ExportFrameLayout(
+                frameSize: cropPixelRect.size,
+                imageRect: CGRect(origin: .zero, size: cropPixelRect.size)
+            )
         let outputW = Int(layout.frameSize.width)
         let outputH = Int(layout.frameSize.height)
         guard outputW > 0 && outputH > 0 else { return nil }
@@ -1212,7 +1238,7 @@ class ScreenshotEditorViewModel: ObservableObject {
         NSGraphicsContext.current = nsContext
         defer { NSGraphicsContext.restoreGraphicsState() }
 
-        if backgroundStyle != .transparent {
+        if includesExportDecorations, backgroundStyle != .transparent {
             let fullRect = CGRect(x: 0, y: 0, width: outputW, height: outputH)
             if backgroundStyle == .solid {
                 context.setFillColor(NSColor(backgroundColor).cgColor)
@@ -1236,7 +1262,9 @@ class ScreenshotEditorViewModel: ObservableObject {
             width: layout.imageRect.width,
             height: layout.imageRect.height
         )
-        let imageCornerRadius = max(0, min(canvasCornerRadius, min(imageRect.width, imageRect.height) / 2))
+        let imageCornerRadius = includesExportDecorations
+            ? max(0, min(canvasCornerRadius, min(imageRect.width, imageRect.height) / 2))
+            : 0
         let imageClipPath = CGPath(
             roundedRect: imageRect,
             cornerWidth: imageCornerRadius,
@@ -1250,7 +1278,7 @@ class ScreenshotEditorViewModel: ObservableObject {
         // window capture's transparent rounded corners transparent instead of filling
         // them with a solid shadow color, matching the live preview.
         context.saveGState()
-        if canvasShadowRadius > 0 {
+        if includesExportDecorations, canvasShadowRadius > 0 {
             context.setShadow(
                 offset: .zero,
                 blur: canvasShadowRadius,
@@ -1486,12 +1514,15 @@ class ScreenshotEditorViewModel: ObservableObject {
     }
 
     private var exportImageSize: CGSize {
-        guard imagePixelSize.width > 0, imagePixelSize.height > 0 else { return .zero }
-        guard let crop = cropRect else { return imagePixelSize }
-        return CGSize(
-            width: crop.width * imagePixelSize.width,
-            height: crop.height * imagePixelSize.height
-        )
+        resolvedCropPixelRect(for: cropRect)?.size ?? .zero
+    }
+
+    private func resolvedCropPixelRect(for normalizedCrop: CGRect?) -> CGRect? {
+        guard imagePixelSize.width > 0, imagePixelSize.height > 0 else { return nil }
+        guard let normalizedCrop else {
+            return CGRect(origin: .zero, size: imagePixelSize)
+        }
+        return ScreenshotEditorCropMath.pixelRect(for: normalizedCrop, imageSize: imagePixelSize)
     }
 
     private func exportLayout(for imageSize: CGSize) -> ExportFrameLayout {

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -612,12 +612,14 @@ struct ScreenshotEditorView: View {
                 redo: viewModel.redo,
                 copy: viewModel.copyToClipboard,
                 clearAnnotations: { showClearAnnotationsConfirmation = true },
+                applyCrop: applyCrop,
                 zoomIn: zoomIn,
                 zoomOut: zoomOut,
                 fitZoom: fitZoom,
                 canUndo: viewModel.canUndo,
                 canRedo: viewModel.canRedo,
                 hasAnnotations: viewModel.hasAnnotations,
+                canApplyCrop: viewModel.canApplyCrop,
                 isEditingText: viewModel.isEditingText,
                 canZoomIn: !viewModel.isEditingText && zoomScale < ScreenshotEditorZoomMath.maximumScale,
                 canZoomOut: !viewModel.isEditingText && zoomScale > ScreenshotEditorZoomMath.minimumScale
@@ -644,6 +646,13 @@ struct ScreenshotEditorView: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
+                Button(action: applyCrop) {
+                    Label("Apply Crop", systemImage: "crop")
+                }
+                .disabled(!viewModel.canApplyCrop)
+                .accessibilityHint("Crops the image to the selected area and flattens existing annotations.")
+                .help("Apply the selected crop.")
+
                 Button {
                     viewModel.undo()
                 } label: {
@@ -1076,6 +1085,11 @@ struct ScreenshotEditorView: View {
     private func zoomIn() {
         guard !viewModel.isEditingText else { return }
         setZoom(ScreenshotEditorZoomMath.steppedScale(from: zoomScale, direction: 1))
+    }
+
+    private func applyCrop() {
+        guard viewModel.applyCrop() else { return }
+        fitZoom()
     }
 
     private func zoomOut() {

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -142,6 +142,30 @@ final class CaptureMathTests: XCTestCase {
         XCTAssertEqual(clamped.height, 30)
     }
 
+    func testScreenshotEditorCropConvertsNormalizedRectToPixels() {
+        let crop = ScreenshotEditorCropMath.pixelRect(
+            for: CGRect(x: 0.125, y: 0.25, width: 0.5, height: 0.5),
+            imageSize: CGSize(width: 1_000, height: 800)
+        )
+
+        XCTAssertEqual(crop, CGRect(x: 125, y: 200, width: 500, height: 400))
+    }
+
+    func testScreenshotEditorCropClampsBoundsAndRejectsEmptySelections() {
+        let clamped = ScreenshotEditorCropMath.pixelRect(
+            for: CGRect(x: -0.2, y: 0.25, width: 0.5, height: 1),
+            imageSize: CGSize(width: 1_000, height: 800)
+        )
+
+        XCTAssertEqual(clamped, CGRect(x: 0, y: 200, width: 300, height: 600))
+        XCTAssertNil(
+            ScreenshotEditorCropMath.pixelRect(
+                for: CGRect(x: 0.25, y: 0.25, width: 0, height: 0.5),
+                imageSize: CGSize(width: 1_000, height: 800)
+            )
+        )
+    }
+
     func testExportFrameLayoutPlacesImageAlongAvailableAxis() {
         let horizontalOrigins: [ExportHorizontalAlignment: CGPoint] = [
             .leading: CGPoint(x: 10, y: 10),

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -160,7 +160,7 @@ final class CaptureMathTests: XCTestCase {
         XCTAssertEqual(clamped, CGRect(x: 0, y: 200, width: 300, height: 600))
         XCTAssertNil(
             ScreenshotEditorCropMath.pixelRect(
-                for: CGRect(x: 0.25, y: 0.25, width: 0, height: 0.5),
+                for: CGRect(x: 0.1255, y: 0.25, width: 0, height: 0.5),
                 imageSize: CGSize(width: 1_000, height: 800)
             )
         )

--- a/windows/src/TinyClips.App/Package.Store.appxmanifest
+++ b/windows/src/TinyClips.App/Package.Store.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="23875RefractoredLLC.TinyClips"
     Publisher="CN=995C4AD9-3B22-4B61-B30F-3EAB23CDAEAE"
-    Version="1.6.0.0" />
+    Version="1.8.0.0" />
 
   <Properties>
     <DisplayName>Tiny Clips</DisplayName>

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="Refractored.TinyClips"
     Publisher="CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
-    Version="1.6.0.0" />
+    Version="1.8.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="D90CE0D4-542A-47D3-89A4-CF82BF4E244B" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
Cropping in the macOS screenshot editor was deferred until export, so annotations added after choosing a crop were still mapped to the original image and could shift or scale incorrectly.

This adds an explicit **Apply Crop** action in the toolbar and menu. It flattens existing annotations into the cropped image, resets the editor to that new coordinate space, and clears incompatible history so later annotations are positioned and sized correctly. Export-only backgrounds, padding, corner radius, and shadow remain non-destructive.

## Version

- macOS direct and Mac App Store variants: 1.8.0
- Windows direct and Store MSIX manifests: 1.8.0.0

Includes deterministic crop-geometry tests and a changelog entry.