### PR TITLE
Refine the Windows tray quick-access flyout

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,11 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Changed
+- **Layered acrylic tray flyout** — The system-tray quick-access window now uses a PowerToys-style
+  layered acrylic content surface with a distinct bottom command bar and compact 32-DIP Fluent
+  action buttons, while retaining the existing Tiny Clips popup dimensions and actions.
+
 ## [v1.7.0-windows] - 2026-08-13
 
 ### Internal

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -67,6 +67,8 @@ public partial class App : Application
     private AutomationNotificationAnnouncer? _automationNotificationAnnouncer;
     private const double TrayPopupWidth = 344;
     private const double TrayPopupHeight = 242;
+    private const double TrayPopupFooterHeight = 48;
+    private const double TrayPopupFooterButtonSize = 32;
     private GlobalHotKeyManager? _hotKeyManager;
     private DispatcherQueue? _dispatcher;
     private bool _isExiting;
@@ -191,24 +193,23 @@ public partial class App : Application
         _trayPopup.ShowNearCursor(TrayPopupWidth, TrayPopupHeight);
     }
 
-    // PowerToys-style "quick access" popup: three large capture tiles across the top,
-    // a divider, then a row of small icon buttons (Settings / Guide / Exit) at the bottom.
+    // PowerToys-style "quick access" popup: capture actions on a layered acrylic content
+    // surface with a separate acrylic command bar along the bottom.
     private UIElement BuildTrayPopupContent(IHotKeyService hotKeys)
     {
         void Dismiss() => _trayPopup?.Hide();
 
-        var root = new StackPanel
+        var content = new StackPanel
         {
-            Width = TrayPopupWidth,
-            Padding = new Thickness(12),
-            Spacing = 10,
+            Padding = new Thickness(16),
+            Spacing = 8,
         };
 
-        root.Children.Add(new TextBlock
+        content.Children.Add(new TextBlock
         {
             Text = "Tiny Clips",
-            Margin = new Thickness(4, 2, 0, 0),
-            Style = TextStyle("BodyStrongTextBlockStyle"),
+            Margin = new Thickness(0, 0, 0, 2),
+            Style = ResourceStyle("BodyStrongTextBlockStyle"),
         });
 
         var tiles = new Grid { ColumnSpacing = 6 };
@@ -244,7 +245,7 @@ public partial class App : Application
         Grid.SetColumn(_gifTile.Button, 2);
         tiles.Children.Add(_gifTile.Button);
 
-        root.Children.Add(tiles);
+        content.Children.Add(tiles);
 
         var quickAccess = new Grid { ColumnSpacing = 6 };
         quickAccess.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -257,37 +258,91 @@ public partial class App : Application
         var recent = CreateRecentCapturesButton(Dismiss);
         Grid.SetColumn(recent, 1);
         quickAccess.Children.Add(recent);
-        root.Children.Add(quickAccess);
+        content.Children.Add(quickAccess);
 
-        root.Children.Add(new Border
+        var contentArea = new Border
         {
-            Height = 1,
-            Margin = new Thickness(0, 2, 0, 2),
-            Background = ThemeBrush("DividerStrokeColorDefaultBrush"),
-        });
+            Child = content,
+            Background = ThemeBrush("LayerOnAcrylicFillColorDefaultBrush"),
+            BorderBrush = ThemeBrush("CardStrokeColorDefaultBrush"),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+        };
 
-        var footer = new StackPanel
+        var footer = new Grid
+        {
+            Height = TrayPopupFooterHeight,
+            Padding = new Thickness(12, 0, 12, 0),
+        };
+        footer.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        footer.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var primaryFooterActions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8,
+        };
+        primaryFooterActions.Children.Add(CreateFooterButton(
+            GlyphMediaGallery,
+            "Clips Library",
+            "TrayClipsLibraryButton",
+            new RelayCommand(OpenClipsManagerWindow),
+            Dismiss));
+        footer.Children.Add(primaryFooterActions);
+
+        var secondaryFooterActions = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             HorizontalAlignment = HorizontalAlignment.Right,
-            Spacing = 2,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8,
         };
-        footer.Children.Add(CreateFooterButton(GlyphMediaGallery, "Clips Library", new RelayCommand(OpenClipsManagerWindow), Dismiss));
-        footer.Children.Add(CreateFooterDivider());
-        footer.Children.Add(CreateFooterButton("\uE713", "Settings", new RelayCommand(OpenSettingsWindow), Dismiss));
+        secondaryFooterActions.Children.Add(CreateFooterButton(
+            "\uE713",
+            "Settings",
+            "TraySettingsButton",
+            new RelayCommand(OpenSettingsWindow),
+            Dismiss));
 #if !TINYCLIPS_STORE_BUILD
-        footer.Children.Add(CreateFooterButton(GlyphCheckForUpdates, "Check for updates", new AsyncRelayCommand(CheckForUpdatesFromTrayAsync), Dismiss));
+        secondaryFooterActions.Children.Add(CreateFooterButton(
+            GlyphCheckForUpdates,
+            "Check for updates",
+            "TrayCheckForUpdatesButton",
+            new AsyncRelayCommand(CheckForUpdatesFromTrayAsync),
+            Dismiss));
 #endif
-        footer.Children.Add(CreateFooterDivider());
-        footer.Children.Add(CreateFooterButton("\uE897", "Guide", new RelayCommand(OpenGuideWindow), Dismiss));
-        footer.Children.Add(CreateFooterButton(GlyphBug, "File a Bug", new RelayCommand(OpenQuickBugReportWindow), Dismiss));
-        footer.Children.Add(CreateFooterDivider());
-        footer.Children.Add(CreateFooterButton("\uE7E8", "Exit", new RelayCommand(() => _ = ExitApplicationAsync()), Dismiss));
-        root.Children.Add(footer);
+        secondaryFooterActions.Children.Add(CreateFooterButton(
+            "\uE897",
+            "Guide",
+            "TrayGuideButton",
+            new RelayCommand(OpenGuideWindow),
+            Dismiss));
+        secondaryFooterActions.Children.Add(CreateFooterButton(
+            GlyphBug,
+            "File a Bug",
+            "TrayFileBugButton",
+            new RelayCommand(OpenQuickBugReportWindow),
+            Dismiss));
+        secondaryFooterActions.Children.Add(CreateFooterButton(
+            "\uE7E8",
+            "Exit",
+            "TrayExitButton",
+            new RelayCommand(() => _ = ExitApplicationAsync()),
+            Dismiss));
+        Grid.SetColumn(secondaryFooterActions, 1);
+        footer.Children.Add(secondaryFooterActions);
+
+        var layout = new Grid { Width = TrayPopupWidth };
+        layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        layout.RowDefinitions.Add(new RowDefinition { Height = new GridLength(TrayPopupFooterHeight) });
+        layout.Children.Add(contentArea);
+        Grid.SetRow(footer, 1);
+        layout.Children.Add(footer);
 
         return new Border
         {
-            Child = root,
+            Child = layout,
             CornerRadius = new CornerRadius(8),
             BorderThickness = new Thickness(1),
             BorderBrush = ThemeBrush("SurfaceStrokeColorDefaultBrush"),
@@ -430,35 +485,30 @@ public partial class App : Application
         return new CaptureTile { Button = button, Icon = icon, Label = label };
     }
 
-    private Button CreateFooterButton(string glyph, string tooltip, ICommand command, Action dismiss)
+    private Button CreateFooterButton(
+        string glyph,
+        string tooltip,
+        string automationId,
+        ICommand command,
+        Action dismiss)
     {
         var button = new Button
         {
             Content = new FontIcon { Glyph = glyph, FontFamily = FluentIconFont, FontSize = 16 },
-            Width = 40,
-            Height = 36,
-            Padding = new Thickness(0),
+            Width = TrayPopupFooterButtonSize,
+            Height = TrayPopupFooterButtonSize,
+            Padding = new Thickness(6),
             Command = command,
-            Background = new SolidColorBrush(Colors.Transparent),
-            BorderThickness = new Thickness(0),
-            CornerRadius = new CornerRadius(6),
+            Style = ResourceStyle("SubtleButtonStyle"),
         };
         ToolTipService.SetToolTip(button, tooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(button, automationId);
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(button, tooltip);
         button.Click += (_, _) => dismiss();
         return button;
     }
 
-    private static Border CreateFooterDivider() => new()
-    {
-        Width = 1,
-        Height = 20,
-        Margin = new Thickness(6, 0, 6, 0),
-        VerticalAlignment = VerticalAlignment.Center,
-        Background = ThemeBrush("DividerStrokeColorDefaultBrush"),
-    };
-
-    private static Style? TextStyle(string key)
+    private static Style? ResourceStyle(string key)
         => Application.Current.Resources.TryGetValue(key, out var value) ? value as Style : null;
 
     private static Brush? ThemeBrush(string key)

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -273,65 +273,53 @@ public partial class App : Application
             Height = TrayPopupFooterHeight,
             Padding = new Thickness(12, 0, 12, 0),
         };
-        footer.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        footer.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        var primaryFooterActions = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            VerticalAlignment = VerticalAlignment.Center,
-            Spacing = 8,
-        };
-        primaryFooterActions.Children.Add(CreateFooterButton(
-            GlyphMediaGallery,
-            "Clips Library",
-            "TrayClipsLibraryButton",
-            new RelayCommand(OpenClipsManagerWindow),
-            Dismiss));
-        footer.Children.Add(primaryFooterActions);
-
-        var secondaryFooterActions = new StackPanel
+        var footerActions = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             HorizontalAlignment = HorizontalAlignment.Right,
             VerticalAlignment = VerticalAlignment.Center,
             Spacing = 8,
         };
-        secondaryFooterActions.Children.Add(CreateFooterButton(
+        footerActions.Children.Add(CreateFooterButton(
+            GlyphMediaGallery,
+            "Clips Library",
+            "TrayClipsLibraryButton",
+            new RelayCommand(OpenClipsManagerWindow),
+            Dismiss));
+        footerActions.Children.Add(CreateFooterButton(
             "\uE713",
             "Settings",
             "TraySettingsButton",
             new RelayCommand(OpenSettingsWindow),
             Dismiss));
 #if !TINYCLIPS_STORE_BUILD
-        secondaryFooterActions.Children.Add(CreateFooterButton(
+        footerActions.Children.Add(CreateFooterButton(
             GlyphCheckForUpdates,
             "Check for updates",
             "TrayCheckForUpdatesButton",
             new AsyncRelayCommand(CheckForUpdatesFromTrayAsync),
             Dismiss));
 #endif
-        secondaryFooterActions.Children.Add(CreateFooterButton(
+        footerActions.Children.Add(CreateFooterButton(
             "\uE897",
             "Guide",
             "TrayGuideButton",
             new RelayCommand(OpenGuideWindow),
             Dismiss));
-        secondaryFooterActions.Children.Add(CreateFooterButton(
+        footerActions.Children.Add(CreateFooterButton(
             GlyphBug,
             "File a Bug",
             "TrayFileBugButton",
             new RelayCommand(OpenQuickBugReportWindow),
             Dismiss));
-        secondaryFooterActions.Children.Add(CreateFooterButton(
+        footerActions.Children.Add(CreateFooterButton(
             "\uE7E8",
             "Exit",
             "TrayExitButton",
             new RelayCommand(() => _ = ExitApplicationAsync()),
             Dismiss));
-        Grid.SetColumn(secondaryFooterActions, 1);
-        footer.Children.Add(secondaryFooterActions);
+        footer.Children.Add(footerActions);
 
         var layout = new Grid { Width = TrayPopupWidth };
         layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -322,7 +322,7 @@ public partial class App : Application
         footer.Children.Add(footerActions);
 
         var layout = new Grid { Width = TrayPopupWidth };
-        layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        layout.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
         layout.RowDefinitions.Add(new RowDefinition { Height = new GridLength(TrayPopupFooterHeight) });
         layout.Children.Add(contentArea);
         Grid.SetRow(footer, 1);

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -202,7 +202,7 @@ public partial class App : Application
         var content = new StackPanel
         {
             Padding = new Thickness(16),
-            Spacing = 8,
+            Spacing = 12,
         };
 
         content.Children.Add(new TextBlock

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -340,13 +340,7 @@ public partial class App : Application
         Grid.SetRow(footer, 1);
         layout.Children.Add(footer);
 
-        return new Border
-        {
-            Child = layout,
-            CornerRadius = new CornerRadius(8),
-            BorderThickness = new Thickness(1),
-            BorderBrush = ThemeBrush("SurfaceStrokeColorDefaultBrush"),
-        };
+        return layout;
     }
 
     private ButtonBase CreateFolderButton(Action dismiss)

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -30,7 +30,7 @@ public partial class App : Application
     // Segoe Fluent Icons glyphs.
     private const string GlyphScreenshot = "\uE722";
     private const string GlyphVideo = "\uE714";
-    private const string GlyphGif = "\uE8B9";
+    private const string GlyphGif = "\uF4A9";
     private const string GlyphStop = "\uE71A";
     private const string GlyphCheckForUpdates = "\uE895";
     private const string GlyphFolder = "\uE8B7";


### PR DESCRIPTION
## Summary

- apply a PowerToys-inspired layered acrylic hierarchy to the Windows system-tray quick-access flyout
- place capture actions on a `LayerOnAcrylicFillColorDefaultBrush` surface and separate them from a 48-DIP acrylic footer
- use right-aligned 32 × 32 DIP `SubtleButtonStyle` actions while preserving the existing button ordering and popup dimensions
- remove the redundant custom perimeter stroke, improve content spacing, and use the current Fluent GIF badge
- preserve light dismiss, mixed-DPI positioning, hotkeys, capture commands, folders, recent captures, and all footer actions

## Validation

- `dotnet build windows\src\TinyClips.App\TinyClips.App.csproj -c Debug -p:Platform=x64`
- `dotnet test windows\tests\TinyClips.Core.Tests\TinyClips.Core.Tests.csproj -c Debug` (92 tests)
- Store-flavor ARM64 flyout visually reviewed at its existing 344 × 242 DIP size

## Screenshot

![Tiny Clips tray flyout using layered acrylic and a compact footer command bar](https://github.com/user-attachments/assets/5620f4b1-803f-484a-8b32-455813f3d3aa)

Closes #268
