### PR TITLE
Refactor Windows overlays: shared helpers, DPI, drag, icons

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,8 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Tray Capture Text** — A compact action beside **Clips Library** starts region text recognition
+  and copies the result to the clipboard.
 - **OCR region capture** — Select **Recognize Text** in the capture picker or press `Ctrl+Shift+T`
   to recognize text in a screen region and copy it to the clipboard without saving an image.
   Large regions are automatically downscaled to fit the OCR engine's supported image size, and the
@@ -15,11 +17,18 @@ own `CHANGELOG.md` at the repository root.
   recording and enabled by default.
 
 ### Changed
+- **Updated Guide window** — The guide now covers OCR, configurable shortcuts, screenshot editing,
+  recording options, tray quick access, and Clips Library management.
+- **Guide tray icon** — The Guide action now uses a document icon instead of a help question mark.
 - **Native Settings title bar** — Settings now uses the WinUI `TitleBar` control, keeps the
   navigation pane toggle in the title bar only when the adaptive navigation pane is collapsed,
   places About at the bottom of the navigation pane, and enforces DPI-aware minimum window
   dimensions. The native `AppWindow` icon is also set on activation so the Tiny Clips icon appears
   in taskbar thumbnails and Alt+Tab previews.
+- **Native Clips Library title bar** — The Clips Library window now uses the WinUI `TitleBar`
+  control with the app icon and a live capture-count subtitle. DPI-aware minimum window dimensions
+  (480 × 520 DIP) are enforced and updated automatically when the window is moved between monitors
+  with different scale factors.
 - **Native Screenshot settings cards** — The Screenshot page now uses Community Toolkit
   `SettingsCard` and `SettingsExpander` controls with Fluent icons and the Gallery-style centered,
   constrained settings layout. Image format now starts expanded with icon-free nested JPEG quality
@@ -57,6 +66,14 @@ own `CHANGELOG.md` at the repository root.
 - **Teleprompter overlay settings card** — Teleprompter enablement now uses an icon-led Toolkit
   settings card and the shared Gallery-width layout, while the transcript, speed, and preview
   controls retain their custom presentation.
+- **Native editor and trimmer title bars** — The Screenshot Editor, Video Trimmer, and GIF
+  Trimmer windows now use the WinUI `TitleBar` control with the app icon instead of a custom
+  drawn title bar. DPI-aware minimum window dimensions are enforced and updated automatically
+  when a window moves between monitors with different scale factors.
+- **Native Guide, bug-report, and onboarding title bars** — The Guide, File a Bug, and Welcome
+  windows now use the WinUI `TitleBar` control with the app icon. DPI-aware minimum window
+  dimensions are enforced and updated automatically when a window moves between monitors with
+  different scale factors (Guide 460 × 400 DIP; File a Bug 480 × 500 DIP; Welcome 480 × 520 DIP).
 
 ### Internal
 - Added the Community Toolkit Settings Controls package as the foundation for migrating Settings
@@ -64,6 +81,16 @@ own `CHANGELOG.md` at the repository root.
 - **Layered acrylic tray flyout** — The system-tray quick-access window now uses a PowerToys-style
   layered acrylic content surface with a distinct bottom command bar and compact 32-DIP Fluent
   action buttons, while retaining the existing Tiny Clips popup dimensions and actions.
+- **Window consistency and accessibility** — Secondary windows now honor app themes and
+  high-contrast resources, while recording indicators and capture pickers use consistent surfaces
+  and accessible control names.
+- **Shared overlay infrastructure** — Capture-exclusion (`WDA_EXCLUDEFROMCAPTURE`) and
+  rounded-region (`SetWindowRgn`/`CreateRoundRectRgn`, with correct HRGN ownership on failure)
+  are consolidated into `OverlayWindowHelpers`; drag-anywhere behavior is consolidated into
+  `FloatingWindowDragger`. These helpers are consumed by the borderless capture pickers,
+  countdown, recording/processing indicators, recording-setup, teleprompter, webcam preview,
+  and region-indicator windows, removing duplicated P/Invoke declarations and structs. The
+  `TrayPopupWindow` now unsubscribes its `Activated` handler on closure.
 
 ## [v1.7.0-windows] - 2026-08-13
 

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -35,8 +35,12 @@ public partial class App : Application
     private const string GlyphCheckForUpdates = "\uE895";
     private const string GlyphFolder = "\uE8B7";
     private const string GlyphHistory = "\uE81C";
+    private const string GlyphDocument = "\uE8A5";
     private const string GlyphMediaGallery = "\uE7AA";
+    private const string GlyphTextRecognition = "\uE8D2";
     private const string GlyphBug = "\uEBE8";
+    private const string GlyphSettings = "\uE713";
+    private const string GlyphExit = "\uE7E8";
     private const uint MonitorDefaultToNearest = 2;
 
     private TaskbarIcon? _taskbarIcon;
@@ -288,22 +292,21 @@ public partial class App : Application
             "TrayClipsLibraryButton",
             new RelayCommand(OpenClipsManagerWindow),
             Dismiss));
+
         footerActions.Children.Add(CreateFooterButton(
-            "\uE713",
+            GlyphTextRecognition,
+            $"Capture Text ({hotKeys.GetBinding(HotKeyAction.RecognizeText).DisplayString})",
+            "TrayCaptureTextButton",
+            new AsyncRelayCommand(RecognizeTextAsync),
+            Dismiss));
+        footerActions.Children.Add(CreateFooterButton(
+            GlyphSettings,
             "Settings",
             "TraySettingsButton",
             new RelayCommand(OpenSettingsWindow),
             Dismiss));
-#if !TINYCLIPS_STORE_BUILD
         footerActions.Children.Add(CreateFooterButton(
-            GlyphCheckForUpdates,
-            "Check for updates",
-            "TrayCheckForUpdatesButton",
-            new AsyncRelayCommand(CheckForUpdatesFromTrayAsync),
-            Dismiss));
-#endif
-        footerActions.Children.Add(CreateFooterButton(
-            "\uE897",
+            GlyphDocument,
             "Guide",
             "TrayGuideButton",
             new RelayCommand(OpenGuideWindow),
@@ -315,7 +318,7 @@ public partial class App : Application
             new RelayCommand(OpenQuickBugReportWindow),
             Dismiss));
         footerActions.Children.Add(CreateFooterButton(
-            "\uE7E8",
+            GlyphExit,
             "Exit",
             "TrayExitButton",
             new RelayCommand(() => _ = ExitApplicationAsync()),
@@ -367,7 +370,7 @@ public partial class App : Application
         var flyout = new MenuFlyout();
         var button = new DropDownButton
         {
-            Content = QuickAccessContent(GlyphHistory, captures.Count == 0 ? "No recent captures" : $"Recent ({captures.Count})"),
+            Content = QuickAccessContent(GlyphHistory, captures.Count == 0 ? "No captures" : $"Recent ({captures.Count})"),
             Flyout = flyout,
             IsEnabled = captures.Count > 0,
             HorizontalAlignment = HorizontalAlignment.Stretch,

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -299,6 +299,14 @@ public partial class App : Application
             "TrayCaptureTextButton",
             new AsyncRelayCommand(RecognizeTextAsync),
             Dismiss));
+#if !TINYCLIPS_STORE_BUILD
+        footerActions.Children.Add(CreateFooterButton(
+            GlyphCheckForUpdates,
+            "Check for updates",
+            "TrayCheckForUpdatesButton",
+            new AsyncRelayCommand(CheckForUpdatesFromTrayAsync),
+            Dismiss));
+#endif
         footerActions.Children.Add(CreateFooterButton(
             GlyphSettings,
             "Settings",

--- a/windows/src/TinyClips.App/Infrastructure/FloatingWindowDragger.cs
+++ b/windows/src/TinyClips.App/Infrastructure/FloatingWindowDragger.cs
@@ -13,9 +13,10 @@ namespace TinyClips.App;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Wire the three public methods to <see cref="UIElement.PointerPressed"/>,
-/// <see cref="UIElement.PointerMoved"/>, and <see cref="UIElement.PointerReleased"/> on
-/// the drag surface.  Buttons and other interactive controls should mark their own pointer
+/// Wire the public methods to <see cref="UIElement.PointerPressed"/>,
+/// <see cref="UIElement.PointerMoved"/>, <see cref="UIElement.PointerReleased"/>,
+/// <see cref="UIElement.PointerCanceled"/>, and <see cref="UIElement.PointerCaptureLost"/>
+/// on the drag surface. Buttons and other interactive controls should mark their own pointer
 /// events handled so a drag is only initiated on the bar background.
 /// </para>
 /// <para>
@@ -93,6 +94,14 @@ internal sealed class FloatingWindowDragger
 
         _dragging = false;
         element.ReleasePointerCapture(e.Pointer);
+    }
+
+    /// <summary>
+    /// Clears drag state when WinUI cancels the interaction or ends pointer capture.
+    /// </summary>
+    public void OnPointerCaptureEnded(object sender, PointerRoutedEventArgs e)
+    {
+        _dragging = false;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/windows/src/TinyClips.App/Infrastructure/FloatingWindowDragger.cs
+++ b/windows/src/TinyClips.App/Infrastructure/FloatingWindowDragger.cs
@@ -1,0 +1,107 @@
+using System.Runtime.InteropServices;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Windows.Graphics;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Encapsulates drag-anywhere behavior for borderless floating overlay windows.
+/// Window movement is anchored to the absolute cursor position rather than a
+/// pointer-relative offset to avoid feedback jitter as the window moves under the pointer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire the three public methods to <see cref="UIElement.PointerPressed"/>,
+/// <see cref="UIElement.PointerMoved"/>, and <see cref="UIElement.PointerReleased"/> on
+/// the drag surface.  Buttons and other interactive controls should mark their own pointer
+/// events handled so a drag is only initiated on the bar background.
+/// </para>
+/// <para>
+/// Windows whose pointer-release handler performs additional work (e.g.
+/// <c>TeleprompterWindow</c> position persistence or <c>WebcamPreviewWindow</c> corner
+/// snapping) keep their own drag state rather than using this helper, as the instruction
+/// specifies that differing behaviors should not be forced into a shared abstraction.
+/// </para>
+/// </remarks>
+internal sealed class FloatingWindowDragger
+{
+    private readonly AppWindow _appWindow;
+    private bool _dragging;
+    private POINT _cursorStart;
+    private PointInt32 _windowStart;
+
+    /// <param name="appWindow">
+    /// The <see cref="AppWindow"/> whose position this dragger controls.
+    /// Typically obtained from <c>window.AppWindow</c> in the host window's constructor.
+    /// </param>
+    public FloatingWindowDragger(AppWindow appWindow)
+    {
+        _appWindow = appWindow;
+    }
+
+    /// <summary>
+    /// Call from <see cref="UIElement.PointerPressed"/> on the drag surface.
+    /// Captures the pointer so drag events are received even when the pointer leaves the element.
+    /// </summary>
+    public void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        GetCursorPos(out _cursorStart);
+        _windowStart = _appWindow.Position;
+        _dragging = element.CapturePointer(e.Pointer);
+    }
+
+    /// <summary>
+    /// Call from <see cref="UIElement.PointerMoved"/> on the drag surface.
+    /// Moves the window by the delta between the current and start cursor positions.
+    /// </summary>
+    public void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_dragging)
+        {
+            return;
+        }
+
+        GetCursorPos(out var current);
+        var dx = current.X - _cursorStart.X;
+        var dy = current.Y - _cursorStart.Y;
+
+        if (dx == 0 && dy == 0)
+        {
+            return;
+        }
+
+        _appWindow.Move(new PointInt32(_windowStart.X + dx, _windowStart.Y + dy));
+    }
+
+    /// <summary>
+    /// Call from <see cref="UIElement.PointerReleased"/> on the drag surface.
+    /// Clears the drag flag and releases pointer capture.
+    /// </summary>
+    public void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not UIElement element)
+        {
+            return;
+        }
+
+        _dragging = false;
+        element.ReleasePointerCapture(e.Pointer);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out POINT lpPoint);
+}

--- a/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
+++ b/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
@@ -1,0 +1,71 @@
+using System.Runtime.InteropServices;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Focused helpers for native window behaviors shared by borderless overlay windows:
+/// capture pickers, session overlays, and the tray popup.
+/// Only behaviors with multiple consumers whose semantics are truly identical are
+/// centralized here. Specialized region algorithms (punch-hole, layered alpha) stay local
+/// to their respective windows.
+/// </summary>
+internal static class OverlayWindowHelpers
+{
+    private const uint WdaExcludeFromCapture = 0x11;
+
+    /// <summary>
+    /// Applies <c>WDA_EXCLUDEFROMCAPTURE</c> to the window.
+    /// Returns <see langword="true"/> on success, <see langword="false"/> on failure.
+    /// The caller is responsible for deciding whether to surface or silence a failure;
+    /// callers that previously surfaced failures (e.g. <c>TeleprompterWindow</c>) should
+    /// still read <see cref="Marshal.GetLastWin32Error"/> after a false return because this
+    /// DllImport preserves the Win32 last-error via <c>SetLastError = true</c>.
+    /// </summary>
+    public static bool ExcludeFromCapture(nint hwnd) =>
+        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+
+    /// <summary>
+    /// Clips a borderless overlay to a rounded rectangle.
+    /// <para>
+    /// Native HRGN ownership: after a successful <c>SetWindowRgn</c> call Windows takes
+    /// ownership of the HRGN and the caller must not delete it. On failure (or if
+    /// <c>CreateRoundRectRgn</c> itself failed) the handle is released here.
+    /// </para>
+    /// </summary>
+    /// <param name="hwnd">Target window handle.</param>
+    /// <param name="widthPx">Window width in physical pixels.</param>
+    /// <param name="heightPx">Window height in physical pixels.</param>
+    /// <param name="scale">DPI scale factor (e.g. 1.5 for 144 DPI).</param>
+    /// <param name="cornerRadiusDip">Corner radius in device-independent pixels.</param>
+    public static void ApplyRoundedRegion(nint hwnd, int widthPx, int heightPx, double scale, int cornerRadiusDip)
+    {
+        var radius = (int)Math.Round(cornerRadiusDip * scale);
+        var hrgn = CreateRoundRectRgn(0, 0, widthPx + 1, heightPx + 1, radius, radius);
+        if (hrgn == 0)
+        {
+            // CreateRoundRectRgn failed; nothing to apply or free.
+            return;
+        }
+
+        if (SetWindowRgn(hwnd, hrgn, redrawWindow: true) == 0)
+        {
+            // SetWindowRgn failed; Windows did not take ownership — release the region.
+            DeleteObject(hrgn);
+        }
+        // On success Windows owns hrgn; do not delete.
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool redrawWindow);
+
+    [DllImport("gdi32.dll")]
+    private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteObject(nint hObject);
+}

--- a/windows/src/TinyClips.App/Infrastructure/TrayPopupWindow.cs
+++ b/windows/src/TinyClips.App/Infrastructure/TrayPopupWindow.cs
@@ -30,6 +30,7 @@ internal sealed class TrayPopupWindow : Window
         Content = content;
 
         Activated += OnActivated;
+        Closed += OnClosed;
         _appWindow.Hide();
     }
 
@@ -39,6 +40,13 @@ internal sealed class TrayPopupWindow : Window
         {
             _appWindow.Hide();
         }
+    }
+
+    private void OnClosed(object sender, WindowEventArgs e)
+    {
+        // Unsubscribe so a stale Activated notification cannot reach a closed _appWindow.
+        Activated -= OnActivated;
+        Closed -= OnClosed;
     }
 
     public bool IsOpen => _appWindow.IsVisible;

--- a/windows/src/TinyClips.App/Infrastructure/WindowChromeController.cs
+++ b/windows/src/TinyClips.App/Infrastructure/WindowChromeController.cs
@@ -1,0 +1,104 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Manages full-window chrome concerns for a standard <see cref="Window"/>:
+/// <list type="bullet">
+///   <item>Sets the taskbar / Alt+Tab <see cref="AppWindow"/> icon on the first activation.</item>
+///   <item>Enforces DIP-based preferred minimum dimensions and updates them whenever the
+///     <see cref="XamlRoot"/> rasterization scale changes, for example when the user moves the
+///     window to a monitor with a different DPI.</item>
+/// </list>
+/// All event subscriptions are released when the window fires <see cref="Window.Closed"/>.
+/// Construct one instance per window in the window's constructor, after
+/// <see cref="Window.InitializeComponent"/> has run, and keep it alive as a field.
+/// </summary>
+internal sealed class WindowChromeController
+{
+    private readonly Window _window;
+    private readonly FrameworkElement _rootElement;
+    private readonly int _minWidthDip;
+    private readonly int _minHeightDip;
+    private XamlRoot? _xamlRoot;
+
+    /// <param name="window">The window to manage.</param>
+    /// <param name="rootElement">Root <see cref="FrameworkElement"/> of the window's content
+    ///   tree, used to reach <see cref="XamlRoot"/> once the element tree is loaded.</param>
+    /// <param name="minWidthDip">Preferred minimum width in device-independent pixels.</param>
+    /// <param name="minHeightDip">Preferred minimum height in device-independent pixels.</param>
+    public WindowChromeController(
+        Window window,
+        FrameworkElement rootElement,
+        int minWidthDip,
+        int minHeightDip)
+    {
+        _window = window;
+        _rootElement = rootElement;
+        _minWidthDip = minWidthDip;
+        _minHeightDip = minHeightDip;
+
+        // Apply an initial minimum size using the HWND-based scale before XamlRoot is available.
+        // This is refined in OnRootElementLoaded once the rasterization scale is known.
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+        UpdatePreferredMinimumSize(AppWindowPlacement.GetScaleForWindow(hwnd));
+
+        window.Activated += OnActivatedSetIcon;
+        rootElement.Loaded += OnRootElementLoaded;
+        window.Closed += OnWindowClosed;
+    }
+
+    // Sets the AppWindow icon once on first activation and self-unsubscribes.
+    private void OnActivatedSetIcon(object sender, WindowActivatedEventArgs args)
+    {
+        _window.AppWindow.SetIcon(@"Assets\AppIcon.ico");
+        _window.Activated -= OnActivatedSetIcon;
+    }
+
+    private void OnRootElementLoaded(object sender, RoutedEventArgs args)
+    {
+        _rootElement.Loaded -= OnRootElementLoaded;
+        _xamlRoot = _rootElement.XamlRoot;
+
+        if (_xamlRoot is null)
+        {
+            return;
+        }
+
+        _xamlRoot.Changed += OnXamlRootChanged;
+        UpdatePreferredMinimumSize(_xamlRoot.RasterizationScale);
+    }
+
+    private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
+    {
+        UpdatePreferredMinimumSize(sender.RasterizationScale);
+    }
+
+    private void UpdatePreferredMinimumSize(double scale)
+    {
+        if (_window.AppWindow.Presenter is OverlappedPresenter presenter)
+        {
+            presenter.PreferredMinimumWidth  = AppWindowPlacement.DipToPixels(_minWidthDip, scale);
+            presenter.PreferredMinimumHeight = AppWindowPlacement.DipToPixels(_minHeightDip, scale);
+        }
+    }
+
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        // Belt-and-suspenders: unsubscribe Loaded in case the window is closed before the
+        // element tree is ever loaded (Loaded already self-unsubscribes in the normal path).
+        _rootElement.Loaded -= OnRootElementLoaded;
+
+        if (_xamlRoot is not null)
+        {
+            _xamlRoot.Changed -= OnXamlRootChanged;
+            _xamlRoot = null;
+        }
+
+        // OnActivatedSetIcon is self-unsubscribing, but clean it up here in case the window
+        // is closed before its first activation.
+        _window.Activated -= OnActivatedSetIcon;
+        _window.Closed -= OnWindowClosed;
+    }
+}

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
@@ -11,6 +11,8 @@
     <Grid
         x:Name="RootGrid"
         Background="Transparent"
+        PointerCanceled="OnPointerCaptureEnded"
+        PointerCaptureLost="OnPointerCaptureEnded"
         PointerMoved="OnPointerMoved"
         PointerPressed="OnPointerPressed"
         PointerReleased="OnPointerReleased">

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -213,6 +213,8 @@ public sealed partial class CapturePickerWindow : Window
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
 
+    private void OnPointerCaptureEnded(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerCaptureEnded(sender, e);
+
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
         switch (e.Key)

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -42,9 +42,7 @@ public sealed partial class CapturePickerWindow : Window
     private int _windowHeight;
     private double _windowScale = 1.0;
 
-    private bool _dragging;
-    private POINT _dragCursorStart;
-    private PointInt32 _dragWindowStart;
+    private readonly FloatingWindowDragger _dragger;
 
     private CapturePickerWindow(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes)
     {
@@ -81,6 +79,8 @@ public sealed partial class CapturePickerWindow : Window
             LimitButton.Visibility = Visibility.Collapsed;
         }
 
+        _dragger = new FloatingWindowDragger(AppWindow);
+
         ConfigurePresenter();
         PositionNearTopOfPrimaryDisplay();
 
@@ -102,7 +102,9 @@ public sealed partial class CapturePickerWindow : Window
             return;
         }
         Activated -= OnActivated;
-        ApplyRoundedRegion(_windowWidth, _windowHeight, _windowScale);
+        OverlayWindowHelpers.ApplyRoundedRegion(
+            WinRT.Interop.WindowNative.GetWindowHandle(this),
+            _windowWidth, _windowHeight, _windowScale, CornerRadiusDip);
         RootGrid.Focus(FocusState.Programmatic);
     }
 
@@ -110,7 +112,7 @@ public sealed partial class CapturePickerWindow : Window
     {
         RootGrid.UpdateLayout();
         RootGrid.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
-        var scale = GetScale();
+        var scale = AppWindowPlacement.GetScaleForWindow(WinRT.Interop.WindowNative.GetWindowHandle(this));
         var width = (int)Math.Ceiling(RootGrid.DesiredSize.Width * scale);
         var height = (int)Math.Ceiling(RootGrid.DesiredSize.Height * scale);
         width = Math.Max(width, (int)(360 * scale));
@@ -127,14 +129,6 @@ public sealed partial class CapturePickerWindow : Window
         _windowWidth = width;
         _windowHeight = height;
         _windowScale = scale;
-    }
-
-    private void ApplyRoundedRegion(int width, int height, double scale)
-    {
-        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var radius = (int)Math.Round(CornerRadiusDip * scale);
-        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, radius, radius);
-        SetWindowRgn(hwnd, region, true);
     }
 
     private void BuildTimerFlyout()
@@ -212,75 +206,12 @@ public sealed partial class CapturePickerWindow : Window
 
     // Drag-anywhere support: the R / S / W / timer / cancel buttons handle their own
     // pointer events (marking them handled), so a drag only starts on the bar background.
-    // Window movement is anchored to absolute cursor position (not element-relative,
-    // which feeds back and jitters as the window moves under the pointer).
-    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
+    // Delegates to FloatingWindowDragger which anchors movement to absolute cursor position.
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerPressed(sender, e);
 
-        GetCursorPos(out _dragCursorStart);
-        _dragWindowStart = AppWindow.Position;
-        _dragging = element.CapturePointer(e.Pointer);
-    }
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerMoved(sender, e);
 
-    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
-    {
-        if (!_dragging)
-        {
-            return;
-        }
-
-        GetCursorPos(out var current);
-        var dx = current.X - _dragCursorStart.X;
-        var dy = current.Y - _dragCursorStart.Y;
-
-        if (dx == 0 && dy == 0)
-        {
-            return;
-        }
-
-        AppWindow.Move(new PointInt32(_dragWindowStart.X + dx, _dragWindowStart.Y + dy));
-    }
-
-    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
-
-        _dragging = false;
-        element.ReleasePointerCapture(e.Pointer);
-    }
-
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int X;
-        public int Y;
-    }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern bool GetCursorPos(out POINT lpPoint);
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern uint GetDpiForWindow(nint hwnd);
-
-    private double GetScale()
-    {
-        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var dpi = GetDpiForWindow(hwnd);
-        return dpi <= 0 ? 1.0 : dpi / 96.0;
-    }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-    private static extern int SetWindowRgn(nint hWnd, nint hRgn, [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)] bool bRedraw);
-
-    [System.Runtime.InteropServices.DllImport("gdi32.dll")]
-    private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {

--- a/windows/src/TinyClips.App/Views/ClipsManagerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ClipsManagerWindow.xaml
@@ -19,27 +19,17 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!--  Title bar  -->
-        <Grid
+        <!--  Title bar (native WinUI TitleBar; subtitle updated in code via AppTitleBar.Subtitle)  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="56"
-            Padding="20,0">
-            <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Spacing="8">
-                <FontIcon
-                    FontFamily="Segoe Fluent Icons"
-                    FontSize="16"
-                    Foreground="{ThemeResource AccentFillColorDefaultBrush}"
-                    Glyph="&#xEB9F;" />
-                <TextBlock
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="Your captures" />
-                <TextBlock
-                    x:Name="LibrarySummaryText"
-                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}" />
-            </StackPanel>
-        </Grid>
+            AutomationProperties.AutomationId="ClipsManagerTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Tiny Clips — Library">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <!--  Library toolbar  -->
         <Grid

--- a/windows/src/TinyClips.App/Views/ClipsManagerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ClipsManagerWindow.xaml.cs
@@ -178,15 +178,24 @@ public sealed partial class ClipItemViewModel : ObservableObject
 [SupportedOSPlatform("windows10.0.22000.0")]
 public sealed partial class ClipsManagerWindow : Window
 {
-    private const string SettingsKeyViewMode = "clipsManagerViewMode";
-    private const string SettingsKeyFilter   = "clipsManagerFilter";
+    // Minimum dimensions chosen to fit the toolbar (filter, toggle, refresh buttons with 20 px
+    // side padding) and at least one full grid-card row (ItemHeight = 256 DIP + chrome).
+    // Width 480 DIP: toolbar minimum ~380 DIP + buffer; grid card 332+padding fits in one column.
+    // Height 520 DIP: TitleBar ~48 + toolbar ~60 + one grid card 256 + bottom padding 20 = ~384;
+    // 520 provides comfortable headroom while matching the SettingsWindow width floor.
+    private const int MinimumWidthDip  = 480;
+    private const int MinimumHeightDip = 520;
+
+    private const string SettingsKeyViewMode   = "clipsManagerViewMode";
+    private const string SettingsKeyFilter     = "clipsManagerFilter";
     private const string SettingsKeyDateFilter = "clipsManagerDateFilter";
-    private const string SettingsKeySort     = "clipsManagerSort";
+    private const string SettingsKeySort       = "clipsManagerSort";
 
     private readonly IClipLibraryService _library;
     private readonly IUploadcareUploadService _uploadcare;
     private readonly ISettingsService _settings;
     private readonly ICaptureSettings _captureSettings;
+    private readonly WindowChromeController _chromeController;
 
     private readonly ObservableCollection<ClipItemViewModel> _visibleClips = [];
     private IReadOnlyList<ClipItemViewModel> _allClips = [];
@@ -196,9 +205,9 @@ public sealed partial class ClipsManagerWindow : Window
 
     public ClipsManagerWindow()
     {
-        _library  = App.Services.GetRequiredService<IClipLibraryService>();
-        _uploadcare = App.Services.GetRequiredService<IUploadcareUploadService>();
-        _settings = App.Services.GetRequiredService<ISettingsService>();
+        _library       = App.Services.GetRequiredService<IClipLibraryService>();
+        _uploadcare    = App.Services.GetRequiredService<IUploadcareUploadService>();
+        _settings      = App.Services.GetRequiredService<ISettingsService>();
         _captureSettings = App.Services.GetRequiredService<ICaptureSettings>();
 
         InitializeComponent();
@@ -209,13 +218,28 @@ public sealed partial class ClipsManagerWindow : Window
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         AppWindowPlacement.CenterInCurrentWorkAreaAtDipSize(AppWindow, hwnd, 1600, 820);
 
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
+
         ApplyTheme();
         RestorePersistedState();
 
         ClipsGridView.ItemsSource = _visibleClips;
         ClipsListView.ItemsSource = _visibleClips;
 
+        // OnFirstActivated loads clips after the window is visible; it self-unsubscribes.
         Activated += OnFirstActivated;
+        Closed += OnClosed;
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        // Ensure OnFirstActivated is unsubscribed even if the window is closed before its
+        // first activation (the normal self-unsubscribe in OnFirstActivated handles the common
+        // path; this is belt-and-suspenders for the early-close edge case).
+        Activated -= OnFirstActivated;
+        Closed -= OnClosed;
     }
 
     private void ApplyTheme()
@@ -271,7 +295,7 @@ public sealed partial class ClipsManagerWindow : Window
 
     private void UpdateContentVisibility()
     {
-        LibrarySummaryText.Text = _visibleClips.Count switch
+        AppTitleBar.Subtitle = _visibleClips.Count switch
         {
             0 => "No captures",
             1 => "1 capture",

--- a/windows/src/TinyClips.App/Views/CountdownWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CountdownWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Text;
 using Microsoft.UI.Windowing;
@@ -21,7 +20,6 @@ public sealed partial class CountdownWindow : Window
 {
     private const int SizeDip = 132;
     private const int CornerRadiusDip = 8;
-    private const uint WdaExcludeFromCapture = 0x11;
 
     private readonly DispatcherQueueTimer _timer;
     private readonly TaskCompletionSource<bool> _completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -200,19 +198,8 @@ public sealed partial class CountdownWindow : Window
 
         // Clip the square window to a rounded square (matching the card) and keep it
         // out of recordings.
-        var radius = AppWindowPlacement.DipToPixels(CornerRadiusDip, target.Scale);
-        var region = CreateRoundRectRgn(0, 0, size + 1, size + 1, radius, radius);
-        SetWindowRgn(hwnd, region, true);
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        OverlayWindowHelpers.ApplyRoundedRegion(hwnd, size, size, target.Scale, CornerRadiusDip);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
     }
 
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);
-
-    [DllImport("gdi32.dll")]
-    private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
 }

--- a/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml
@@ -20,16 +20,17 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid
+        <!--  Native WinUI TitleBar: icon, title, drag region, and DWM chrome.  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="48"
-            Padding="16,0">
-            <TextBlock
-                VerticalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="Trim GIF" />
-        </Grid>
+            AutomationProperties.AutomationId="GifTrimmerTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Trim GIF">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <!--  Preview  -->
         <Grid

--- a/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
@@ -22,6 +22,14 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class GifTrimmerWindow : Window
 {
+    // Minimum dimensions chosen to keep the trim bar, frame stepper, and footer legible.
+    // Width 560 DIP: trim bar needs at least ~360px; footer has PlayToggle + SpeedCombo (96) +
+    //   three action buttons (~300px) + spacing/padding, totalling ~480 + 80 margins.
+    // Height 480 DIP: TitleBar (~48) + preview floor (~160) + trim section (~160) + footer (~92)
+    //   + margins (~20). GIF frames are often smaller than video so the floor is set lower.
+    private const int MinimumWidthDip  = 560;
+    private const int MinimumHeightDip = 480;
+
     private readonly string _filePath;
     private readonly List<SoftwareBitmap> _frames = new();
     private readonly List<ushort> _delays = new();
@@ -32,6 +40,8 @@ public sealed partial class GifTrimmerWindow : Window
     private bool _ready;
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _playTimer;
     private int _playIndex;
+
+    private readonly WindowChromeController _chromeController;
 
     public GifTrimmerWindow(string filePath)
     {
@@ -45,6 +55,11 @@ public sealed partial class GifTrimmerWindow : Window
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         AppWindowPlacement.CenterInCurrentWorkAreaAtHalfSize(AppWindow);
+
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed. The Closed subscription is
+        // additive; both the controller's cleanup and the existing OnWindowClosed handler run.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
 
         var settings = App.Services.GetRequiredService<ICaptureSettings>();
         RootGrid.RequestedTheme = settings.Theme switch

--- a/windows/src/TinyClips.App/Views/GuideWindow.xaml
+++ b/windows/src/TinyClips.App/Views/GuideWindow.xaml
@@ -18,16 +18,17 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid
+        <!--  Native WinUI TitleBar: icon, drag region, and DWM chrome.  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="48"
-            Padding="16,0">
-            <TextBlock
-                VerticalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="Guide" />
-        </Grid>
+            AutomationProperties.AutomationId="GuideTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Tiny Clips Guide">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <ScrollViewer Grid.Row="1" Padding="0,0,0,24">
             <StackPanel
@@ -39,7 +40,7 @@
                 <TextBlock
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource BodyTextBlockStyle}"
-                    Text="Tiny Clips lives in your system tray. Click the tray icon any time to take a screenshot, record video, or capture a GIF." />
+                    Text="Tiny Clips lives in your system tray. Click the tray icon any time to capture a screenshot, video, GIF, or text from your screen." />
 
                 <!--  Capture modes  -->
                 <TextBlock
@@ -51,16 +52,20 @@
                     <StackPanel Spacing="12">
                         <local:GuideRow
                             Glyph="&#xE722;"
-                            Subtitle="Capture a region, a single window, or a full screen as a PNG or JPEG."
+                            Subtitle="Save a region, window, or full screen as PNG or JPEG, then annotate or crop in the built-in editor."
                             Title="Screenshot" />
                         <local:GuideRow
                             Glyph="&#xE714;"
-                            Subtitle="Record your screen to an MP4 video with a configurable frame rate."
+                            Subtitle="Record your screen to MP4 with optional microphone audio and a webcam overlay."
                             Title="Video" />
                         <local:GuideRow
                             Glyph="&#xE786;"
-                            Subtitle="Record a short, looping animated GIF, perfect for sharing."
+                            Subtitle="Record a short animated GIF with a configurable frame rate, maximum width, and click highlights."
                             Title="GIF" />
+                        <local:GuideRow
+                            Glyph="&#xE8D2;"
+                            Subtitle="Select a screen region; Windows OCR extracts the text and copies it straight to the clipboard."
+                            Title="Recognize Text" />
                     </StackPanel>
                 </Border>
 
@@ -84,6 +89,10 @@
                             Glyph="&#xE737;"
                             Subtitle="Press W to capture a specific application window."
                             Title="Window" />
+                        <local:GuideRow
+                            Glyph="&#xE8D2;"
+                            Subtitle="Press T to select a region and copy its recognized text to the clipboard."
+                            Title="Recognize Text" />
                     </StackPanel>
                 </Border>
 
@@ -160,6 +169,25 @@
                             <TextBlock
                                 VerticalAlignment="Center"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
+                                Text="Recognize text" />
+                            <Border
+                                Grid.Column="1"
+                                Padding="10,4"
+                                Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                CornerRadius="{ThemeResource ControlCornerRadius}">
+                                <TextBlock
+                                    x:Name="OcrShortcut"
+                                    FontFamily="Consolas" />
+                            </Border>
+                        </Grid>
+                        <Grid ColumnSpacing="16">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="Stop recording" />
                             <Border
                                 Grid.Column="1"
@@ -173,6 +201,91 @@
                         </Grid>
                     </StackPanel>
                 </Border>
+
+                <!--  Screenshot editor  -->
+                <TextBlock
+                    Margin="4,16,0,4"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Text="Screenshot editor" />
+
+                <Border Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="12">
+                        <local:GuideRow
+                            Glyph="&#xE70F;"
+                            Subtitle="Add rectangles, ellipses, arrows, lines, free-hand drawing, text labels, and numbered badges. Drag handles to reposition or resize any annotation after it is placed."
+                            Title="Annotations" />
+                        <local:GuideRow
+                            Glyph="&#xED1A;"
+                            Subtitle="Permanently obscure sensitive content with the Redact tool, or trim the canvas to any size with Crop. Undo steps back through every change."
+                            Title="Redact and crop" />
+                    </StackPanel>
+                </Border>
+
+                <!--  Recording extras  -->
+                <TextBlock
+                    Margin="4,16,0,4"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Text="Recording extras" />
+
+                <Border Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="12">
+                        <local:GuideRow
+                            Glyph="&#xE8B8;"
+                            Subtitle="Overlay a live webcam feed during video recording. Configure shape, corner placement, and size in Settings → Video."
+                            Title="Webcam overlay" />
+                        <local:GuideRow
+                            Glyph="&#xE720;"
+                            Subtitle="Record system audio, microphone audio, or both. Choose your microphone in Settings → Video."
+                            Title="System and microphone audio" />
+                        <local:GuideRow
+                            Glyph="&#xE916;"
+                            Subtitle="Add a countdown before recording starts, cap the recording length, and keep the display awake for the full session — all in Settings → Video."
+                            Title="Countdown and time limit" />
+                        <local:GuideRow
+                            Glyph="&#xE8A5;"
+                            Subtitle="Enable a scrolling text overlay to read from a script while recording. Configure transcript and speed in Settings → Teleprompter."
+                            Title="Teleprompter" />
+                    </StackPanel>
+                </Border>
+
+                <!--  Tray quick access  -->
+                <TextBlock
+                    Margin="4,16,0,4"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Text="Tray quick access" />
+
+                <Border Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="12">
+                        <local:GuideRow
+                            Glyph="&#xE7AA;"
+                            Subtitle="Left- or right-click the tray icon to open the quick access popup. Screenshot, Video, and GIF tiles each show the current shortcut. Use Capture Text for instant OCR."
+                            Title="Quick access popup" />
+                        <local:GuideRow
+                            Glyph="&#xE81C;"
+                            Subtitle="Open your most recent captures or browse save folders by capture type directly from the popup, without opening the full library."
+                            Title="Recent captures and folders" />
+                    </StackPanel>
+                </Border>
+
+                <!--  Clips Library  -->
+                <TextBlock
+                    Margin="4,16,0,4"
+                    Style="{StaticResource SubtitleTextBlockStyle}"
+                    Text="Clips Library" />
+
+                <Border Style="{StaticResource SettingCardStyle}">
+                    <StackPanel Spacing="12">
+                        <local:GuideRow
+                            Glyph="&#xEB9F;"
+                            Subtitle="Browse all your screenshots, videos, and GIFs in a responsive three-column grid. Open, copy, reveal in Explorer, or delete any capture from the library."
+                            Title="Browse and manage captures" />
+                        <local:GuideRow
+                            Glyph="&#xE71C;"
+                            Subtitle="Filter by capture type and date range (Today, This week, This month) using the Sort &amp; filter flyout in the library toolbar."
+                            Title="Sort and filter" />
+                    </StackPanel>
+                </Border>
+
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/windows/src/TinyClips.App/Views/GuideWindow.xaml
+++ b/windows/src/TinyClips.App/Views/GuideWindow.xaml
@@ -277,7 +277,7 @@
                     <StackPanel Spacing="12">
                         <local:GuideRow
                             Glyph="&#xEB9F;"
-                            Subtitle="Browse all your screenshots, videos, and GIFs in a responsive three-column grid. Open, copy, reveal in Explorer, or delete any capture from the library."
+                            Subtitle="Browse all your screenshots, videos, and GIFs in a responsive grid. Open, copy, reveal in Explorer, or delete any capture from the library."
                             Title="Browse and manage captures" />
                         <local:GuideRow
                             Glyph="&#xE71C;"

--- a/windows/src/TinyClips.App/Views/GuideWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/GuideWindow.xaml.cs
@@ -7,11 +7,17 @@ using Windows.Graphics;
 namespace TinyClips.App;
 
 /// <summary>
-/// Read-only help reference describing capture modes, the region/screen/window picker,
-/// and the current keyboard shortcuts.
+/// Read-only overview of capture modes, shortcuts, editing, recording, and library features.
 /// </summary>
 public sealed partial class GuideWindow : Window
 {
+    // 460×400 DIP: scrollable content; guide opens at 720×860 so the minimum is deliberately
+    // narrow — text wraps, the MaxWidth=720 inner panel simply centres when the window is wider.
+    private const int MinimumWidthDip  = 460;
+    private const int MinimumHeightDip = 400;
+
+    private readonly WindowChromeController _chromeController;
+
     public GuideWindow()
     {
         InitializeComponent();
@@ -19,7 +25,12 @@ public sealed partial class GuideWindow : Window
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        AppWindowPlacement.CenterInCurrentWorkAreaAtDipSize(AppWindow, hwnd, 720, 760);
+        AppWindowPlacement.CenterInCurrentWorkAreaAtDipSize(AppWindow, hwnd, 720, 860);
+
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed. GuideWindow has no other
+        // subscriptions so no additive Closed handler is needed.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
 
         var settings = App.Services.GetRequiredService<ICaptureSettings>();
         RootGrid.RequestedTheme = settings.Theme switch
@@ -33,6 +44,7 @@ public sealed partial class GuideWindow : Window
         ScreenshotShortcut.Text = hotKeys.GetBinding(HotKeyAction.Screenshot).DisplayString;
         VideoShortcut.Text = hotKeys.GetBinding(HotKeyAction.RecordVideo).DisplayString;
         GifShortcut.Text = hotKeys.GetBinding(HotKeyAction.RecordGif).DisplayString;
+        OcrShortcut.Text = hotKeys.GetBinding(HotKeyAction.RecognizeText).DisplayString;
         StopRecordingShortcut.Text = hotKeys.StopRecordingDisplayString;
     }
 }

--- a/windows/src/TinyClips.App/Views/GuideWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/GuideWindow.xaml.cs
@@ -11,8 +11,8 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class GuideWindow : Window
 {
-    // 460×400 DIP: scrollable content; guide opens at 720×860 so the minimum is deliberately
-    // narrow — text wraps, the MaxWidth=720 inner panel simply centres when the window is wider.
+    // 460 x 400 DIP: scrollable content; guide opens at 720 x 860 so the minimum is deliberately
+    // narrow; text wraps, and the MaxWidth=720 inner panel simply centers when the window is wider.
     private const int MinimumWidthDip  = 460;
     private const int MinimumHeightDip = 400;
 

--- a/windows/src/TinyClips.App/Views/OnboardingWindow.xaml
+++ b/windows/src/TinyClips.App/Views/OnboardingWindow.xaml
@@ -13,22 +13,37 @@
     </Window.SystemBackdrop>
 
     <Grid x:Name="RootGrid">
+        <Grid.Resources>
+            <!--  Step-indicator dot styles — Fill is resolved from the element's live theme context,
+                  which is safe in High Contrast and all other themes.  -->
+            <Style
+                x:Key="DotActiveStyle"
+                TargetType="Ellipse">
+                <Setter Property="Fill" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+            </Style>
+            <Style
+                x:Key="DotInactiveStyle"
+                TargetType="Ellipse">
+                <Setter Property="Fill" Value="{ThemeResource ControlStrongFillColorDefaultBrush}" />
+            </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid
+        <!--  Native WinUI TitleBar: icon, drag region, and DWM chrome.  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="48"
-            Padding="16,0">
-            <TextBlock
-                VerticalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="Welcome" />
-        </Grid>
+            AutomationProperties.AutomationId="OnboardingTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Welcome to Tiny Clips">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <!--  Steps  -->
         <Grid Grid.Row="1" Padding="48,16">
@@ -201,17 +216,17 @@
                     x:Name="Dot0"
                     Width="8"
                     Height="8"
-                    Fill="{ThemeResource AccentFillColorDefaultBrush}" />
+                    Style="{StaticResource DotActiveStyle}" />
                 <Ellipse
                     x:Name="Dot1"
                     Width="8"
                     Height="8"
-                    Fill="{ThemeResource ControlStrongFillColorDefaultBrush}" />
+                    Style="{StaticResource DotInactiveStyle}" />
                 <Ellipse
                     x:Name="Dot2"
                     Width="8"
                     Height="8"
-                    Fill="{ThemeResource ControlStrongFillColorDefaultBrush}" />
+                    Style="{StaticResource DotInactiveStyle}" />
             </StackPanel>
 
             <Button

--- a/windows/src/TinyClips.App/Views/OnboardingWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/OnboardingWindow.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 using Windows.Graphics;
@@ -17,8 +16,14 @@ public sealed partial class OnboardingWindow : Window
 {
     private const int LastStep = 2;
 
+    // 480×520 DIP: step 2 (the densest step) holds an 88-DIP illustration, title, body,
+    // shortcut card, and navigation footer; 520 keeps all content in-frame at 100% DPI.
+    private const int MinimumWidthDip  = 480;
+    private const int MinimumHeightDip = 520;
+
     private readonly ICaptureSettings _settings;
     private int _step;
+    private readonly WindowChromeController _chromeController;
 
     public OnboardingWindow()
     {
@@ -30,6 +35,11 @@ public sealed partial class OnboardingWindow : Window
         SetTitleBar(AppTitleBar);
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         AppWindowPlacement.CenterInCurrentWorkAreaAtDipSize(AppWindow, hwnd, 720, 640);
+
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed. The window's own Close() calls
+        // are not lifecycle subscriptions, so no additive handler is needed.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
 
         RootGrid.RequestedTheme = _settings.Theme switch
         {
@@ -85,10 +95,10 @@ public sealed partial class OnboardingWindow : Window
         SkipButton.Visibility = _step >= LastStep ? Visibility.Collapsed : Visibility.Visible;
         NextButton.Content = _step >= LastStep ? "Get started" : "Next";
 
-        var active = (SolidColorBrush)Application.Current.Resources["AccentFillColorDefaultBrush"];
-        var inactive = (SolidColorBrush)Application.Current.Resources["ControlStrongFillColorDefaultBrush"];
-        Dot0.Fill = _step == 0 ? active : inactive;
-        Dot1.Fill = _step == 1 ? active : inactive;
-        Dot2.Fill = _step == 2 ? active : inactive;
+        var active = (Style)RootGrid.Resources["DotActiveStyle"];
+        var inactive = (Style)RootGrid.Resources["DotInactiveStyle"];
+        Dot0.Style = _step == 0 ? active : inactive;
+        Dot1.Style = _step == 1 ? active : inactive;
+        Dot2.Style = _step == 2 ? active : inactive;
     }
 }

--- a/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Window.SystemBackdrop>
-        <MicaBackdrop />
+        <DesktopAcrylicBackdrop />
     </Window.SystemBackdrop>
 
     <Grid Background="Transparent">

--- a/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using TinyClips.Core.Capture;
@@ -19,8 +18,6 @@ public sealed partial class ProcessingIndicatorWindow : Window
     private const int WidthDip = 220;
     private const int HeightDip = 64;
     private const int TopOffsetDip = 24;
-
-    private const uint WdaExcludeFromCapture = 0x11;
 
     private bool _closed;
 
@@ -48,7 +45,7 @@ public sealed partial class ProcessingIndicatorWindow : Window
 
         // Keep the panel out of any concurrent capture.
         var hwnd = WindowNative.GetWindowHandle(this);
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
     }
 
     public void ClosePanel()
@@ -96,7 +93,4 @@ public sealed partial class ProcessingIndicatorWindow : Window
         _closed = true;
     }
 
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
 }

--- a/windows/src/TinyClips.App/Views/QuickBugReportWindow.xaml
+++ b/windows/src/TinyClips.App/Views/QuickBugReportWindow.xaml
@@ -10,21 +10,22 @@
 
     <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
-            <RowDefinition Height="48" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid x:Name="AppTitleBar" Padding="16,0">
-            <StackPanel VerticalAlignment="Center" Orientation="Horizontal" Spacing="8">
-                <FontIcon
-                    FontFamily="Segoe Fluent Icons"
-                    FontSize="16"
-                    Foreground="{ThemeResource AccentFillColorDefaultBrush}"
-                    Glyph="&#xEBE8;" />
-                <TextBlock Style="{StaticResource CaptionTextBlockStyle}" Text="File a Bug" />
-            </StackPanel>
-        </Grid>
+        <!--  Native WinUI TitleBar: icon, drag region, and DWM chrome.  -->
+        <TitleBar
+            x:Name="AppTitleBar"
+            Grid.Row="0"
+            AutomationProperties.AutomationId="QuickBugReportTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="File a Bug">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <ScrollViewer
             Grid.Row="1"

--- a/windows/src/TinyClips.App/Views/QuickBugReportWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/QuickBugReportWindow.xaml.cs
@@ -1,12 +1,21 @@
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
+using TinyClips.Core.Models;
+using TinyClips.Core.Services;
 
 namespace TinyClips.App;
 
 public sealed partial class QuickBugReportWindow : Window
 {
+	// 480×500 DIP: keeps the fixed button-bar footer and enough scrollable form area
+	// visible at any display density. Form opens at 620×640 by default.
+	private const int MinimumWidthDip  = 480;
+	private const int MinimumHeightDip = 500;
+
 	private readonly string _version;
 	private readonly string _distribution;
+	private readonly WindowChromeController _chromeController;
 
 	public QuickBugReportWindow(string version, string distribution)
 	{
@@ -19,6 +28,19 @@ public sealed partial class QuickBugReportWindow : Window
 		SetTitleBar(AppTitleBar);
 		var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
 		AppWindowPlacement.CenterInCurrentWorkAreaAtDipSize(AppWindow, hwnd, 620, 640);
+
+		// WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+		// scale tracking, and cleanup of all three on Closed. The window's own Close() calls
+		// in event handlers are not lifecycle subscriptions, so no additive handler is needed.
+		_chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
+
+		var settings = App.Services.GetRequiredService<ICaptureSettings>();
+		RootGrid.RequestedTheme = settings.Theme switch
+		{
+			AppTheme.Light => ElementTheme.Light,
+			AppTheme.Dark => ElementTheme.Dark,
+			_ => ElementTheme.Default,
+		};
 
 		AppInfoText.Text =
 			$"Automatically included: Windows, Tiny Clips v{version}, {distribution}, {System.Runtime.InteropServices.RuntimeInformation.OSDescription}";

--- a/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml
+++ b/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml
@@ -11,6 +11,8 @@
     <Grid
         x:Name="RootGrid"
         Background="Transparent"
+        PointerCanceled="OnPointerCaptureEnded"
+        PointerCaptureLost="OnPointerCaptureEnded"
         PointerMoved="OnPointerMoved"
         PointerPressed="OnPointerPressed"
         PointerReleased="OnPointerReleased">

--- a/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml
+++ b/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Window.SystemBackdrop>
-        <MicaBackdrop />
+        <DesktopAcrylicBackdrop />
     </Window.SystemBackdrop>
 
     <Grid
@@ -18,7 +18,7 @@
             Padding="12,8"
             Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-            BorderThickness="0"
+            BorderThickness="1"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Border.Shadow>
                 <ThemeShadow />

--- a/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Windowing;
@@ -21,15 +20,10 @@ public sealed partial class RecordingIndicatorWindow : Window
     private const int TopOffsetDip = 24;
     private const int RegionOutsideOffsetDip = 12;
 
-    private const uint WdaExcludeFromCapture = 0x11;
-
     private bool _finishRequested;
     private string _stopHintText = "Stop from tray";
     private bool _closed;
-
-    private bool _dragging;
-    private POINT _dragCursorStart;
-    private PointInt32 _dragWindowStart;
+    private readonly FloatingWindowDragger _dragger;
 
     public RecordingIndicatorWindow(string stopHint)
     {
@@ -41,6 +35,7 @@ public sealed partial class RecordingIndicatorWindow : Window
         HotKeyText.Text = _stopHintText;
 
         ConfigurePresenter();
+        _dragger = new FloatingWindowDragger(AppWindow);
         Closed += OnClosed;
     }
 
@@ -68,7 +63,7 @@ public sealed partial class RecordingIndicatorWindow : Window
         // Exclude the floating panel from screen capture so it never appears in the
         // recorded video/GIF.
         var hwnd = WindowNative.GetWindowHandle(this);
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
     }
 
     public void UpdateElapsed(TimeSpan elapsed)
@@ -211,48 +206,12 @@ public sealed partial class RecordingIndicatorWindow : Window
 
     // Drag-anywhere support: pressing the Stop button is handled by the Button itself
     // (it marks the pointer event handled), so dragging only begins on the panel surface.
-    // Anchored to absolute cursor position to avoid feedback jitter as the window moves.
-    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
+    // Delegates to FloatingWindowDragger which anchors movement to absolute cursor position.
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerPressed(sender, e);
 
-        GetCursorPos(out _dragCursorStart);
-        _dragWindowStart = AppWindow.Position;
-        _dragging = element.CapturePointer(e.Pointer);
-    }
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerMoved(sender, e);
 
-    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
-    {
-        if (!_dragging)
-        {
-            return;
-        }
-
-        GetCursorPos(out var current);
-        var dx = current.X - _dragCursorStart.X;
-        var dy = current.Y - _dragCursorStart.Y;
-
-        if (dx == 0 && dy == 0)
-        {
-            return;
-        }
-
-        AppWindow.Move(new PointInt32(_dragWindowStart.X + dx, _dragWindowStart.Y + dy));
-    }
-
-    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
-
-        _dragging = false;
-        element.ReleasePointerCapture(e.Pointer);
-    }
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
 
     private void ConfigurePresenter()
     {
@@ -309,17 +268,4 @@ public sealed partial class RecordingIndicatorWindow : Window
         MicrophoneMuteChanged = null;
     }
 
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int X;
-        public int Y;
-    }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern bool GetCursorPos(out POINT lpPoint);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
 }

--- a/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RecordingIndicatorWindow.xaml.cs
@@ -213,6 +213,8 @@ public sealed partial class RecordingIndicatorWindow : Window
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
 
+    private void OnPointerCaptureEnded(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerCaptureEnded(sender, e);
+
     private void ConfigurePresenter()
     {
         var presenter = OverlappedPresenter.CreateForContextMenu();

--- a/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml
+++ b/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml
@@ -13,6 +13,8 @@
         x:Name="RootGrid"
         Background="Transparent"
         KeyDown="OnKeyDown"
+        PointerCanceled="OnPointerCaptureEnded"
+        PointerCaptureLost="OnPointerCaptureEnded"
         PointerMoved="OnPointerMoved"
         PointerPressed="OnPointerPressed"
         PointerReleased="OnPointerReleased">

--- a/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
@@ -581,4 +581,6 @@ public sealed partial class RecordingSetupWindow : Window
     private void OnPointerMoved(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerMoved(sender, e);
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
+
+    private void OnPointerCaptureEnded(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerCaptureEnded(sender, e);
 }

--- a/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -44,7 +43,6 @@ public sealed partial class RecordingSetupWindow : Window
 {
     private const int TopOffsetDip = 24;
     private const int RegionOutsideOffsetDip = 12;
-    private const uint WdaExcludeFromCapture = 0x11;
 
     private readonly TaskCompletionSource<RecordingSetupResult?> _result = new();
     private readonly CaptureType _captureType;
@@ -63,9 +61,7 @@ public sealed partial class RecordingSetupWindow : Window
     private bool _microphonePermissionPending;
     private bool _webcamPermissionPending;
 
-    private bool _dragging;
-    private POINT _dragCursorStart;
-    private PointInt32 _dragWindowStart;
+    private readonly FloatingWindowDragger _dragger;
 
     private RecordingSetupWindow(
         CaptureType captureType,
@@ -99,6 +95,7 @@ public sealed partial class RecordingSetupWindow : Window
             settings.WebcamCornerRadius);
 
         ConfigurePresenter();
+        _dragger = new FloatingWindowDragger(AppWindow);
         ConfigureForCaptureType();
         UpdateMouseClicksVisual();
         UpdateStartButtonEnabled();
@@ -209,7 +206,7 @@ public sealed partial class RecordingSetupWindow : Window
         RootGrid.Focus(FocusState.Programmatic);
 
         var hwnd = WindowNative.GetWindowHandle(this);
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
     }
 
     private void PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
@@ -576,58 +573,12 @@ public sealed partial class RecordingSetupWindow : Window
         AutomationProperties.SetName(MouseClicksToggle, $"Mouse click visuals {state}");
     }
 
-    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
+    // Drag-anywhere support: interactive controls mark pointer events handled; dragging
+    // only begins on the setup panel background.
+    // Delegates to FloatingWindowDragger which anchors movement to absolute cursor position.
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerPressed(sender, e);
 
-        GetCursorPos(out _dragCursorStart);
-        _dragWindowStart = AppWindow.Position;
-        _dragging = element.CapturePointer(e.Pointer);
-    }
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerMoved(sender, e);
 
-    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
-    {
-        if (!_dragging)
-        {
-            return;
-        }
-
-        GetCursorPos(out var current);
-        var dx = current.X - _dragCursorStart.X;
-        var dy = current.Y - _dragCursorStart.Y;
-        if (dx == 0 && dy == 0)
-        {
-            return;
-        }
-
-        AppWindow.Move(new PointInt32(_dragWindowStart.X + dx, _dragWindowStart.Y + dy));
-    }
-
-    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is not UIElement element)
-        {
-            return;
-        }
-
-        _dragging = false;
-        element.ReleasePointerCapture(e.Pointer);
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int X;
-        public int Y;
-    }
-
-    [DllImport("user32.dll")]
-    private static extern bool GetCursorPos(out POINT lpPoint);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
 }

--- a/windows/src/TinyClips.App/Views/RegionIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RegionIndicatorWindow.xaml.cs
@@ -22,7 +22,6 @@ public sealed partial class RegionIndicatorWindow : Window
     private const int GwlExStyle = -20;
     private const long WsExLayered = 0x00080000;
     private const long WsExTransparent = 0x00000020;
-    private const uint WdaExcludeFromCapture = 0x11;
     private const int RgnDiff = 4;
 
     private bool _closed;
@@ -117,7 +116,7 @@ public sealed partial class RegionIndicatorWindow : Window
         var newStyle = (nint)(exStyle | WsExLayered | WsExTransparent);
         SetWindowLongPtr(hwnd, GwlExStyle, newStyle);
 
-        SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
     }
 
     // 32/64-bit-safe GetWindowLongPtr / SetWindowLongPtr wrappers. On 32-bit Windows the
@@ -139,10 +138,6 @@ public sealed partial class RegionIndicatorWindow : Window
 
     [DllImport("user32.dll", EntryPoint = "SetWindowLongW")]
     private static extern int SetWindowLong32(nint hwnd, int index, int value);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);

--- a/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml
@@ -59,6 +59,7 @@
                 <Button
                     HorizontalAlignment="Right"
                     AutomationProperties.AutomationId="ScreenPickerCancel"
+                    AutomationProperties.Name="Cancel screen capture"
                     Click="OnCancel"
                     Content="Cancel" />
             </StackPanel>

--- a/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml.cs
@@ -65,7 +65,9 @@ public sealed partial class ScreenPickerWindow : Window
         }
 
         _layoutApplied = true;
-        ApplyRoundedRegion(_windowWidth, _windowHeight, _windowScale);
+        OverlayWindowHelpers.ApplyRoundedRegion(
+            WinRT.Interop.WindowNative.GetWindowHandle(this),
+            _windowWidth, _windowHeight, _windowScale, CornerRadiusDip);
     }
 
     private void ConfigurePresenter()
@@ -79,7 +81,8 @@ public sealed partial class ScreenPickerWindow : Window
 
     private void CenterOnPrimaryDisplay(int width, int height)
     {
-        var scale = GetScale();
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        var scale = AppWindowPlacement.GetScaleForWindow(hwnd);
         var w = (int)Math.Round(width * scale);
         var h = (int)Math.Round(height * scale);
 
@@ -95,30 +98,6 @@ public sealed partial class ScreenPickerWindow : Window
         _windowHeight = h;
         _windowScale = scale;
     }
-
-    private void ApplyRoundedRegion(int width, int height, double scale)
-    {
-        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var radius = (int)Math.Round(CornerRadiusDip * scale);
-        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, radius, radius);
-        SetWindowRgn(hwnd, region, true);
-    }
-
-    private double GetScale()
-    {
-        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var dpi = GetDpiForWindow(hwnd);
-        return dpi <= 0 ? 1.0 : dpi / 96.0;
-    }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern uint GetDpiForWindow(nint hwnd);
-
-    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-    private static extern int SetWindowRgn(nint hWnd, nint hRgn, [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)] bool bRedraw);
-
-    [System.Runtime.InteropServices.DllImport("gdi32.dll")]
-    private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
 
     private void Complete(MonitorInfo? monitor)
     {

--- a/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml
@@ -19,16 +19,17 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Grid
+        <!--  Native WinUI TitleBar: icon, title, drag region, and DWM chrome.  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="48"
-            Padding="16,0">
-            <TextBlock
-                VerticalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="Edit screenshot" />
-        </Grid>
+            AutomationProperties.AutomationId="ScreenshotEditorTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Edit Screenshot">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <!--  Output actions  -->
         <Border

--- a/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml.cs
@@ -21,8 +21,16 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class ScreenshotEditorWindow : Window
 {
+    // Minimum dimensions chosen to keep the tool rail + inspector + a usable canvas visible.
+    // Width 760 DIP: tool rail (~52) + inspector (~200) + canvas floor (~300) + margins (~208).
+    // The CommandBar will gracefully overflow AppBarButtons into its "More" menu below this width.
+    // Height 520 DIP: TitleBar (~48) + CommandBar row (~60) + canvas floor (~300) + padding (~112).
+    private const int MinimumWidthDip  = 760;
+    private const int MinimumHeightDip = 520;
+
     private readonly string _filePath;
     private readonly EditorController _controller;
+    private readonly WindowChromeController _chromeController;
     private string _activeSavePath;
 
     public ScreenshotEditorWindow(string filePath)
@@ -43,6 +51,11 @@ public sealed partial class ScreenshotEditorWindow : Window
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         AppWindowPlacement.CenterInCurrentWorkAreaAtHalfSize(AppWindow);
+
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed. The Closed subscription here is
+        // additive; both this controller's cleanup and the existing OnClosed handler below run.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
 
         var settings = App.Services.GetRequiredService<ICaptureSettings>();
         RootGrid.RequestedTheme = settings.Theme switch

--- a/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
@@ -22,8 +22,6 @@ public sealed partial class TeleprompterWindow : Window
     private const int HeightDip = 140;
     private const int TopOffsetDip = 24;
 
-    private const uint WdaExcludeFromCapture = 0x11;
-
     // The capture-exclusion style makes the window read back as fully transparent to XAML
     // hit-testing; a ~1% alpha background keeps the panel draggable without showing a fill.
     private static readonly SolidColorBrush SizingSurfaceBrush = new(Microsoft.UI.ColorHelper.FromArgb(1, 0, 0, 0));
@@ -68,7 +66,7 @@ public sealed partial class TeleprompterWindow : Window
     public bool TryShow()
     {
         var hwnd = WindowNative.GetWindowHandle(this);
-        if (!SetWindowDisplayAffinity(hwnd, WdaExcludeFromCapture))
+        if (!OverlayWindowHelpers.ExcludeFromCapture(hwnd))
         {
             var error = Marshal.GetLastWin32Error();
             Debug.WriteLine($"Teleprompter capture exclusion failed (Win32 error {error}); overlay will remain hidden.");
@@ -293,8 +291,4 @@ public sealed partial class TeleprompterWindow : Window
 
     [DllImport("user32.dll")]
     private static extern bool GetCursorPos(out POINT lpPoint);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
 }

--- a/windows/src/TinyClips.App/Views/VideoTrimmerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/VideoTrimmerWindow.xaml
@@ -20,16 +20,17 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid
+        <!--  Native WinUI TitleBar: icon, title, drag region, and DWM chrome.  -->
+        <TitleBar
             x:Name="AppTitleBar"
             Grid.Row="0"
-            Height="48"
-            Padding="16,0">
-            <TextBlock
-                VerticalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="Trim video" />
-        </Grid>
+            AutomationProperties.AutomationId="VideoTrimmerTitleBar"
+            IsPaneToggleButtonVisible="False"
+            Title="Trim Video">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <!--  Preview  -->
         <Grid

--- a/windows/src/TinyClips.App/Views/VideoTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/VideoTrimmerWindow.xaml.cs
@@ -22,6 +22,13 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class VideoTrimmerWindow : Window
 {
+    // Minimum dimensions chosen to keep the trim bar, playback controls, and footer legible.
+    // Width 640 DIP: trim bar needs at least ~400px; footer has SpeedCombo (96) + RemoveAudio
+    //   checkbox + three buttons (~300px) + spacing/padding, totalling ~540 + 100 margins.
+    // Height 520 DIP: TitleBar (~48) + preview floor (~200) + trim section (~180) + footer (~92).
+    private const int MinimumWidthDip  = 640;
+    private const int MinimumHeightDip = 520;
+
     private readonly string _filePath;
     private TimeSpan _duration = TimeSpan.Zero;
     private double _startSeconds;
@@ -32,6 +39,8 @@ public sealed partial class VideoTrimmerWindow : Window
 
     // Step a 1/30s "frame" since the recorded fps isn't exposed by the WinRT clip API.
     private static readonly TimeSpan FrameStep = TimeSpan.FromSeconds(1.0 / 30.0);
+
+    private readonly WindowChromeController _chromeController;
 
     public VideoTrimmerWindow(string filePath)
     {
@@ -45,6 +54,11 @@ public sealed partial class VideoTrimmerWindow : Window
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         AppWindowPlacement.CenterInCurrentWorkAreaAtHalfSize(AppWindow);
+
+        // WindowChromeController owns: icon-on-activation, DIP minimum enforcement, XamlRoot
+        // scale tracking, and cleanup of all three on Closed. The Closed subscription is
+        // additive; both the controller's cleanup and the existing OnWindowClosed handler run.
+        _chromeController = new WindowChromeController(this, RootGrid, MinimumWidthDip, MinimumHeightDip);
 
         var settings = App.Services.GetRequiredService<ICaptureSettings>();
         RootGrid.RequestedTheme = settings.Theme switch

--- a/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
@@ -16,8 +16,6 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class WebcamPreviewWindow : Window
 {
-    private const uint WdaExcludeFromCapture = 0x11;
-
     private readonly IWebcamCaptureService _capture;
     private readonly RectInt32 _captureBounds;
     private readonly int _margin;
@@ -54,7 +52,7 @@ public sealed partial class WebcamPreviewWindow : Window
 
     public void Show()
     {
-        if (!SetWindowDisplayAffinity(WindowNative.GetWindowHandle(this), WdaExcludeFromCapture))
+        if (!OverlayWindowHelpers.ExcludeFromCapture(WindowNative.GetWindowHandle(this)))
         {
             ClosePanel();
             return;
@@ -278,8 +276,4 @@ public sealed partial class WebcamPreviewWindow : Window
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetWindowRect(nint hwnd, out RECT rect);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetWindowDisplayAffinity(nint hwnd, uint affinity);
 }

--- a/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml
@@ -11,7 +11,9 @@
     <Grid x:Name="RootGrid" Background="Transparent">
         <Border
             Padding="24"
-           BorderThickness="0"
+            Background="{ThemeResource LayerFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="1"
             CornerRadius="8">
             <Grid RowSpacing="16">
                 <Grid.RowDefinitions>
@@ -58,6 +60,7 @@
                     Grid.Row="2"
                     HorizontalAlignment="Right"
                     AutomationProperties.AutomationId="WindowPickerCancel"
+                    AutomationProperties.Name="Cancel window capture"
                     Click="OnCancel"
                     Content="Cancel" />
             </Grid>

--- a/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml.cs
@@ -57,7 +57,9 @@ public sealed partial class WindowPickerWindow : Window
         }
 
         _layoutApplied = true;
-        ApplyRoundedRegion(_windowWidth, _windowHeight, _windowScale);
+        OverlayWindowHelpers.ApplyRoundedRegion(
+            WindowNative.GetWindowHandle(this),
+            _windowWidth, _windowHeight, _windowScale, CornerRadiusDip);
     }
 
     private void ConfigurePresenter()
@@ -71,7 +73,8 @@ public sealed partial class WindowPickerWindow : Window
 
     private void CenterOnPrimaryDisplay(int width, int height)
     {
-        var scale = GetScale();
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var scale = AppWindowPlacement.GetScaleForWindow(hwnd);
         var w = (int)Math.Round(width * scale);
         var h = (int)Math.Round(height * scale);
 
@@ -87,30 +90,6 @@ public sealed partial class WindowPickerWindow : Window
         _windowHeight = h;
         _windowScale = scale;
     }
-
-    private void ApplyRoundedRegion(int width, int height, double scale)
-    {
-        var hwnd = WindowNative.GetWindowHandle(this);
-        var radius = (int)Math.Round(CornerRadiusDip * scale);
-        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, radius, radius);
-        SetWindowRgn(hwnd, region, true);
-    }
-
-    private double GetScale()
-    {
-        var hwnd = WindowNative.GetWindowHandle(this);
-        var dpi = GetDpiForWindow(hwnd);
-        return dpi <= 0 ? 1.0 : dpi / 96.0;
-    }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern uint GetDpiForWindow(nint hwnd);
-
-    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-    private static extern int SetWindowRgn(nint hWnd, nint hRgn, [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)] bool bRedraw);
-
-    [System.Runtime.InteropServices.DllImport("gdi32.dll")]
-    private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
 
     private void Complete(nint? hwnd)
     {


### PR DESCRIPTION
Refactor Windows overlays: shared helpers, DPI, drag, icons

Consolidate overlay window logic into OverlayWindowHelpers and FloatingWindowDragger for native interop, capture exclusion, region clipping, and drag-anywhere support. Add WindowChromeController for standard windows to manage app icon, DPI-aware minimum sizing, and scale tracking. Update all overlays and secondary windows to use these helpers, ensuring consistent behavior and removing duplicated P/Invoke code. Improve accessibility, theme consistency, and update Guide/docs for new OCR/text capture and tray features. Add "Capture Text" to tray popup.