### PR TITLE
Fix mac release version override

### DIFF
--- a/.github/skills/tag-new-release/SKILL.md
+++ b/.github/skills/tag-new-release/SKILL.md
@@ -36,7 +36,7 @@ On Windows, use PowerShell:
 powershell -ExecutionPolicy Bypass -File .github/skills/tag-new-release/tag-new-release.ps1 -Platform windows -Version v1.0.9-windows
 ```
 
-If `--version` is omitted:
+If `--version` is provided, that exact tag value is used for the release. If `--version` is omitted:
 - macOS defaults to `v<Info.plist CFBundleShortVersionString>.0-mac` (for example, `v1.5.0-mac`)
 - Windows defaults to incrementing patch from the latest `v*-windows` tag.
 
@@ -46,7 +46,7 @@ When asked to tag a new release:
 
 1. **Check existing tags** - Inspect recent git tags for the selected platform.
 2. **Determine release version**:
-   - macOS: Validate against `mac/TinyClips/Info.plist` `CFBundleShortVersionString`
+   - macOS: If the user provides a tag version, use it as the source of truth; otherwise validate it against `mac/TinyClips/Info.plist` `CFBundleShortVersionString`
    - Windows: Use provided tag or infer by incrementing the latest `-windows` patch tag
 3. **Read platform changelog**:
    - macOS: root `CHANGELOG.md`
@@ -83,7 +83,8 @@ The tag message should include cleanly formatted release notes from the selected
 - Do not create a release tag from a dirty working directory.
 - Do not overwrite an existing tag.
 - Do not push tags without explicit user approval.
-- If the requested version conflicts with app version or existing tags, stop and ask the user how to proceed.
+- If the requested version conflicts with existing tags, stop and ask the user how to proceed.
+- When the version is provided explicitly by the user, honor that value even if it differs from the app's current `Info.plist` version.
 
 ## Files included
 

--- a/.github/skills/tag-new-release/tag-new-release.ps1
+++ b/.github/skills/tag-new-release/tag-new-release.ps1
@@ -118,22 +118,36 @@ if ($Platform -eq "mac") {
     $unreleasedLine = "## Unreleased"
     $infoPlistPath = Join-Path $repoRoot "mac\TinyClips\Info.plist"
     $appVersion = Get-PlistValue -Path $infoPlistPath -KeyName "CFBundleShortVersionString"
+    $userProvidedVersion = $PSBoundParameters.ContainsKey('Version')
 
     if (-not $Version) {
-        if ($appVersion -notmatch '^[0-9]+\.[0-9]+$') {
-            throw "mac app version must be X.Y in Info.plist, got: $appVersion"
+        if ($appVersion -match '^[0-9]+\.[0-9]+$') {
+            $Version = "v$appVersion.0-mac"
+        } elseif ($appVersion -match '^[0-9]+\.[0-9]+\.[0-9]+$') {
+            $Version = "v$appVersion-mac"
+        } else {
+            throw "mac app version must be X.Y or X.Y.Z in Info.plist, got: $appVersion"
         }
-        $Version = "v$appVersion.0-mac"
     }
 
-    if ($Version -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(-mac)?$') {
-        throw "Invalid mac version format: $Version (expected vX.Y.Z or vX.Y.Z-mac)"
+    if ($Version -notmatch '^v[0-9]+(\.[0-9]+){2,3}(-mac)?$') {
+        throw "Invalid mac version format: $Version (expected vX.Y.Z[-mac], vX.Y.Z.W[-mac])"
     }
     if ($Version -notmatch '-mac$') {
         $Version = "$Version-mac"
     }
-    if ($Version -notmatch "^v$([regex]::Escape($appVersion))\.[0-9]+-mac$") {
-        throw "mac tag version ($Version) does not align with Info.plist version ($appVersion)."
+    if (-not $userProvidedVersion) {
+        if ($appVersion -match '^[0-9]+\.[0-9]+$') {
+            $expectedVersion = "v$appVersion.0-mac"
+        } elseif ($appVersion -match '^[0-9]+\.[0-9]+\.[0-9]+$') {
+            $expectedVersion = "v$appVersion-mac"
+        } else {
+            throw "mac app version must be X.Y or X.Y.Z in Info.plist, got: $appVersion"
+        }
+
+        if ($Version -ne $expectedVersion) {
+            throw "mac tag version ($Version) does not align with Info.plist version ($appVersion)."
+        }
     }
 } else {
     $changelogPath = Join-Path $repoRoot "windows\CHANGELOG.md"

--- a/.github/skills/tag-new-release/tag-new-release.sh
+++ b/.github/skills/tag-new-release/tag-new-release.sh
@@ -96,11 +96,14 @@ if [[ -n "$INPUT_VERSION" ]]; then
     VERSION="$INPUT_VERSION"
 else
     if [[ "$PLATFORM" == "mac" ]]; then
-        if [[ ! "$APP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ mac app version must be X.Y in Info.plist, got: $APP_VERSION" >&2
+        if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            VERSION="v${APP_VERSION}.0-mac"
+        elif [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION="v${APP_VERSION}-mac"
+        else
+            echo "❌ mac app version must be X.Y or X.Y.Z in Info.plist, got: $APP_VERSION" >&2
             exit 1
         fi
-        VERSION="v${APP_VERSION}.0-mac"
     else
         LATEST_WINDOWS_TAG="$(git tag --list 'v*-windows' --sort=-creatordate | head -n 1)"
         if [[ -z "$LATEST_WINDOWS_TAG" ]]; then
@@ -118,17 +121,27 @@ else
 fi
 
 if [[ "$PLATFORM" == "mac" ]]; then
-    if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-mac)?$ ]]; then
+    if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+){2,3}(-mac)?$ ]]; then
         echo "❌ Invalid mac version format: $VERSION" >&2
-        echo "Expected: vX.Y.Z or vX.Y.Z-mac" >&2
+        echo "Expected: vX.Y.Z[-mac], vX.Y.Z.W[-mac]" >&2
         exit 1
     fi
     if [[ ! "$VERSION" =~ -mac$ ]]; then
         VERSION="${VERSION}-mac"
     fi
-    if [[ -n "$APP_VERSION" && ! "$VERSION" =~ ^v${APP_VERSION}\.[0-9]+-mac$ ]]; then
-        echo "❌ mac tag version ($VERSION) does not align with Info.plist version ($APP_VERSION)." >&2
-        exit 1
+    if [[ -z "$INPUT_VERSION" && -n "$APP_VERSION" ]]; then
+        if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            EXPECTED_VERSION="v${APP_VERSION}.0-mac"
+        elif [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            EXPECTED_VERSION="v${APP_VERSION}-mac"
+        else
+            echo "❌ mac app version must be X.Y or X.Y.Z in Info.plist, got: $APP_VERSION" >&2
+            exit 1
+        fi
+        if [[ "$VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "❌ mac tag version ($VERSION) does not align with Info.plist version ($APP_VERSION)." >&2
+            exit 1
+        fi
     fi
     RELEASE_HEADING="## ${VERSION} - ${TODAY}"
     SECTION_HEADER_PREFIX="### "


### PR DESCRIPTION
## Summary

Honor an explicitly provided mac release tag during `prepare` instead of rejecting it against the current `Info.plist` value.

## Changes

- allow local release prep to use a user-provided tag like `v1.6.1-mac`
- only enforce the `Info.plist` version check when inferring the tag automatically
- update release tool docs to clarify the override behavior

## Validation

- verified the explicit override succeeds in a dry-run release prepare
- verified the default inferred mac version still matches the app plist when no override is provided