### PR TITLE
Fix release metadata PR base branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,6 +467,7 @@ jobs:
       - name: Create release metadata pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          base: main
           commit-message: "Update release metadata for ${{ env.RELEASE_TAG }}"
           branch: release-metadata/${{ env.RELEASE_TAG }}
           delete-branch: true


### PR DESCRIPTION
## Summary

Fix the macOS release workflow failure when creating the release metadata PR from a detached HEAD checkout.

## Root cause

`peter-evans/create-pull-request@v7` requires an explicit `base` branch when the action runs on a tag checkout instead of a normal branch.

## Fix

- add `base: main` to the `Create release metadata pull request` step in `.github/workflows/release.yml`

## Validation

- confirmed the workflow YAML still parses correctly after the change