### PR TITLE
Fix release PR auto-merge under branch protection

### DIFF
--- a/.github/extensions/tinyclips-release-hub/release-data.mjs
+++ b/.github/extensions/tinyclips-release-hub/release-data.mjs
@@ -896,7 +896,7 @@ export async function performReleaseAction(action, input) {
             throw new Error(`Release PR #${pullRequest.number} is still a draft.`);
         }
         if (pullRequest.state === "OPEN") {
-            await run("gh", ["pr", "merge", String(pullRequest.number), "--merge", "--delete-branch"]);
+            await run("gh", ["pr", "merge", String(pullRequest.number), "--merge", "--auto", "--delete-branch"]);
         }
         const merged = JSON.parse(await run("gh", [
             "pr", "view", String(pullRequest.number),
@@ -941,7 +941,7 @@ export async function performReleaseAction(action, input) {
         if (pullRequest.isDraft) {
             throw new Error(`Release metadata PR #${pullRequest.number} is still a draft.`);
         }
-        await run("gh", ["pr", "merge", String(pullRequest.number), "--merge", "--delete-branch"]);
+        await run("gh", ["pr", "merge", String(pullRequest.number), "--merge", "--auto", "--delete-branch"]);
         const merged = JSON.parse(await run("gh", [
             "pr", "view", String(pullRequest.number),
             "--json", "state,mergedAt,mergeCommit,url",


### PR DESCRIPTION
## Summary
- Update release metadata merge automation to use GitHub auto-merge (`gh pr merge --merge --auto --delete-branch`) so protected base branches can merge after required checks pass.
- This keeps release PRs moving without bypassing branch protection.

## Why
The release hub was merging release metadata PRs with `gh pr merge --merge --delete-branch` only. Under branch protection, GitHub rejects that flow unless the merge is allowed to wait for checks via `--auto`.

## Validation
- Parsed the updated JS module with Node successfully.
- The explicit override behavior for release tags was already validated in the prior release-prep fix.