### PR TITLE
Add transcript import from text file to Teleprompter (Win)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,8 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Teleprompter transcript file import** — Settings → Teleprompter can now load a `.txt`, `.md`,
+  or `.csv` file up to 1 MB to replace the recording transcript.
 - **Tray Capture Text** — A compact action beside **Clips Library** starts region text recognition
   and copies the result to the clipboard.
 - **OCR region capture** — Select **Recognize Text** in the capture picker or press `Ctrl+Shift+T`

--- a/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml
@@ -32,7 +32,23 @@
 
         <Border Style="{StaticResource SettingCardStyle}">
             <StackPanel Spacing="8">
-                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Transcript" />
+                <Grid ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="Transcript" />
+                    <Button
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="LoadTeleprompterTranscriptButton"
+                        AutomationProperties.Name="Load teleprompter transcript from text file"
+                        Click="OnLoadTranscriptClicked"
+                        Content="Load Text File..."
+                        IsEnabled="{x:Bind ViewModel.TeleprompterEnabled, Mode=OneWay}" />
+                </Grid>
                 <TextBox
                     MinHeight="160"
                     AcceptsReturn="True"
@@ -45,7 +61,7 @@
                 <TextBlock
                     Style="{StaticResource CaptionTextBlockStyle}"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Text="Shown for video recordings only — never for GIFs or screenshots. The overlay stays hidden while this is empty."
+                    Text="Paste or type a script, or load a plain-text file up to 1 MB. Shown for video recordings only — never for GIFs or screenshots."
                     TextWrapping="Wrap" />
             </StackPanel>
         </Border>

--- a/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml.cs
+++ b/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml.cs
@@ -23,6 +23,9 @@ public sealed partial class TeleprompterSettingsSection : UserControl, ISettings
 
     public SettingsViewModel ViewModel { get; }
 
+    /// <summary>Raised when the user requests to load a transcript file.</summary>
+    public event EventHandler? LoadTranscriptRequested;
+
     public TeleprompterSettingsSection(SettingsViewModel viewModel)
     {
         ViewModel = viewModel;
@@ -109,6 +112,11 @@ public sealed partial class TeleprompterSettingsSection : UserControl, ISettings
         UpdatePreviewButton();
         PreviewScroller.ChangeView(null, 0, null, disableAnimation: true);
         StartPreviewIfPossible();
+    }
+
+    private void OnLoadTranscriptClicked(object sender, RoutedEventArgs e)
+    {
+        LoadTranscriptRequested?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnPreviewTick(object? sender, object e)

--- a/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
@@ -243,14 +243,14 @@ public sealed partial class SettingsWindow : Window
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
 
-        var file = await picker.PickSingleFileAsync();
-        if (file is null)
-        {
-            return;
-        }
-
         try
         {
+            var file = await picker.PickSingleFileAsync();
+            if (file is null)
+            {
+                return;
+            }
+
             var properties = await file.GetBasicPropertiesAsync();
             if (properties.Size > MaximumTranscriptSizeInBytes)
             {

--- a/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class SettingsWindow : Window
 {
     private const int MinimumWidthDip = 480;
     private const int MinimumHeightDip = 640;
+    private const ulong MaximumTranscriptSizeInBytes = 1_000_000;
 
     private readonly Dictionary<SettingsSectionKind, UserControl> _sectionCache = new();
     private XamlRoot? _xamlRoot;
@@ -171,7 +172,7 @@ public sealed partial class SettingsWindow : Window
             SettingsSectionKind.Video => new VideoSettingsSection(ViewModel),
             SettingsSectionKind.Gif => new GifSettingsSection(ViewModel),
             SettingsSectionKind.MouseClicks => new MouseClicksSettingsSection(ViewModel),
-            SettingsSectionKind.Teleprompter => new TeleprompterSettingsSection(ViewModel),
+            SettingsSectionKind.Teleprompter => CreateTeleprompterSection(),
             SettingsSectionKind.Hotkeys => new HotkeysSettingsSection(ViewModel),
             SettingsSectionKind.About => new AboutSettingsSection(ViewModel),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),
@@ -185,6 +186,13 @@ public sealed partial class SettingsWindow : Window
     {
         var section = new GeneralSettingsSection(ViewModel);
         section.BrowseSaveDirectoryRequested += OnBrowseSaveDirectoryRequested;
+        return section;
+    }
+
+    private TeleprompterSettingsSection CreateTeleprompterSection()
+    {
+        var section = new TeleprompterSettingsSection(ViewModel);
+        section.LoadTranscriptRequested += OnLoadTranscriptRequested;
         return section;
     }
 
@@ -220,5 +228,56 @@ public sealed partial class SettingsWindow : Window
                     break;
             }
         }
+    }
+
+    private async void OnLoadTranscriptRequested(object? sender, EventArgs e)
+    {
+        var picker = new FileOpenPicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+        };
+        picker.FileTypeFilter.Add(".txt");
+        picker.FileTypeFilter.Add(".md");
+        picker.FileTypeFilter.Add(".csv");
+
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+
+        var file = await picker.PickSingleFileAsync();
+        if (file is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var properties = await file.GetBasicPropertiesAsync();
+            if (properties.Size > MaximumTranscriptSizeInBytes)
+            {
+                await ShowTranscriptLoadErrorAsync("The selected transcript is larger than 1 MB.");
+                return;
+            }
+
+            ViewModel.TeleprompterTranscript = await FileIO.ReadTextAsync(file);
+        }
+        catch (Exception)
+        {
+            await ShowTranscriptLoadErrorAsync(
+                "The selected file could not be loaded. Choose a plain-text file that is 1 MB or smaller.");
+        }
+    }
+
+    private async Task ShowTranscriptLoadErrorAsync(string message)
+    {
+        var dialog = new ContentDialog
+        {
+            CloseButtonText = "Close",
+            Content = message,
+            DefaultButton = ContentDialogButton.Close,
+            Title = "Unable to load transcript",
+            XamlRoot = RootGrid.XamlRoot,
+        };
+
+        await dialog.ShowAsync();
     }
 }


### PR DESCRIPTION
Add transcript import from text file to Teleprompter (Win)

Users can now import a teleprompter transcript from .txt, .md, or .csv files (up to 1 MB) in the Windows app's Settings → Teleprompter section. A "Load Text File..." button opens a file picker; valid file contents replace the transcript. Errors (e.g., file too large, unreadable) show a dialog. Includes UI, event, and file handling logic.

#### PR Classification
New feature: Adds transcript import functionality to the Windows app's Teleprompter settings.

#### PR Summary
Enables users to import teleprompter transcripts from text files (.txt, .md, .csv, up to 1 MB) via a new "Load Text File..." button in Teleprompter settings. Handles file selection, validation, and error feedback.
- Updated Teleprompter settings UI to add and wire up the "Load Text File..." button.
- Implemented file picker logic and transcript replacement in the relevant ViewModel/controller.
- Added error handling and user dialogs for invalid or oversized files.
