### PR TITLE
Windows: capture flow performance pass, latency tracing, and recorder pre-warm

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,15 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Capture flow latency instrumentation** — `CaptureFlowTrace` records elapsed/delta timings at
+  every transition of the capture flow (picker, region overlay, backdrop, countdown, recorder
+  start/stop, editor/trimmer). Output goes to the debugger always, and to
+  `%LOCALAPPDATA%\TinyClips\Temp\capture-flow-trace.log` in Debug builds or when the
+  `TINYCLIPS_CAPTURE_TRACE` environment variable is set, so lag can be measured in packaged builds.
+- **Screenshot source setting** — Settings → Screenshot → *Re-capture screen after region
+  selection* (off by default). Off saves the frozen frame shown behind the region overlay
+  instantly (Snipping Tool behavior, no second capture); on re-captures the live screen after the
+  overlay closes, which reflects changes made while selecting.
 - **Tray Capture Text** — A compact action beside **Clips Library** starts region text recognition
   and copies the result to the clipboard.
 - **OCR region capture** — Select **Recognize Text** in the capture picker or press `Ctrl+Shift+T`
@@ -17,6 +26,38 @@ own `CHANGELOG.md` at the repository root.
   recording and enabled by default.
 
 ### Changed
+- **Much snappier capture flow** — A performance pass over every transition between hotkey/tray,
+  picker, region overlay, countdown, recorder, and editor/trimmer:
+  - The 150 ms "wait for the tray menu" pause before every capture is gone; the tray popup,
+    capture picker, and region overlay are excluded from capture (`WDA_EXCLUDEFROMCAPTURE`) so
+    capturing can start immediately.
+  - The region overlay's frozen screen backdrop is captured *while the picker bar is still
+    showing* and handed to the overlay, which is created immediately and reveals itself as soon as
+    the frame is painted (event-driven) instead of after fixed 250 ms + 50 ms delays. The backdrop
+    upload uses `SoftwareBitmapSource` off the UI thread instead of a `WriteableBitmap` copy.
+  - One process-wide shared Direct3D 11 device (multithread-protected, recreated on device
+    removal) replaces the 3–4 devices previously created per capture; single-frame monitor
+    captures settle after one frame instead of two; pixel readback uses a single contiguous copy
+    when the pitch allows.
+  - Region screenshots are cropped from the already-captured backdrop instead of performing a
+    second WGC capture (unless a countdown ran or the new *Re-capture* setting is on).
+  - The screenshot editor opens directly from the in-memory frame while PNG/JPEG encoding, the
+    disk write, and the clipboard copy run in the background; Save / Save a copy / Open folder
+    wait for the file if it is still being written. (When a screenshot downscale is configured the
+    editor stays file-backed so its pixels match the saved file.)
+  - Video/GIF recorders gain `PrepareAsync`: the capture session, H.264 transcoder, webcam, and
+    audio devices are pre-warmed during the countdown so recording starts the instant it reaches
+    zero; `StartAsync` reuses the prepared pipeline when the target/region match and the pipeline
+    is discarded cleanly if the flow is cancelled.
+  - The countdown signals completion as soon as it reaches zero (its card is already excluded from
+    capture) instead of waiting 140 ms fade + 80 ms before recording starts.
+  - The capture picker bar is now a single pooled window that is hidden/shown between captures
+    instead of being created and destroyed (with its acrylic backdrop) on every hotkey press.
+  - The GIF trimmer shows its first frame immediately and decodes the remaining frames in the
+    background (previously it decoded every frame serially before the window became usable).
+  - Picker re-open after a capture no longer stacks two 150 ms delays.
+  - Release builds publish with ReadyToRun so first-use of each overlay window type doesn't pay JIT
+    cost.
 - **Updated Guide window** — The guide now covers OCR, configurable shortcuts, screenshot editing,
   recording options, tray quick access, and Clips Library management.
 - **Guide tray icon** — The Guide action now uses a document icon instead of a help question mark.

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -103,6 +103,8 @@ public partial class App : Application
         RegisterGlobalHotKeys();
         ShowOnboardingIfNeeded();
         HandleFileActivation();
+        // Create the shared D3D capture device off the UI thread so the first capture is instant.
+        _ = Task.Run(() => Services.GetRequiredService<IScreenCaptureService>().WarmUp());
 #if !TINYCLIPS_STORE_BUILD
         _ = RunStartupUpdateCheckAsync();
 #endif
@@ -528,10 +530,17 @@ public partial class App : Application
 
         var captureFlowCts = new CancellationTokenSource();
         _captureFlowCts = captureFlowCts;
+        Task<CapturedFrame?[]>? earlyBackdrops = null;
+        IReadOnlyList<MonitorInfo>? earlyBackdropMonitors = null;
+        long earlyBackdropStarted = 0;
         try
         {
-            // Give the tray menu a moment to dismiss so it isn't part of the capture.
-            await Task.Delay(150);
+            CaptureFlowTrace.Begin(type.ToString().ToLowerInvariant() + (forcedMode is null ? string.Empty : $"/{forcedMode}"));
+
+            // The tray popup and picker are excluded from capture (WDA_EXCLUDEFROMCAPTURE), so
+            // there is no longer any need to pause for the menu to dismiss before capturing.
+            // Warm the shared D3D capture device in the background so the first capture is fast.
+            Services.GetRequiredService<IScreenCaptureService>().WarmUp();
 
             // For an auto-reopened picker, bail out if a recording started during the delay.
             if (abortIfRecording && (_isExiting || IsAnyRecordingActive()))
@@ -542,6 +551,19 @@ public partial class App : Application
             var settings = Services.GetRequiredService<ICaptureSettings>();
             var (cdEnabled, cdDuration) = GetCountdown(settings, type);
             var wasPickerInitiated = forcedMode is null && settings.ShouldShowCapturePicker(type);
+            if (wasPickerInitiated)
+            {
+                // Start grabbing the region-overlay backdrop while the user reads the picker bar,
+                // so choosing "Region" shows the overlay immediately. If the user dawdles the
+                // frame is refreshed on selection (see ResolveTargetAsync) so it never goes stale.
+                earlyBackdropMonitors = ResolveBackdropMonitors(settings);
+                if (earlyBackdropMonitors.Count > 0)
+                {
+                    earlyBackdropStarted = Stopwatch.GetTimestamp();
+                    earlyBackdrops = RegionSelectController.CaptureBackdropsAsync(earlyBackdropMonitors);
+                }
+            }
+
             var pick = wasPickerInitiated
                 ? await CapturePickerWindow.RunAsync(type, cdEnabled, cdDuration, settings.VideoRecordingTimeLimitMinutes)
                 : new CapturePickerResult(
@@ -549,23 +571,31 @@ public partial class App : Application
                     cdEnabled,
                     cdDuration,
                     settings.VideoRecordingTimeLimitMinutes);
+            CaptureFlowTrace.Mark($"picker: result {(pick is null ? "cancelled" : pick.Mode.ToString())}");
             if (pick is null)
             {
                 return;
             }
 
             var isTextRecognition = pick.Mode == CapturePickerMode.RecognizeText;
+            var earlyBackdrop = earlyBackdrops is null
+                ? null
+                : new EarlyBackdrop(earlyBackdropMonitors!, earlyBackdrops, earlyBackdropStarted);
             var resolved = await ResolveTargetAsync(
-                isTextRecognition ? CapturePickerMode.Region : pick.Mode);
+                isTextRecognition ? CapturePickerMode.Region : pick.Mode,
+                earlyBackdrop);
+            CaptureFlowTrace.Mark($"target: {(resolved is null ? "cancelled" : "resolved")}");
             if (resolved is not { } selection)
             {
                 return;
             }
 
             RecordingSetupResult? recordingSetup = null;
+            Task? recorderPrepare = null;
             if (type is CaptureType.Video or CaptureType.Gif)
             {
                 recordingSetup = await ShowRecordingSetupAsync(type, selection, settings);
+                CaptureFlowTrace.Mark($"setup: {(recordingSetup is null ? "cancelled" : "confirmed")}");
                 if (recordingSetup is null)
                 {
                     CloseRecordingRegionIndicator();
@@ -573,6 +603,10 @@ public partial class App : Application
                 }
 
                 ApplyRecordingSetup(type, recordingSetup, settings);
+
+                // Pre-warm the whole recording pipeline (capture session, encoder, webcam, audio)
+                // while the countdown runs so the recording starts the instant it hits zero.
+                recorderPrepare = PrepareRecorderAsync(type, selection, captureFlowCts.Token);
             }
 
             var showDisabledStopDuringCountdown = type is CaptureType.Video or CaptureType.Gif
@@ -584,7 +618,8 @@ public partial class App : Application
             }
 
             RegionIndicatorWindow? regionIndicator = null;
-            if (pick.CountdownEnabled && pick.CountdownDuration > 0)
+            var countdownRan = pick.CountdownEnabled && pick.CountdownDuration > 0;
+            if (countdownRan)
             {
                 try
                 {
@@ -632,26 +667,13 @@ public partial class App : Application
 
                 case CaptureType.Screenshot:
                     captureFlowCts.Token.ThrowIfCancellationRequested();
-                    var screenshots = Services.GetRequiredService<IScreenshotService>();
-                    var path = await screenshots.CaptureTargetAsync(selection.Target, selection.Region);
-                    Services.GetRequiredService<IRecentCaptureService>().Record(path, CaptureType.Screenshot);
-                    await CopyToClipboardAsync(path, CaptureType.Screenshot);
-                    if (settings.ShowScreenshotEditor)
-                    {
-                        OpenScreenshotEditor(path, reopenPickerAfterClose: wasPickerInitiated);
-                    }
-                    else
-                    {
-                        RevealInExplorer(path);
-                        ShowSaveToast(path);
-                        ReopenPickerAfterCaptureIfNeeded(CaptureType.Screenshot, wasPickerInitiated);
-                    }
+                    await CaptureScreenshotAndPresentAsync(selection, settings, countdownRan, wasPickerInitiated, captureFlowCts.Token);
                     break;
 
                 case CaptureType.Video:
                     captureFlowCts.Token.ThrowIfCancellationRequested();
                     settings.VideoRecordingTimeLimitMinutes = (int)Math.Round(Math.Max(0, pick.VideoTimeLimitMinutes));
-                    _activeRecordingSelection = selection;
+                    _activeRecordingSelection = selection with { Backdrop = null };
                     _activeRecordingType = CaptureType.Video;
                     _activeRecordingWasPickerInitiated = wasPickerInitiated;
                     ShowRecordingRegionIndicator(selection);
@@ -660,15 +682,17 @@ public partial class App : Application
                         ShowRecordingIndicator(CaptureType.Video, selection);
                     }
                     AcquireDisplaySleepAssertionIfEnabled();
+                    await AwaitRecorderPrepareAsync(recorderPrepare);
                     await Services.GetRequiredService<IVideoRecordingService>()
                         .StartAsync(selection.Target, selection.Region, pick.VideoTimeLimitMinutes, captureFlowCts.Token);
+                    CaptureFlowTrace.Mark("video: StartAsync returned");
                     ActivateRecordingIndicatorForStartedCapture(CaptureType.Video);
                     UpdateRecordingState();
                     break;
 
                 case CaptureType.Gif:
                     captureFlowCts.Token.ThrowIfCancellationRequested();
-                    _activeRecordingSelection = selection;
+                    _activeRecordingSelection = selection with { Backdrop = null };
                     _activeRecordingType = CaptureType.Gif;
                     _activeRecordingWasPickerInitiated = wasPickerInitiated;
                     ShowRecordingRegionIndicator(selection);
@@ -677,8 +701,10 @@ public partial class App : Application
                         ShowRecordingIndicator(CaptureType.Gif, selection);
                     }
                     AcquireDisplaySleepAssertionIfEnabled();
+                    await AwaitRecorderPrepareAsync(recorderPrepare);
                     await Services.GetRequiredService<IGifRecordingService>()
                         .StartAsync(selection.Target, selection.Region, captureFlowCts.Token);
+                    CaptureFlowTrace.Mark("gif: StartAsync returned");
                     ActivateRecordingIndicatorForStartedCapture(CaptureType.Gif);
                     UpdateRecordingState();
                     break;
@@ -686,6 +712,8 @@ public partial class App : Application
         }
         catch (OperationCanceledException)
         {
+            CaptureFlowTrace.Mark("flow cancelled");
+            _ = DiscardPreparedRecordersAsync();
             CloseRecordingRegionIndicator();
             HideRecordingIndicatorIfNotRecording();
             _activeRecordingSelection = null;
@@ -700,6 +728,8 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Capture failed: {ex}");
+            CaptureFlowTrace.Mark($"flow failed: {ex.GetType().Name}");
+            _ = DiscardPreparedRecordersAsync();
             ShowSaveFailureNotification(CaptureOutputDescription(type));
             UpdateRecordingState();
             CloseRecordingRegionIndicator();
@@ -721,6 +751,158 @@ public partial class App : Application
 
             captureFlowCts.Dispose();
         }
+    }
+
+    /// <summary>Monitor(s) the region overlay will cover, mirroring <see cref="ResolveTargetAsync"/>.</summary>
+    private static IReadOnlyList<MonitorInfo> ResolveBackdropMonitors(ICaptureSettings settings)
+    {
+        var monitors = Services.GetRequiredService<IMonitorService>();
+        var all = monitors.GetMonitors();
+        if (all.Count == 0)
+        {
+            return all;
+        }
+
+        var preferred = ResolvePreferredMonitor(monitors, settings.MultiMonitorCaptureMode);
+        return preferred is { } single ? new[] { single } : all;
+    }
+
+    // A backdrop captured while the picker was showing; refreshed if older than this on use.
+    private static readonly TimeSpan EarlyBackdropMaxAge = TimeSpan.FromMilliseconds(600);
+
+    private sealed record EarlyBackdrop(IReadOnlyList<MonitorInfo> Monitors, Task<CapturedFrame?[]> Frames, long StartedTimestamp)
+    {
+        public bool IsFreshFor(IReadOnlyList<MonitorInfo> monitors) =>
+            Stopwatch.GetElapsedTime(StartedTimestamp) <= EarlyBackdropMaxAge
+            && monitors.Count == Monitors.Count
+            && monitors.Zip(Monitors).All(pair => pair.First.HMonitor == pair.Second.HMonitor);
+    }
+
+    private Task PrepareRecorderAsync(CaptureType type, TargetSelection selection, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return type == CaptureType.Video
+                ? Services.GetRequiredService<IVideoRecordingService>().PrepareAsync(selection.Target, selection.Region, cancellationToken)
+                : Services.GetRequiredService<IGifRecordingService>().PrepareAsync(selection.Target, selection.Region, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Waits for a background pre-warm to settle. Failures are swallowed here: StartAsync will
+    /// rebuild the pipeline itself and surface any real error through the normal path.
+    /// </summary>
+    private static async Task AwaitRecorderPrepareAsync(Task? prepare)
+    {
+        if (prepare is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await prepare;
+            CaptureFlowTrace.Mark("recorder: pre-warm complete");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Recorder pre-warm failed (will retry in StartAsync): {ex}");
+            CaptureFlowTrace.Mark("recorder: pre-warm failed");
+        }
+    }
+
+    private static async Task DiscardPreparedRecordersAsync()
+    {
+        try
+        {
+            await Services.GetRequiredService<IVideoRecordingService>().DiscardPreparedAsync();
+            await Services.GetRequiredService<IGifRecordingService>().DiscardPreparedAsync();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Discarding prepared recorder failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Produces the screenshot and gets it in front of the user as fast as possible. When the
+    /// region overlay's frozen backdrop is usable (no countdown, live re-capture not requested)
+    /// the screenshot is a crop of that frame: no second capture. The editor is opened from the
+    /// in-memory frame while encoding/saving/clipboard run concurrently, so the window appears
+    /// before the PNG hits disk.
+    /// </summary>
+    private async Task CaptureScreenshotAndPresentAsync(
+        TargetSelection selection,
+        ICaptureSettings settings,
+        bool countdownRan,
+        bool wasPickerInitiated,
+        CancellationToken cancellationToken)
+    {
+        var screenshots = Services.GetRequiredService<IScreenshotService>();
+        CapturedFrame frame;
+        if (selection.Backdrop is { } backdrop && !countdownRan && !settings.ScreenshotUsesLiveCapture)
+        {
+            frame = selection.Region is { } region ? backdrop.Crop(region) : backdrop;
+            CaptureFlowTrace.Mark("screenshot: cropped from frozen backdrop");
+        }
+        else
+        {
+            frame = await Services.GetRequiredService<IScreenCaptureService>()
+                .CaptureAsync(selection.Target, selection.Region, includeCursor: false, cancellationToken);
+            CaptureFlowTrace.Mark("screenshot: live frame captured");
+        }
+
+        if (settings.ShowBrandingOverlay)
+        {
+            // Brand once, up front, so the in-memory editor preview matches the saved file.
+            new BrandingOverlayCompositor().Draw(frame.BgraPixels, frame.Width, frame.Height);
+        }
+
+        var saveTask = SaveScreenshotFrameAsync(screenshots, frame, alreadyBranded: true);
+        if (settings.ShowScreenshotEditor)
+        {
+            // With a downscale configured, the saved file's dimensions differ from the frame; keep
+            // the editor file-backed so Save/Reset/Copy operate on the same pixels as the file.
+            var scaleApplied = settings.ScreenshotScale is > 0 and < 100;
+            if (!scaleApplied)
+            {
+                OpenScreenshotEditor(frame, saveTask, reopenPickerAfterClose: wasPickerInitiated);
+                CaptureFlowTrace.Mark("screenshot: editor opened from memory");
+                try
+                {
+                    await saveTask;
+                }
+                catch (Exception ex)
+                {
+                    // The editor already reports the failure via BindToPendingSaveAsync.
+                    Debug.WriteLine($"Background screenshot save failed: {ex}");
+                }
+                return;
+            }
+
+            var savedPath = await saveTask;
+            OpenScreenshotEditor(savedPath, reopenPickerAfterClose: wasPickerInitiated);
+            CaptureFlowTrace.Mark("screenshot: editor opened from file (scaled)");
+            return;
+        }
+
+        var path = await saveTask;
+        RevealInExplorer(path);
+        ShowSaveToast(path);
+        ReopenPickerAfterCaptureIfNeeded(CaptureType.Screenshot, wasPickerInitiated);
+    }
+
+    private async Task<string> SaveScreenshotFrameAsync(IScreenshotService screenshots, CapturedFrame frame, bool alreadyBranded)
+    {
+        var path = await screenshots.SaveFrameAsync(frame, applyBranding: !alreadyBranded);
+        Services.GetRequiredService<IRecentCaptureService>().Record(path, CaptureType.Screenshot);
+        await CopyToClipboardAsync(path, CaptureType.Screenshot);
+        CaptureFlowTrace.Mark("screenshot: saved + clipboard");
+        return path;
     }
 
     private async Task<RecordingSetupResult?> ShowRecordingSetupAsync(CaptureType type, TargetSelection selection, ICaptureSettings settings)
@@ -790,7 +972,7 @@ public partial class App : Application
         settings.WebcamCornerRadius = setup.WebcamCornerRadius;
     }
 
-    private async Task<TargetSelection?> ResolveTargetAsync(CapturePickerMode mode)
+    private async Task<TargetSelection?> ResolveTargetAsync(CapturePickerMode mode, EarlyBackdrop? earlyBackdrop = null)
     {
         var monitors = Services.GetRequiredService<IMonitorService>();
         var settings = Services.GetRequiredService<ICaptureSettings>();
@@ -807,23 +989,24 @@ public partial class App : Application
                 }
 
                 var preferredMonitor = ResolvePreferredMonitor(monitors, settings.MultiMonitorCaptureMode);
-                if (preferredMonitor is { } single)
-                {
-                    var region = await RegionSelectWindow.RunAsync(single);
-                    return region is { } singleRegion
-                        ? new TargetSelection(CaptureTarget.Monitor(single.HMonitor), singleRegion, single)
-                        : null;
-                }
+                var overlayMonitors = preferredMonitor is { } single ? new[] { single } : all;
 
-                var result = await RegionSelectController.RunAsync(all);
+                // Reuse the backdrop grabbed while the picker was up if it is still fresh;
+                // otherwise the controller captures a new one (in parallel with window creation).
+                var backdrops = earlyBackdrop is { } early && early.IsFreshFor(overlayMonitors)
+                    ? early.Frames
+                    : null;
+                CaptureFlowTrace.Mark(backdrops is null ? "region: capturing fresh backdrop" : "region: reusing early backdrop");
+
+                var result = await RegionSelectController.RunAsync(overlayMonitors, backdrops);
                 if (result is not { } selection)
                 {
                     return null;
                 }
 
-                var selectedMonitor = all.FirstOrDefault(m => m.HMonitor == selection.HMonitor)
+                var selectedMonitor = overlayMonitors.FirstOrDefault(m => m.HMonitor == selection.HMonitor)
                     ?? monitors.GetPrimaryMonitor();
-                return new TargetSelection(CaptureTarget.Monitor(selection.HMonitor), selection.Region, selectedMonitor);
+                return new TargetSelection(CaptureTarget.Monitor(selection.HMonitor), selection.Region, selectedMonitor, selection.Backdrop);
             }
 
             case CapturePickerMode.Screen:
@@ -920,7 +1103,7 @@ public partial class App : Application
         return monitors.FirstOrDefault(m => m.HMonitor == hMonitor) ?? monitorService.GetPrimaryMonitor();
     }
 
-    private readonly record struct TargetSelection(CaptureTarget Target, PixelRect? Region, MonitorInfo? Monitor);
+    private readonly record struct TargetSelection(CaptureTarget Target, PixelRect? Region, MonitorInfo? Monitor, CapturedFrame? Backdrop = null);
 
     private async Task ToggleVideoAsync()
     {
@@ -1080,6 +1263,7 @@ public partial class App : Application
     {
         _dispatcher?.TryEnqueue(async () =>
         {
+            CaptureFlowTrace.Mark("recording: completed event on UI thread");
             UpdateRecordingState();
             HideRecordingIndicator();
             HideProcessingIndicator();
@@ -1132,16 +1316,20 @@ public partial class App : Application
             if (video.IsRecording)
             {
                 stoppedType = CaptureType.Video;
+                CaptureFlowTrace.Begin("stop-video");
                 HideRecordingIndicator();
                 ShowProcessingIndicator(CaptureType.Video, _activeRecordingSelection);
                 await video.StopAsync();
+                CaptureFlowTrace.Mark("video: StopAsync returned");
             }
             else if (gif.IsRecording)
             {
                 stoppedType = CaptureType.Gif;
+                CaptureFlowTrace.Begin("stop-gif");
                 HideRecordingIndicator();
                 ShowProcessingIndicator(CaptureType.Gif, _activeRecordingSelection);
                 await gif.StopAsync();
+                CaptureFlowTrace.Mark("gif: StopAsync returned");
             }
             else
             {
@@ -2310,6 +2498,17 @@ public partial class App : Application
     }
 
     private void OpenScreenshotEditor(string path, bool reopenPickerAfterClose = false)
+        => OpenScreenshotEditorCore(() => new ScreenshotEditorWindow(path), path, reopenPickerAfterClose);
+
+    /// <summary>
+    /// Opens the editor directly from the captured pixels while <paramref name="saveTask"/>
+    /// encodes and writes the file in the background. The editor binds to the final path once
+    /// the save completes so Save/Save-a-copy work exactly as before.
+    /// </summary>
+    private void OpenScreenshotEditor(CapturedFrame frame, Task<string> saveTask, bool reopenPickerAfterClose)
+        => OpenScreenshotEditorCore(() => new ScreenshotEditorWindow(frame, saveTask), null, reopenPickerAfterClose);
+
+    private void OpenScreenshotEditorCore(Func<ScreenshotEditorWindow> create, string? fallbackPath, bool reopenPickerAfterClose)
     {
         try
         {
@@ -2317,7 +2516,7 @@ public partial class App : Application
             _editorWindow = null;
             oldWindow?.Close();
 
-            var window = new ScreenshotEditorWindow(path);
+            var window = create();
             _editorWindow = window;
             window.Closed += (_, _) =>
             {
@@ -2335,8 +2534,11 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"OpenScreenshotEditor failed: {ex}");
-            RevealInExplorer(path);
-            ShowSaveToast(path);
+            if (fallbackPath is not null)
+            {
+                RevealInExplorer(fallbackPath);
+                ShowSaveToast(fallbackPath);
+            }
             if (reopenPickerAfterClose)
             {
                 ReopenPickerAfterCaptureIfNeeded(CaptureType.Screenshot, pickerInitiated: true);
@@ -2399,6 +2601,7 @@ public partial class App : Application
         _onboardingWindow?.Close();
         _editorWindow?.Close();
         _trimmerWindow?.Close();
+        CapturePickerWindow.ReleasePooled();
         Application.Current.Exit();
         // No persistent host window keeps the process alive, so force termination
         // to guarantee the user can always quit from the tray menu.
@@ -2418,7 +2621,8 @@ public partial class App : Application
 
     private async Task ReopenPickerAfterCaptureAsync(CaptureType type)
     {
-        await Task.Delay(150);
+        // Yield one dispatcher turn so the previous flow's windows finish closing.
+        await Task.Yield();
         if (_isExiting || IsAnyRecordingActive())
         {
             return;

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -530,7 +530,7 @@ public partial class App : Application
 
         var captureFlowCts = new CancellationTokenSource();
         _captureFlowCts = captureFlowCts;
-        Task<CapturedFrame?[]>? earlyBackdrops = null;
+        IReadOnlyList<Task<CapturedFrame?>>? earlyBackdrops = null;
         IReadOnlyList<MonitorInfo>? earlyBackdropMonitors = null;
         long earlyBackdropStarted = 0;
         try
@@ -770,7 +770,7 @@ public partial class App : Application
     // A backdrop captured while the picker was showing; refreshed if older than this on use.
     private static readonly TimeSpan EarlyBackdropMaxAge = TimeSpan.FromMilliseconds(600);
 
-    private sealed record EarlyBackdrop(IReadOnlyList<MonitorInfo> Monitors, Task<CapturedFrame?[]> Frames, long StartedTimestamp)
+    private sealed record EarlyBackdrop(IReadOnlyList<MonitorInfo> Monitors, IReadOnlyList<Task<CapturedFrame?>> Frames, long StartedTimestamp)
     {
         public bool IsFreshFor(IReadOnlyList<MonitorInfo> monitors) =>
             Stopwatch.GetElapsedTime(StartedTimestamp) <= EarlyBackdropMaxAge

--- a/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorController.cs
+++ b/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorController.cs
@@ -174,6 +174,15 @@ internal sealed class EditorController : IDisposable
         var decoder = await BitmapDecoder.CreateAsync(stream);
         var bitmap = await decoder.GetSoftwareBitmapAsync(
             BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+        await SetBitmapFromCaptureAsync(bitmap);
+    }
+
+    /// <summary>
+    /// Loads a freshly captured bitmap (already BGRA8 premultiplied) as the document, resetting
+    /// annotations — the in-memory equivalent of <see cref="LoadAsync"/>.
+    /// </summary>
+    public async Task SetBitmapFromCaptureAsync(SoftwareBitmap bitmap)
+    {
         await SetBitmapAsync(bitmap);
         _annotations.Clear();
         _counterValue = 1;

--- a/windows/src/TinyClips.App/Controls/Settings/ScreenshotSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/ScreenshotSettingsSection.xaml
@@ -124,6 +124,16 @@
                         AutomationProperties.Name="Open editor after capture"
                         IsOn="{x:Bind ViewModel.ShowScreenshotEditor, Mode=TwoWay}" />
                 </controls:SettingsCard>
+
+                <controls:SettingsCard
+                    Description="Off (recommended): the frozen frame shown while you select is saved instantly. On: re-capture the live screen after selecting, which reflects changes made during selection but is slower."
+                    Header="Re-capture screen after region selection"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE72C;}">
+                    <ToggleSwitch
+                        AutomationProperties.AutomationId="ScreenshotLiveCaptureToggle"
+                        AutomationProperties.Name="Re-capture screen after region selection"
+                        IsOn="{x:Bind ViewModel.ScreenshotUsesLiveCapture, Mode=TwoWay}" />
+                </controls:SettingsCard>
             </StackPanel>
         </StackPanel>
     </Border>

--- a/windows/src/TinyClips.App/Infrastructure/RegionSelectController.cs
+++ b/windows/src/TinyClips.App/Infrastructure/RegionSelectController.cs
@@ -3,23 +3,27 @@ using TinyClips.Core.Capture;
 
 namespace TinyClips.App;
 
-public readonly record struct RegionSelectResult(nint HMonitor, PixelRect Region);
+/// <summary>
+/// The user's region choice. <see cref="Backdrop"/> is the frozen monitor frame that was shown
+/// behind the overlay (null when backdrop capture failed); <see cref="Region"/> is relative to it.
+/// </summary>
+public readonly record struct RegionSelectResult(nint HMonitor, PixelRect Region, CapturedFrame? Backdrop);
 
 public static class RegionSelectController
 {
-    public static async Task<RegionSelectResult?> RunAsync(IReadOnlyList<MonitorInfo> monitors)
+    /// <summary>
+    /// Starts capturing a frozen frame of each monitor. Kick this off as early as possible (e.g.
+    /// while the capture picker is still showing) so the overlay can appear without waiting.
+    /// Failures resolve to null entries rather than faulting.
+    /// </summary>
+    public static Task<CapturedFrame?[]> CaptureBackdropsAsync(IReadOnlyList<MonitorInfo> monitors)
     {
-        if (monitors.Count == 0)
-        {
-            return null;
-        }
-
         var capture = App.Services.GetRequiredService<IScreenCaptureService>();
-        var backdropTasks = monitors.Select(async monitor =>
+        var tasks = monitors.Select(async monitor =>
         {
             try
             {
-                return await capture.CaptureMonitorAsync(monitor.HMonitor);
+                return (CapturedFrame?)await capture.CaptureMonitorAsync(monitor.HMonitor).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -27,8 +31,29 @@ public static class RegionSelectController
                 return null;
             }
         }).ToArray();
+        return Task.WhenAll(tasks);
+    }
 
-        var backdrops = await Task.WhenAll(backdropTasks);
+    public static Task<RegionSelectResult?> RunAsync(IReadOnlyList<MonitorInfo> monitors) =>
+        RunAsync(monitors, backdrops: null);
+
+    /// <summary>
+    /// Shows the region overlay on every monitor. When <paramref name="backdrops"/> is supplied
+    /// (from <see cref="CaptureBackdropsAsync"/> for the same monitor list) the overlay windows
+    /// are created immediately and paint the backdrop when it arrives; otherwise the capture is
+    /// started here.
+    /// </summary>
+    public static async Task<RegionSelectResult?> RunAsync(
+        IReadOnlyList<MonitorInfo> monitors,
+        Task<CapturedFrame?[]>? backdrops)
+    {
+        if (monitors.Count == 0)
+        {
+            return null;
+        }
+
+        backdrops ??= CaptureBackdropsAsync(monitors);
+        CaptureFlowTrace.Mark("region: overlay windows creating");
 
         var completion = new TaskCompletionSource<RegionSelectResult?>(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -52,8 +77,11 @@ public static class RegionSelectController
 
         for (var i = 0; i < monitors.Count; i++)
         {
-            var window = new RegionSelectWindow(monitors[i], backdrops[i], Complete);
-            windows.Add(window);
+            var index = i;
+            var backdropTask = backdrops.ContinueWith(
+                t => t.IsCompletedSuccessfully ? t.Result[index] : null,
+                TaskScheduler.Default);
+            windows.Add(new RegionSelectWindow(monitors[i], backdropTask, Complete));
         }
 
         foreach (var window in windows)
@@ -61,6 +89,7 @@ public static class RegionSelectController
             window.Activate();
         }
 
+        CaptureFlowTrace.Mark("region: overlay windows activated");
         return await completion.Task;
     }
 }

--- a/windows/src/TinyClips.App/Infrastructure/RegionSelectController.cs
+++ b/windows/src/TinyClips.App/Infrastructure/RegionSelectController.cs
@@ -14,12 +14,14 @@ public static class RegionSelectController
     /// <summary>
     /// Starts capturing a frozen frame of each monitor. Kick this off as early as possible (e.g.
     /// while the capture picker is still showing) so the overlay can appear without waiting.
-    /// Failures resolve to null entries rather than faulting.
+    /// One task per monitor is returned (never aggregated) so each overlay can reveal as soon as
+    /// its own frame arrives rather than waiting for the slowest monitor. Failures resolve to
+    /// null rather than faulting.
     /// </summary>
-    public static Task<CapturedFrame?[]> CaptureBackdropsAsync(IReadOnlyList<MonitorInfo> monitors)
+    public static IReadOnlyList<Task<CapturedFrame?>> CaptureBackdropsAsync(IReadOnlyList<MonitorInfo> monitors)
     {
         var capture = App.Services.GetRequiredService<IScreenCaptureService>();
-        var tasks = monitors.Select(async monitor =>
+        return monitors.Select(async monitor =>
         {
             try
             {
@@ -31,7 +33,6 @@ public static class RegionSelectController
                 return null;
             }
         }).ToArray();
-        return Task.WhenAll(tasks);
     }
 
     public static Task<RegionSelectResult?> RunAsync(IReadOnlyList<MonitorInfo> monitors) =>
@@ -45,14 +46,18 @@ public static class RegionSelectController
     /// </summary>
     public static async Task<RegionSelectResult?> RunAsync(
         IReadOnlyList<MonitorInfo> monitors,
-        Task<CapturedFrame?[]>? backdrops)
+        IReadOnlyList<Task<CapturedFrame?>>? backdrops)
     {
         if (monitors.Count == 0)
         {
             return null;
         }
 
-        backdrops ??= CaptureBackdropsAsync(monitors);
+        if (backdrops is null || backdrops.Count != monitors.Count)
+        {
+            backdrops = CaptureBackdropsAsync(monitors);
+        }
+
         CaptureFlowTrace.Mark("region: overlay windows creating");
 
         var completion = new TaskCompletionSource<RegionSelectResult?>(
@@ -77,11 +82,7 @@ public static class RegionSelectController
 
         for (var i = 0; i < monitors.Count; i++)
         {
-            var index = i;
-            var backdropTask = backdrops.ContinueWith(
-                t => t.IsCompletedSuccessfully ? t.Result[index] : null,
-                TaskScheduler.Default);
-            windows.Add(new RegionSelectWindow(monitors[i], backdropTask, Complete));
+            windows.Add(new RegionSelectWindow(monitors[i], backdrops[i], Complete));
         }
 
         foreach (var window in windows)

--- a/windows/src/TinyClips.App/Infrastructure/TrayPopupWindow.cs
+++ b/windows/src/TinyClips.App/Infrastructure/TrayPopupWindow.cs
@@ -29,6 +29,10 @@ internal sealed class TrayPopupWindow : Window
         SystemBackdrop = new DesktopAcrylicBackdrop();
         Content = content;
 
+        // Never let the tray popup land in a screenshot/backdrop captured right after a click,
+        // which lets the capture flow start immediately instead of waiting for it to dismiss.
+        OverlayWindowHelpers.ExcludeFromCapture(_hwnd);
+
         Activated += OnActivated;
         Closed += OnClosed;
         _appWindow.Hide();

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -103,6 +103,12 @@
 
   <!-- Publish Properties -->
   <PropertyGroup>
+    <!--
+      ReadyToRun pre-compiles IL so the first capture after launch doesn't pay JIT cost for every
+      overlay window type. Applies to `dotnet publish`; the MSIX `dotnet build` path in CI is
+      framework-dependent and unaffected.
+    -->
+    <PublishReadyToRun Condition="'$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release'">True</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == ''">False</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug' and ('$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true')">True</PublishTrimmed>

--- a/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
@@ -359,6 +359,9 @@ public sealed partial class SettingsViewModel : ObservableObject
     private bool _showScreenshotEditor;
 
     [ObservableProperty]
+    private bool _screenshotUsesLiveCapture;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ScreenshotCapturePickerAfterCaptureEnabled))]
     private bool _showScreenshotCapturePicker;
 
@@ -738,6 +741,7 @@ public sealed partial class SettingsViewModel : ObservableObject
             ScreenshotCountdownEnabled = _settings.ScreenshotCountdownEnabled;
             ScreenshotCountdownDuration = _settings.ScreenshotCountdownDuration;
             ShowScreenshotEditor = _settings.ShowScreenshotEditor;
+            ScreenshotUsesLiveCapture = _settings.ScreenshotUsesLiveCapture;
             ShowScreenshotCapturePicker = _settings.ShowScreenshotCapturePicker;
             ShowScreenshotCapturePickerAfterCapture = _settings.ShowScreenshotCapturePickerAfterCapture;
 
@@ -1095,6 +1099,8 @@ public sealed partial class SettingsViewModel : ObservableObject
         Persist(() => _settings.ScreenshotCountdownDuration = (int)Math.Round(value));
 
     partial void OnShowScreenshotEditorChanged(bool value) => Persist(() => _settings.ShowScreenshotEditor = value);
+
+    partial void OnScreenshotUsesLiveCaptureChanged(bool value) => Persist(() => _settings.ScreenshotUsesLiveCapture = value);
 
     partial void OnShowScreenshotCapturePickerChanged(bool value) =>
         Persist(() =>

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -141,21 +141,24 @@ public sealed partial class CapturePickerWindow : Window
 
     private void PositionNearTopOfPrimaryDisplay()
     {
+        // The pooled window may still sit on a previous primary monitor while hidden. Move it to
+        // the target work area first so the DPI transition happens before measuring.
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        var work = DisplayArea.Primary?.WorkArea
+            ?? DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Primary).WorkArea;
+        var target = AppWindowPlacement.PrepareForTargetWorkArea(AppWindow, hwnd, work);
+        var scale = target.Scale;
+
         RootGrid.UpdateLayout();
         RootGrid.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
-        var scale = AppWindowPlacement.GetScaleForWindow(WinRT.Interop.WindowNative.GetWindowHandle(this));
         var width = (int)Math.Ceiling(RootGrid.DesiredSize.Width * scale);
         var height = (int)Math.Ceiling(RootGrid.DesiredSize.Height * scale);
         width = Math.Max(width, (int)(360 * scale));
         height = Math.Max(height, (int)(64 * scale));
 
-        AppWindow.Resize(new SizeInt32(width, height));
-        if (DisplayArea.Primary?.WorkArea is { } work)
-        {
-            var x = work.X + ((work.Width - width) / 2);
-            var y = work.Y + (int)(72 * scale);
-            AppWindow.Move(new PointInt32(x, y));
-        }
+        var x = work.X + ((work.Width - width) / 2);
+        var y = work.Y + (int)(72 * scale);
+        AppWindow.MoveAndResize(new RectInt32(x, y, width, height));
 
         _windowWidth = width;
         _windowHeight = height;

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
 using Windows.Graphics;
 using Windows.System;
@@ -33,24 +34,55 @@ public sealed partial class CapturePickerWindow : Window
     private static readonly int[] LimitOptions = { 0, 1, 2, 5, 10, 15, 30 };
     private const int CornerRadiusDip = 8;
 
-    private readonly TaskCompletionSource<CapturePickerResult?> _result = new();
+    // A single hidden instance is kept alive between captures: creating a WinUI window with an
+    // acrylic backdrop costs 100-250 ms, which used to be paid on every hotkey press.
+    private static CapturePickerWindow? _pooled;
+
+    private TaskCompletionSource<CapturePickerResult?> _result = new();
     private bool _countdownEnabled;
     private int _countdownDuration;
     private double _videoTimeLimitMinutes;
     private bool _completed;
+    private bool _isShowing;
+    private bool _pendingRegionApply;
     private int _windowWidth;
     private int _windowHeight;
     private double _windowScale = 1.0;
 
     private readonly FloatingWindowDragger _dragger;
 
-    private CapturePickerWindow(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes)
+    private CapturePickerWindow()
     {
         InitializeComponent();
 
+        BuildTimerFlyout();
+        BuildLimitFlyout();
+
+        _dragger = new FloatingWindowDragger(AppWindow);
+
+        ConfigurePresenter();
+        OverlayWindowHelpers.ExcludeFromCapture(WinRT.Interop.WindowNative.GetWindowHandle(this));
+
+        RootGrid.KeyDown += OnKeyDown;
+        Activated += OnActivated;
+        Closed += (_, _) =>
+        {
+            if (ReferenceEquals(_pooled, this))
+            {
+                _pooled = null;
+            }
+
+            Complete(null);
+        };
+    }
+
+    private void Configure(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes)
+    {
         _countdownEnabled = countdownEnabled;
         _countdownDuration = countdownDuration <= 0 ? 3 : countdownDuration;
         _videoTimeLimitMinutes = videoTimeLimitMinutes < 0 ? 0 : videoTimeLimitMinutes;
+        _completed = false;
+        _result = new TaskCompletionSource<CapturePickerResult?>();
 
         ModeIcon.Glyph = captureType switch
         {
@@ -65,33 +97,27 @@ public sealed partial class CapturePickerWindow : Window
             _ => "Screenshot",
         };
 
-        BuildTimerFlyout();
         UpdateTimerLabel();
-
-        if (captureType == CaptureType.Video)
-        {
-            LimitButton.Visibility = Visibility.Visible;
-            BuildLimitFlyout();
-            UpdateLimitLabel();
-        }
-        else
-        {
-            LimitButton.Visibility = Visibility.Collapsed;
-        }
-
-        _dragger = new FloatingWindowDragger(AppWindow);
-
-        ConfigurePresenter();
-        PositionNearTopOfPrimaryDisplay();
-
-        RootGrid.KeyDown += OnKeyDown;
-        Activated += OnActivated;
+        LimitButton.Visibility = captureType == CaptureType.Video ? Visibility.Visible : Visibility.Collapsed;
+        UpdateLimitLabel();
     }
 
     public static Task<CapturePickerResult?> RunAsync(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes = 0)
     {
-        var window = new CapturePickerWindow(captureType, countdownEnabled, countdownDuration, videoTimeLimitMinutes);
+        var window = _pooled;
+        if (window is null || window._isShowing)
+        {
+            window = new CapturePickerWindow();
+            _pooled ??= window;
+        }
+
+        window.Configure(captureType, countdownEnabled, countdownDuration, videoTimeLimitMinutes);
+        window.PositionNearTopOfPrimaryDisplay();
+        window._isShowing = true;
+        window._pendingRegionApply = true;
+        window.AppWindow.Show();
         window.Activate();
+        CaptureFlowTrace.Mark("picker: activated");
         return window._result.Task;
     }
 
@@ -101,10 +127,15 @@ public sealed partial class CapturePickerWindow : Window
         {
             return;
         }
-        Activated -= OnActivated;
-        OverlayWindowHelpers.ApplyRoundedRegion(
-            WinRT.Interop.WindowNative.GetWindowHandle(this),
-            _windowWidth, _windowHeight, _windowScale, CornerRadiusDip);
+
+        if (_pendingRegionApply)
+        {
+            _pendingRegionApply = false;
+            OverlayWindowHelpers.ApplyRoundedRegion(
+                WinRT.Interop.WindowNative.GetWindowHandle(this),
+                _windowWidth, _windowHeight, _windowScale, CornerRadiusDip);
+        }
+
         RootGrid.Focus(FocusState.Programmatic);
     }
 
@@ -245,7 +276,31 @@ public sealed partial class CapturePickerWindow : Window
         }
 
         _completed = true;
+        _isShowing = false;
         _result.TrySetResult(mode is { } m ? new CapturePickerResult(m, _countdownEnabled, _countdownDuration, _videoTimeLimitMinutes) : null);
+
+        // Hide rather than close so the next capture reuses this window instantly.
+        if (ReferenceEquals(_pooled, this))
+        {
+            try
+            {
+                AppWindow.Hide();
+                return;
+            }
+            catch
+            {
+                _pooled = null;
+            }
+        }
+
         Close();
+    }
+
+    /// <summary>Closes the cached instance (e.g. on app exit).</summary>
+    internal static void ReleasePooled()
+    {
+        var pooled = _pooled;
+        _pooled = null;
+        pooled?.Close();
     }
 }

--- a/windows/src/TinyClips.App/Views/CountdownWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CountdownWindow.xaml.cs
@@ -49,6 +49,7 @@ public sealed partial class CountdownWindow : Window
     {
         var window = new CountdownWindow(seconds);
         window.Activate();
+        CaptureFlowTrace.Mark("countdown: window shown");
 
         // Resize/position and clip the window to a rounded square only AFTER it has been
         // shown. Applying SetWindowRgn before the first present leaves the surface blank,
@@ -74,23 +75,21 @@ public sealed partial class CountdownWindow : Window
             _timer.Stop();
             _timer.Tick -= OnTick;
 
-            // Hide immediately so the window is gone from the very first recorded frame,
-            // then give the compositor a beat before signalling completion.
-            await AnimateFadeAsync(RootBorder, 0, 140);
-            if (_isCancelled)
-            {
-                return;
-            }
-
-            AppWindow.Hide();
-            await Task.Delay(80);
+            // The card is excluded from capture (WDA_EXCLUDEFROMCAPTURE), so it can never land in
+            // the recording; signal completion immediately and let the fade-out run concurrently
+            // with recording start instead of adding ~220 ms of dead time after "1".
             if (_isCancelled)
             {
                 return;
             }
 
             _completed.TrySetResult(true);
-            Close();
+            CaptureFlowTrace.Mark("countdown: reached zero");
+            await AnimateFadeAsync(RootBorder, 0, 140);
+            if (!_isCancelled)
+            {
+                Close();
+            }
             return;
         }
 

--- a/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class GifTrimmerWindow : Window
     private readonly string _filePath;
     private readonly List<SoftwareBitmap?> _frames = new();
     private readonly List<ushort> _delays = new();
-    private Task _decodeTask = Task.CompletedTask;
+    private readonly Task _decodeTask;
     private readonly System.Threading.CancellationTokenSource _decodeCts = new();
     private int _start;
     private int _end;
@@ -73,26 +73,31 @@ public sealed partial class GifTrimmerWindow : Window
         };
 
         Closed += OnWindowClosed;
-        _ = LoadAsync();
+        _decodeTask = LoadAsync(_decodeCts.Token);
     }
 
-    private async Task LoadAsync()
+    /// <summary>
+    /// Owns the GIF stream for the whole load: the first frame is decoded up front so the window
+    /// is usable immediately, then the remaining frames stream in. The stream is disposed in one
+    /// place regardless of where the load fails or is cancelled, and cleanup awaits this task.
+    /// </summary>
+    private async Task LoadAsync(System.Threading.CancellationToken cancellationToken)
     {
+        IRandomAccessStream? stream = null;
         try
         {
             var file = await StorageFile.GetFileFromPathAsync(_filePath);
-            var stream = await file.OpenAsync(FileAccessMode.Read);
+            stream = await file.OpenAsync(FileAccessMode.Read);
             var decoder = await BitmapDecoder.CreateAsync(BitmapDecoder.GifDecoderId, stream);
             var frameCount = (int)decoder.FrameCount;
-            if (frameCount == 0)
+            if (frameCount == 0 || cancellationToken.IsCancellationRequested)
             {
-                stream.Dispose();
                 return;
             }
 
             // Decode only the first frame up front so the window is usable immediately; the
-            // remaining frames stream in on a background task (a 30 s GIF is ~900 frames, which
-            // previously blocked the window on several seconds of serial decoding).
+            // remaining frames stream in below (a 30 s GIF is ~900 frames, which previously
+            // blocked the window on several seconds of serial decoding).
             for (var i = 0; i < frameCount; i++)
             {
                 _frames.Add(null);
@@ -100,6 +105,10 @@ public sealed partial class GifTrimmerWindow : Window
             }
 
             await DecodeFrameAsync(decoder, 0);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
 
             _start = 0;
             _end = frameCount - 1;
@@ -113,30 +122,6 @@ public sealed partial class GifTrimmerWindow : Window
             SetCurrent(0);
             CaptureFlowTrace.Mark("gif trimmer: first frame visible");
 
-            _decodeTask = DecodeRemainingFramesAsync(decoder, stream, frameCount, _decodeCts.Token);
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"GIF trimmer load failed: {ex}");
-        }
-    }
-
-    private async Task DecodeFrameAsync(BitmapDecoder decoder, int index)
-    {
-        var frame = await decoder.GetFrameAsync((uint)index);
-        var bitmap = await frame.GetSoftwareBitmapAsync(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
-        _frames[index] = bitmap;
-        _delays[index] = await ReadDelayAsync(frame);
-    }
-
-    private async Task DecodeRemainingFramesAsync(
-        BitmapDecoder decoder,
-        IRandomAccessStream stream,
-        int frameCount,
-        System.Threading.CancellationToken cancellationToken)
-    {
-        try
-        {
             for (var i = 1; i < frameCount && !cancellationToken.IsCancellationRequested; i++)
             {
                 await DecodeFrameAsync(decoder, i);
@@ -151,12 +136,20 @@ public sealed partial class GifTrimmerWindow : Window
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"GIF trimmer background decode failed: {ex}");
+            System.Diagnostics.Debug.WriteLine($"GIF trimmer load failed: {ex}");
         }
         finally
         {
-            stream.Dispose();
+            stream?.Dispose();
         }
+    }
+
+    private async Task DecodeFrameAsync(BitmapDecoder decoder, int index)
+    {
+        var frame = await decoder.GetFrameAsync((uint)index);
+        var bitmap = await frame.GetSoftwareBitmapAsync(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+        _frames[index] = bitmap;
+        _delays[index] = await ReadDelayAsync(frame);
     }
 
     private static async Task<ushort> ReadDelayAsync(BitmapFrame frame)

--- a/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/GifTrimmerWindow.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
+using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 using Windows.Foundation;
@@ -31,8 +32,10 @@ public sealed partial class GifTrimmerWindow : Window
     private const int MinimumHeightDip = 480;
 
     private readonly string _filePath;
-    private readonly List<SoftwareBitmap> _frames = new();
+    private readonly List<SoftwareBitmap?> _frames = new();
     private readonly List<ushort> _delays = new();
+    private Task _decodeTask = Task.CompletedTask;
+    private readonly System.Threading.CancellationTokenSource _decodeCts = new();
     private int _start;
     private int _end;
     private int _current;
@@ -78,25 +81,28 @@ public sealed partial class GifTrimmerWindow : Window
         try
         {
             var file = await StorageFile.GetFileFromPathAsync(_filePath);
-            using var stream = await file.OpenAsync(FileAccessMode.Read);
+            var stream = await file.OpenAsync(FileAccessMode.Read);
             var decoder = await BitmapDecoder.CreateAsync(BitmapDecoder.GifDecoderId, stream);
-
-            for (uint i = 0; i < decoder.FrameCount; i++)
+            var frameCount = (int)decoder.FrameCount;
+            if (frameCount == 0)
             {
-                var frame = await decoder.GetFrameAsync(i);
-                var bitmap = await frame.GetSoftwareBitmapAsync(
-                    BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
-                _frames.Add(bitmap);
-                _delays.Add(await ReadDelayAsync(frame));
-            }
-
-            if (_frames.Count == 0)
-            {
+                stream.Dispose();
                 return;
             }
 
+            // Decode only the first frame up front so the window is usable immediately; the
+            // remaining frames stream in on a background task (a 30 s GIF is ~900 frames, which
+            // previously blocked the window on several seconds of serial decoding).
+            for (var i = 0; i < frameCount; i++)
+            {
+                _frames.Add(null);
+                _delays.Add(10);
+            }
+
+            await DecodeFrameAsync(decoder, 0);
+
             _start = 0;
-            _end = _frames.Count - 1;
+            _end = frameCount - 1;
             _current = 0;
 
             _ready = true;
@@ -105,10 +111,51 @@ public sealed partial class GifTrimmerWindow : Window
             TrimBar.KeyboardStep = LastFrame == 0 ? 1 : 1.0 / LastFrame;
             UpdateLabels();
             SetCurrent(0);
+            CaptureFlowTrace.Mark("gif trimmer: first frame visible");
+
+            _decodeTask = DecodeRemainingFramesAsync(decoder, stream, frameCount, _decodeCts.Token);
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"GIF trimmer load failed: {ex}");
+        }
+    }
+
+    private async Task DecodeFrameAsync(BitmapDecoder decoder, int index)
+    {
+        var frame = await decoder.GetFrameAsync((uint)index);
+        var bitmap = await frame.GetSoftwareBitmapAsync(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+        _frames[index] = bitmap;
+        _delays[index] = await ReadDelayAsync(frame);
+    }
+
+    private async Task DecodeRemainingFramesAsync(
+        BitmapDecoder decoder,
+        IRandomAccessStream stream,
+        int frameCount,
+        System.Threading.CancellationToken cancellationToken)
+    {
+        try
+        {
+            for (var i = 1; i < frameCount && !cancellationToken.IsCancellationRequested; i++)
+            {
+                await DecodeFrameAsync(decoder, i);
+                if (i == _current)
+                {
+                    // The user scrubbed ahead of the decoder; paint the frame now that it exists.
+                    _ = ShowFrameAsync(i);
+                }
+            }
+
+            CaptureFlowTrace.Mark("gif trimmer: all frames decoded");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"GIF trimmer background decode failed: {ex}");
+        }
+        finally
+        {
+            stream.Dispose();
         }
     }
 
@@ -232,13 +279,14 @@ public sealed partial class GifTrimmerWindow : Window
 
     private async Task ShowFrameAsync(int index)
     {
-        if (index < 0 || index >= _frames.Count)
+        if (index < 0 || index >= _frames.Count || _frames[index] is not { } frame)
         {
+            // Not decoded yet; DecodeRemainingFramesAsync repaints once it arrives.
             return;
         }
 
         var source = new SoftwareBitmapSource();
-        await source.SetBitmapAsync(_frames[index]);
+        await source.SetBitmapAsync(frame);
         PreviewImage.Source = source;
     }
 
@@ -366,6 +414,16 @@ public sealed partial class GifTrimmerWindow : Window
 
         try
         {
+            if (_frames[_current] is null)
+            {
+                await _decodeTask;
+            }
+
+            if (_frames[_current] is not { } frameToExport)
+            {
+                return;
+            }
+
             var storage = App.Services.GetRequiredService<IClipStorageService>();
             outputPath = storage.GenerateFilePath(CaptureType.Screenshot, ".png", "(frame)");
             var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(outputPath)!);
@@ -375,7 +433,7 @@ public sealed partial class GifTrimmerWindow : Window
             using (var stream = await file.OpenAsync(FileAccessMode.ReadWrite))
             {
                 var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
-                encoder.SetSoftwareBitmap(_frames[_current]);
+                encoder.SetSoftwareBitmap(frameToExport);
                 await encoder.FlushAsync();
             }
 
@@ -407,6 +465,9 @@ public sealed partial class GifTrimmerWindow : Window
 
         try
         {
+            // Frames still decoding in the background must land before re-encoding.
+            await _decodeTask;
+
             var storage = App.Services.GetRequiredService<IClipStorageService>();
             outputPath = storage.GenerateFilePath(CaptureType.Gif, ".gif", " (trimmed)");
             var folder = await StorageFolder.GetFolderFromPathAsync(System.IO.Path.GetDirectoryName(outputPath)!);
@@ -426,7 +487,12 @@ public sealed partial class GifTrimmerWindow : Window
 
                 for (var i = _start; i <= _end; i++)
                 {
-                    encoder.SetSoftwareBitmap(_frames[i]);
+                    if (_frames[i] is not { } frame)
+                    {
+                        throw new InvalidOperationException($"GIF frame {i} failed to decode.");
+                    }
+
+                    encoder.SetSoftwareBitmap(frame);
 
                     var delayProps = new BitmapPropertySet
                     {
@@ -482,12 +548,28 @@ public sealed partial class GifTrimmerWindow : Window
     private void OnWindowClosed(object sender, WindowEventArgs e)
     {
         _playTimer?.Stop();
+        _decodeCts.Cancel();
+        _ = DisposeFramesWhenDecodeSettlesAsync();
+    }
+
+    private async Task DisposeFramesWhenDecodeSettlesAsync()
+    {
+        try
+        {
+            await _decodeTask;
+        }
+        catch
+        {
+            // Decode failures are already logged; we only need it to be finished before disposing.
+        }
+
         foreach (var frame in _frames)
         {
-            frame.Dispose();
+            frame?.Dispose();
         }
 
         _frames.Clear();
+        _decodeCts.Dispose();
     }
 
     /// <summary>Raised once when the window closes. Carries the trimmed file path, or null if untrimmed.</summary>

--- a/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RecordingSetupWindow.xaml.cs
@@ -119,6 +119,7 @@ public sealed partial class RecordingSetupWindow : Window
             webcamDevices,
             mediaPermissions);
         window.ShowNear(monitor, regionInVirtualDesktop);
+        CaptureFlowTrace.Mark("setup: panel shown");
         if (captureType == CaptureType.Video)
         {
             _ = window.LoadMicrophonesAsync();

--- a/windows/src/TinyClips.App/Views/RegionSelectWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/RegionSelectWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Graphics;
+using Windows.Graphics.Imaging;
 using Windows.System;
 using TinyClips.Core.Capture;
 using WinRT.Interop;
@@ -25,22 +26,22 @@ public sealed partial class RegionSelectWindow : Window
     private const uint LwaAlpha = 0x00000002;
 
     private readonly MonitorInfo _monitor;
-    private readonly CapturedFrame? _backdropFrame;
+    private readonly Task<CapturedFrame?> _backdropTask;
     private readonly Action<RegionSelectResult?> _onComplete;
     private readonly nint _hwnd;
+    private CapturedFrame? _backdropFrame;
     private Point _start;
     private bool _dragging;
     private bool _completed;
     private bool _closedByController;
     private bool _rootLoaded;
     private bool _backdropReady;
-    private bool _revealQueued;
     private bool _revealed;
 
-    internal RegionSelectWindow(MonitorInfo monitor, CapturedFrame? backdropFrame, Action<RegionSelectResult?> onComplete)
+    internal RegionSelectWindow(MonitorInfo monitor, Task<CapturedFrame?> backdropTask, Action<RegionSelectResult?> onComplete)
     {
         _monitor = monitor;
-        _backdropFrame = backdropFrame;
+        _backdropTask = backdropTask;
         _onComplete = onComplete;
 
         InitializeComponent();
@@ -48,19 +49,15 @@ public sealed partial class RegionSelectWindow : Window
         ConfigurePresenter();
         _hwnd = WindowNative.GetWindowHandle(this);
         SetWindowAlpha(_hwnd, 0);
+        // Keep the overlay itself out of any capture that runs while it is (or was just) visible.
+        OverlayWindowHelpers.ExcludeFromCapture(_hwnd);
         AppWindow.Move(new PointInt32(monitor.X, monitor.Y));
         AppWindow.Resize(new SizeInt32(monitor.Width, monitor.Height));
 
-        if (_backdropFrame is not null)
-        {
-            Backdrop.ImageOpened += OnBackdropReady;
-            Backdrop.ImageFailed += OnBackdropReady;
-        }
-
-        ShowBackdrop();
         RootGrid.Loaded += OnRootGridLoaded;
         Activated += OnActivated;
         Closed += OnClosed;
+        _ = ShowBackdropWhenReadyAsync();
     }
 
     /// <summary>Shows the overlay on the given monitor and resolves with the chosen region.</summary>
@@ -76,75 +73,84 @@ public sealed partial class RegionSelectWindow : Window
         RootGrid.Focus(FocusState.Programmatic);
     }
 
-    private async void OnRootGridLoaded(object sender, RoutedEventArgs e)
+    private void OnRootGridLoaded(object sender, RoutedEventArgs e)
     {
         RootGrid.Loaded -= OnRootGridLoaded;
         _rootLoaded = true;
-        TryQueueReveal();
-
-        await Task.Delay(250);
-        _backdropReady = true;
-        TryQueueReveal();
-    }
-
-    private void OnBackdropReady(object sender, RoutedEventArgs e)
-    {
-        Backdrop.ImageOpened -= OnBackdropReady;
-        Backdrop.ImageFailed -= OnBackdropReady;
-        _backdropReady = true;
-        TryQueueReveal();
-    }
-
-    private async void TryQueueReveal()
-    {
-        if (_revealQueued || !_rootLoaded || !_backdropReady)
-        {
-            return;
-        }
-
-        _revealQueued = true;
-        await Task.Delay(50);
-        RevealWindow();
-    }
-
-    private void RevealWindow()
-    {
-        if (_revealed || _completed || _closedByController)
-        {
-            return;
-        }
-
-        _revealed = true;
-        SetWindowAlpha(_hwnd, 255);
+        TryReveal();
     }
 
     /// <summary>
     /// Paints the pre-captured monitor snapshot behind the dim overlay so the user sees a true
-    /// view of the screen, with only the area outside the selection darkened.
+    /// view of the screen, with only the area outside the selection darkened. The pixel upload
+    /// happens off the UI thread; only the (async) source assignment runs here.
     /// </summary>
-    private void ShowBackdrop()
+    private async Task ShowBackdropWhenReadyAsync()
     {
-        if (_backdropFrame is null)
-        {
-            _backdropReady = true;
-            return;
-        }
-
         try
         {
-            var bitmap = new WriteableBitmap(_backdropFrame.Width, _backdropFrame.Height);
-            using (var stream = bitmap.PixelBuffer.AsStream())
+            var frame = await _backdropTask;
+            if (_completed || _closedByController)
             {
-                stream.Write(_backdropFrame.BgraPixels, 0, _backdropFrame.BgraPixels.Length);
+                return;
             }
 
-            bitmap.Invalidate();
-            Backdrop.Source = bitmap;
+            _backdropFrame = frame;
+            if (frame is null)
+            {
+                _backdropReady = true;
+                TryReveal();
+                return;
+            }
+
+            CaptureFlowTrace.Mark($"region: backdrop frame available ({frame.Width}x{frame.Height})");
+            var softwareBitmap = await Task.Run(() => SoftwareBitmap.CreateCopyFromBuffer(
+                frame.BgraPixels.AsBuffer(),
+                BitmapPixelFormat.Bgra8,
+                frame.Width,
+                frame.Height,
+                BitmapAlphaMode.Premultiplied));
+            if (_completed || _closedByController)
+            {
+                softwareBitmap.Dispose();
+                return;
+            }
+
+            var source = new SoftwareBitmapSource();
+            await source.SetBitmapAsync(softwareBitmap);
+            softwareBitmap.Dispose();
+            Backdrop.Source = source;
+            CaptureFlowTrace.Mark("region: backdrop source set");
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Region backdrop paint failed: {ex}");
         }
+
+        _backdropReady = true;
+        TryReveal();
+    }
+
+    private void TryReveal()
+    {
+        if (_revealed || !_rootLoaded || !_backdropReady)
+        {
+            return;
+        }
+
+        _revealed = true;
+        // Let the backdrop source commit to the visual tree before lifting the alpha, otherwise
+        // the first presented frame can be the bare dim without the screen snapshot behind it.
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            if (_completed || _closedByController)
+            {
+                return;
+            }
+
+            SetWindowAlpha(_hwnd, 255);
+            CaptureFlowTrace.Mark("region: overlay revealed");
+        });
     }
 
     private void OnOverlaySizeChanged(object sender, SizeChangedEventArgs e)
@@ -283,7 +289,7 @@ public sealed partial class RegionSelectWindow : Window
         _dragging = false;
         RootGrid.ReleasePointerCaptures();
         _onComplete(region is { } selected
-            ? new RegionSelectResult(_monitor.HMonitor, selected)
+            ? new RegionSelectResult(_monitor.HMonitor, selected, _backdropFrame)
             : null);
         Close();
     }

--- a/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScreenshotEditorWindow.xaml.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using TinyClips.App.ScreenshotEditor;
+using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 using Windows.Graphics.Imaging;
@@ -28,15 +30,34 @@ public sealed partial class ScreenshotEditorWindow : Window
     private const int MinimumWidthDip  = 760;
     private const int MinimumHeightDip = 520;
 
-    private readonly string _filePath;
+    private string _filePath;
     private readonly EditorController _controller;
     private readonly WindowChromeController _chromeController;
     private string _activeSavePath;
+    private readonly CapturedFrame? _initialFrame;
+    private readonly Task<string>? _pendingSave;
 
     public ScreenshotEditorWindow(string filePath)
+        : this(filePath, initialFrame: null, pendingSave: null)
+    {
+    }
+
+    /// <summary>
+    /// Opens the editor straight from captured pixels while the file is still being encoded and
+    /// written by <paramref name="pendingSave"/>. The editor becomes file-backed (Save, Reset,
+    /// Open folder) as soon as that task yields the final path.
+    /// </summary>
+    public ScreenshotEditorWindow(CapturedFrame frame, Task<string> pendingSave)
+        : this(string.Empty, frame, pendingSave)
+    {
+    }
+
+    private ScreenshotEditorWindow(string filePath, CapturedFrame? initialFrame, Task<string>? pendingSave)
     {
         _filePath = filePath;
         _activeSavePath = filePath;
+        _initialFrame = initialFrame;
+        _pendingSave = pendingSave;
 
         InitializeComponent();
 
@@ -87,7 +108,26 @@ public sealed partial class ScreenshotEditorWindow : Window
     {
         try
         {
+            if (_initialFrame is { } frame)
+            {
+                // Fast path: show the captured pixels immediately; the file is still being written.
+                var bitmap = await Task.Run(() => SoftwareBitmap.CreateCopyFromBuffer(
+                    frame.BgraPixels.AsBuffer(),
+                    BitmapPixelFormat.Bgra8,
+                    frame.Width,
+                    frame.Height,
+                    BitmapAlphaMode.Premultiplied));
+                await _controller.SetBitmapFromCaptureAsync(bitmap);
+                CaptureFlowTrace.Mark("editor: image visible (from memory)");
+                if (string.IsNullOrEmpty(_filePath))
+                {
+                    _ = BindToPendingSaveAsync();
+                }
+                return;
+            }
+
             await _controller.LoadAsync(_filePath);
+            CaptureFlowTrace.Mark("editor: image visible (from file)");
         }
         catch (Exception ex)
         {
@@ -95,6 +135,51 @@ public sealed partial class ScreenshotEditorWindow : Window
             App.ShowImageLoadFailureNotification(System.IO.Path.GetFileName(_filePath));
             Close();
         }
+    }
+
+    private async Task BindToPendingSaveAsync()
+    {
+        if (_pendingSave is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var path = await _pendingSave;
+            _filePath = path;
+            _activeSavePath = path;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Background screenshot save failed: {ex}");
+            App.ShowSaveFailureNotification("the screenshot capture");
+        }
+    }
+
+    /// <summary>Save/Open-folder need the file path; wait for the background save when it's still running.</summary>
+    private async Task<bool> EnsureFileBackingAsync()
+    {
+        if (!string.IsNullOrEmpty(_activeSavePath))
+        {
+            return true;
+        }
+
+        if (_pendingSave is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            await _pendingSave;
+        }
+        catch
+        {
+            // Already reported by BindToPendingSaveAsync.
+        }
+
+        return !string.IsNullOrEmpty(_activeSavePath);
     }
 
     // -- Keyboard shortcuts -------------------------------------------------------------------
@@ -229,15 +314,23 @@ public sealed partial class ScreenshotEditorWindow : Window
 
     private async void OnSave(object sender, RoutedEventArgs e)
     {
+        if (!await EnsureFileBackingAsync())
+        {
+            return;
+        }
+
         await SaveToPathAsync(_activeSavePath, updateActiveSavePath: true);
     }
 
     private async void OnSaveCopy(object sender, RoutedEventArgs e)
     {
+        await EnsureFileBackingAsync();
         var picker = new FileSavePicker { SuggestedStartLocation = PickerLocationId.PicturesLibrary };
         picker.FileTypeChoices.Add("PNG image", new[] { ".png" });
         picker.FileTypeChoices.Add("JPEG image", new[] { ".jpg" });
-        picker.SuggestedFileName = System.IO.Path.GetFileNameWithoutExtension(_activeSavePath) + " (edited)";
+        picker.SuggestedFileName = (string.IsNullOrEmpty(_activeSavePath)
+            ? "Screenshot"
+            : System.IO.Path.GetFileNameWithoutExtension(_activeSavePath)) + " (edited)";
 
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
@@ -270,8 +363,13 @@ public sealed partial class ScreenshotEditorWindow : Window
         return saved;
     }
 
-    private void OnOpenSaveFolder(object sender, RoutedEventArgs e)
+    private async void OnOpenSaveFolder(object sender, RoutedEventArgs e)
     {
+        if (!await EnsureFileBackingAsync())
+        {
+            return;
+        }
+
         var folder = System.IO.Path.GetDirectoryName(_activeSavePath);
         if (string.IsNullOrWhiteSpace(folder))
         {

--- a/windows/src/TinyClips.Core/Capture/CaptureFlowTrace.cs
+++ b/windows/src/TinyClips.Core/Capture/CaptureFlowTrace.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using TinyClips.Core.Services;
+
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// Lightweight latency instrumentation for the capture flow (hotkey → picker → overlay →
+/// capture → editor/recorder). Each <see cref="Mark"/> records the elapsed time since
+/// <see cref="Begin"/> and since the previous mark, so transitions that feel laggy can be
+/// measured instead of guessed. Output goes to <see cref="Debug"/> always, and additionally to
+/// <c>%LOCALAPPDATA%\TinyClips\Temp\capture-flow-trace.log</c> when the
+/// <c>TINYCLIPS_CAPTURE_TRACE</c> environment variable is set (or in DEBUG builds), so packaged
+/// builds can be profiled without a debugger. All I/O is best-effort and never throws.
+/// </summary>
+public static class CaptureFlowTrace
+{
+    private static readonly object Gate = new();
+    private static readonly bool FileLoggingEnabled = ResolveFileLogging();
+    private static long _flowStart;
+    private static long _lastMark;
+    private static string _flowName = string.Empty;
+
+    private static bool ResolveFileLogging()
+    {
+#if DEBUG
+        return true;
+#else
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TINYCLIPS_CAPTURE_TRACE"));
+#endif
+    }
+
+    /// <summary>Starts a new timed flow (e.g. "screenshot", "video"). Resets the clock.</summary>
+    public static void Begin(string flowName)
+    {
+        lock (Gate)
+        {
+            _flowName = flowName;
+            _flowStart = Stopwatch.GetTimestamp();
+            _lastMark = _flowStart;
+        }
+
+        Write($"[{flowName}] begin");
+    }
+
+    /// <summary>Records a named point in the current flow with total and delta elapsed time.</summary>
+    public static void Mark(string label)
+    {
+        long now = Stopwatch.GetTimestamp();
+        double totalMs;
+        double deltaMs;
+        string flow;
+        lock (Gate)
+        {
+            if (_flowStart == 0)
+            {
+                _flowStart = now;
+                _lastMark = now;
+            }
+
+            totalMs = Stopwatch.GetElapsedTime(_flowStart, now).TotalMilliseconds;
+            deltaMs = Stopwatch.GetElapsedTime(_lastMark, now).TotalMilliseconds;
+            _lastMark = now;
+            flow = _flowName;
+        }
+
+        Write($"[{flow}] +{deltaMs,7:F1} ms  (t={totalMs,8:F1} ms)  {label}");
+    }
+
+    private static void Write(string line)
+    {
+        Debug.WriteLine($"CaptureFlowTrace {line}");
+        if (!FileLoggingEnabled)
+        {
+            return;
+        }
+
+        lock (Gate)
+        {
+            try
+            {
+                var path = Path.Combine(TinyClipsTemporaryFiles.EnsureDirectoryExists(), "capture-flow-trace.log");
+                File.AppendAllText(path, $"{DateTimeOffset.Now:HH:mm:ss.fff}  {line}{Environment.NewLine}");
+            }
+            catch
+            {
+                // Best-effort only.
+            }
+        }
+    }
+}

--- a/windows/src/TinyClips.Core/Capture/CapturedFrame.cs
+++ b/windows/src/TinyClips.Core/Capture/CapturedFrame.cs
@@ -18,4 +18,30 @@ public sealed class CapturedFrame
     public int Width { get; }
 
     public int Height { get; }
+
+    /// <summary>
+    /// Returns a tightly-packed copy of the given sub-rectangle (clamped to the frame). Returns
+    /// this instance when the region covers the whole frame.
+    /// </summary>
+    public CapturedFrame Crop(PixelRect region)
+    {
+        var x = Math.Clamp(region.X, 0, Math.Max(0, Width - 1));
+        var y = Math.Clamp(region.Y, 0, Math.Max(0, Height - 1));
+        var width = Math.Clamp(region.Width, 1, Width - x);
+        var height = Math.Clamp(region.Height, 1, Height - y);
+        if (x == 0 && y == 0 && width == Width && height == Height)
+        {
+            return this;
+        }
+
+        var srcStride = Width * 4;
+        var dstStride = width * 4;
+        var pixels = new byte[dstStride * height];
+        for (var row = 0; row < height; row++)
+        {
+            Buffer.BlockCopy(BgraPixels, ((y + row) * srcStride) + (x * 4), pixels, row * dstStride, dstStride);
+        }
+
+        return new CapturedFrame(pixels, width, height);
+    }
 }

--- a/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
+++ b/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
@@ -74,10 +74,9 @@ internal sealed class ContinuousCaptureSession : IDisposable
             throw new NotSupportedException("Windows.Graphics.Capture is not supported on this device.");
         }
 
-        _d3dDevice = WgcInterop.CreateD3D11Device()
-            ?? throw new InvalidOperationException("Failed to create a Direct3D 11 device.");
-        _device = WgcInterop.CreateDirect3DDevice(_d3dDevice)
-            ?? throw new InvalidOperationException("Failed to create the WinRT IDirect3DDevice.");
+        var (d3dDevice, device) = WgcInterop.GetSharedDevice();
+        _d3dDevice = d3dDevice;
+        _device = device;
         _context = _d3dDevice.ImmediateContext;
 
         var item = _target.CreateItem()
@@ -282,12 +281,25 @@ internal sealed class ContinuousCaptureSession : IDisposable
             var pixels = new byte[width * height * 4];
             var src = (byte*)mapped.DataPointer;
             int srcPitch = (int)mapped.RowPitch;
+            int rowBytes = width * 4;
 
-            for (int row = 0; row < height; row++)
+            fixed (byte* dst = pixels)
             {
-                int srcOffset = ((y + row) * srcPitch) + (x * 4);
-                int dstOffset = row * width * 4;
-                Marshal.Copy(new nint(src + srcOffset), pixels, dstOffset, width * 4);
+                if (x == 0 && srcPitch == rowBytes)
+                {
+                    Buffer.MemoryCopy(src + ((long)y * srcPitch), dst, pixels.Length, (long)height * rowBytes);
+                }
+                else
+                {
+                    for (int row = 0; row < height; row++)
+                    {
+                        Buffer.MemoryCopy(
+                            src + ((long)(y + row) * srcPitch) + (x * 4),
+                            dst + ((long)row * rowBytes),
+                            rowBytes,
+                            rowBytes);
+                    }
+                }
             }
 
             return new CapturedFrame(pixels, width, height);
@@ -325,9 +337,8 @@ internal sealed class ContinuousCaptureSession : IDisposable
             _framePool = null;
             _stagingTexture?.Dispose();
             _stagingTexture = null;
-            _device?.Dispose();
+            // The device pair is process-shared (WgcInterop.GetSharedDevice); only drop our references.
             _device = null;
-            _d3dDevice?.Dispose();
             _d3dDevice = null;
             _context = null;
             _latestPixels = null;

--- a/windows/src/TinyClips.Core/Capture/GifRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/GifRecordingService.cs
@@ -29,6 +29,8 @@ public sealed class GifRecordingService : IGifRecordingService
     private double _fps;
     private int _stopping;
     private int _discardRequested;
+    private CaptureTarget? _preparedTarget;
+    private PixelRect? _preparedRegion;
 
     private MouseClickMonitor? _clickMonitor;
     private MouseClickOverlayStyle _clickStyle;
@@ -54,6 +56,47 @@ public sealed class GifRecordingService : IGifRecordingService
 
     public event EventHandler<string?>? RecordingCompleted;
 
+    public async Task PrepareAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (IsRecording)
+            {
+                throw new InvalidOperationException("A GIF recording is already in progress.");
+            }
+
+            var captureTarget = ResolveTarget(target);
+            if (_preparedTarget is { } existing && Matches(existing, _preparedRegion, captureTarget, region))
+            {
+                return;
+            }
+
+            DiscardPreparedCore();
+            PrepareCore(captureTarget, region);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task DiscardPreparedAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!IsRecording)
+            {
+                DiscardPreparedCore();
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task StartAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -64,28 +107,72 @@ public sealed class GifRecordingService : IGifRecordingService
                 throw new InvalidOperationException("A GIF recording is already in progress.");
             }
 
+            var captureTarget = ResolveTarget(target);
+            if (_preparedTarget is null || !Matches(_preparedTarget, _preparedRegion, captureTarget, region))
+            {
+                DiscardPreparedCore();
+                PrepareCore(captureTarget, region);
+            }
+            else
+            {
+                CaptureFlowTrace.Mark("gif: using pre-warmed capture session");
+            }
+
             Interlocked.Exchange(ref _discardRequested, 0);
-
-            var captureTarget = target ?? CaptureTarget.Monitor(
-                (_monitors.GetPrimaryMonitor()
-                    ?? throw new InvalidOperationException("No monitor was found to record.")).HMonitor);
-
-            _fps = Math.Clamp(_settings.GifFrameRate, 1, 50);
             _frames = new List<CapturedFrame>();
-
-            _capture = new ContinuousCaptureSession(captureTarget, region, (int)Math.Round(_fps), includeCursor: true);
-            _capture.FrameReady += OnFrameReady;
-            _capture.Start();
-            _capture.BeginEmitting();
+            _preparedTarget = null;
+            _preparedRegion = null;
 
             StartMouseClickOverlay(captureTarget, region);
             _branding = _settings.ShowBrandingOverlay ? new BrandingOverlayCompositor() : null;
 
+            _capture!.BeginEmitting();
             IsRecording = true;
+            CaptureFlowTrace.Mark("gif: recording started (emitting)");
         }
         finally
         {
             _gate.Release();
+        }
+    }
+
+    private CaptureTarget ResolveTarget(CaptureTarget? target) => target ?? CaptureTarget.Monitor(
+        (_monitors.GetPrimaryMonitor()
+            ?? throw new InvalidOperationException("No monitor was found to record.")).HMonitor);
+
+    private static bool Matches(CaptureTarget a, PixelRect? aRegion, CaptureTarget b, PixelRect? bRegion) =>
+        a.HMonitor == b.HMonitor && a.Hwnd == b.Hwnd && aRegion == bRegion;
+
+    private void PrepareCore(CaptureTarget captureTarget, PixelRect? region)
+    {
+        _fps = Math.Clamp(_settings.GifFrameRate, 1, 50);
+        _capture = new ContinuousCaptureSession(captureTarget, region, (int)Math.Round(_fps), includeCursor: true);
+        _capture.FrameReady += OnFrameReady;
+        try
+        {
+            _capture.Start();
+        }
+        catch
+        {
+            _capture.Dispose();
+            _capture = null;
+            throw;
+        }
+
+        _preparedTarget = captureTarget;
+        _preparedRegion = region;
+        CaptureFlowTrace.Mark("gif: capture session started");
+    }
+
+    private void DiscardPreparedCore()
+    {
+        _preparedTarget = null;
+        _preparedRegion = null;
+        if (!IsRecording && _capture is not null)
+        {
+            _capture.FrameReady -= OnFrameReady;
+            _capture.Dispose();
+            _capture = null;
         }
     }
 
@@ -204,6 +291,7 @@ public sealed class GifRecordingService : IGifRecordingService
             if (!IsRecording)
             {
                 IsPaused = false;
+                DiscardPreparedCore();
                 if (ConsumeDiscardRequested(discard))
                 {
                     lock (_frameLock)

--- a/windows/src/TinyClips.Core/Capture/IGifRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/IGifRecordingService.cs
@@ -21,6 +21,15 @@ public interface IGifRecordingService
     /// </summary>
     Task StartAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Pre-warms the capture session for the given target without starting the recording, so a
+    /// following <see cref="StartAsync"/> with the same target/region begins immediately.
+    /// </summary>
+    Task PrepareAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Tears down a pipeline prepared by <see cref="PrepareAsync"/> that will not be started.</summary>
+    Task DiscardPreparedAsync();
+
     /// <summary>Stops recording, encodes the GIF and returns the saved path (or null if nothing recorded).</summary>
     Task<string?> StopAsync();
 

--- a/windows/src/TinyClips.Core/Capture/IScreenCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/IScreenCaptureService.cs
@@ -6,6 +6,12 @@ public readonly record struct PixelRect(int X, int Y, int Width, int Height);
 public interface IScreenCaptureService
 {
     /// <summary>
+    /// Creates the shared Direct3D capture device ahead of time so the first capture of a
+    /// session does not pay for device creation. Safe to call repeatedly; never throws.
+    /// </summary>
+    void WarmUp();
+
+    /// <summary>
     /// Captures a single frame of the given monitor using Windows.Graphics.Capture.
     /// When <paramref name="region"/> is supplied the frame is cropped to that
     /// monitor-relative rectangle. Pixels are returned tightly packed as BGRA8.

--- a/windows/src/TinyClips.Core/Capture/IScreenshotService.cs
+++ b/windows/src/TinyClips.Core/Capture/IScreenshotService.cs
@@ -22,4 +22,11 @@ public interface IScreenshotService
     /// it. Returns the saved file path.
     /// </summary>
     Task<string> CaptureTargetAsync(CaptureTarget target, PixelRect? region = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Encodes an already-captured frame per the user's screenshot settings (branding overlay,
+    /// PNG/JPEG, scale, quality) and saves it. Used when the region-select overlay's frozen
+    /// backdrop is the screenshot source, so no second capture is needed. Returns the saved path.
+    /// </summary>
+    Task<string> SaveFrameAsync(CapturedFrame frame, bool applyBranding = true, CancellationToken cancellationToken = default);
 }

--- a/windows/src/TinyClips.Core/Capture/IVideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/IVideoRecordingService.cs
@@ -38,6 +38,18 @@ public interface IVideoRecordingService
     /// </summary>
     Task StartAsync(CaptureTarget? target = null, PixelRect? region = null, double? timeLimitMinutesOverride = null, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Pre-warms the recording pipeline (capture session, webcam, audio devices, encoder) for the
+    /// given target without starting the recorded timeline. A following <see cref="StartAsync"/>
+    /// with the same target/region begins emitting immediately instead of paying for setup. Call
+    /// during the countdown or setup panel. Discard with <see cref="DiscardPreparedAsync"/> if
+    /// the recording is cancelled before it starts.
+    /// </summary>
+    Task PrepareAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Tears down a pipeline prepared by <see cref="PrepareAsync"/> that will not be started.</summary>
+    Task DiscardPreparedAsync();
+
     /// <summary>Stops recording, finalizes the MP4 and returns the saved path (or null if nothing recorded).</summary>
     Task<string?> StopAsync();
 

--- a/windows/src/TinyClips.Core/Capture/ScreenCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/ScreenCaptureService.cs
@@ -14,10 +14,14 @@ namespace TinyClips.Core.Capture;
 /// </summary>
 public sealed partial class ScreenCaptureService : IScreenCaptureService
 {
-    // Number of frames to observe before grabbing one, so the capture-start
-    // transition / border flash isn't what we encode.
-    private const int SettleFrames = 2;
+    // Window targets can show a brief capture-start transition on the first frame; monitor
+    // targets (border disabled via IsBorderRequired=false) are clean on the first frame, so
+    // waiting for a second one would only add a vsync of latency.
+    private const int SettleFramesForWindow = 2;
+    private const int SettleFramesForMonitor = 1;
     private const int CaptureTimeoutMs = 4000;
+
+    public void WarmUp() => WgcInterop.WarmUpSharedDevice();
 
     public Task<CapturedFrame> CaptureMonitorAsync(
         nint hMonitor,
@@ -37,18 +41,14 @@ public sealed partial class ScreenCaptureService : IScreenCaptureService
             throw new NotSupportedException("Windows.Graphics.Capture is not supported on this device.");
         }
 
-        ID3D11Device? d3dDevice = null;
-        IDirect3DDevice? device = null;
         Direct3D11CaptureFramePool? framePool = null;
         GraphicsCaptureSession? session = null;
         ID3D11Texture2D? stagingTexture = null;
+        var settleFrames = target.IsWindow ? SettleFramesForWindow : SettleFramesForMonitor;
 
         try
         {
-            d3dDevice = WgcInterop.CreateD3D11Device()
-                ?? throw new InvalidOperationException("Failed to create a Direct3D 11 device.");
-            device = WgcInterop.CreateDirect3DDevice(d3dDevice)
-                ?? throw new InvalidOperationException("Failed to create the WinRT IDirect3DDevice.");
+            var (d3dDevice, device) = WgcInterop.GetSharedDevice();
 
             var item = target.CreateItem()
                 ?? throw new InvalidOperationException("Failed to create a GraphicsCaptureItem for the target.");
@@ -112,7 +112,7 @@ public sealed partial class ScreenCaptureService : IScreenCaptureService
                         context.CopyResource(stagingTexture, frameTexture);
                         frameCount++;
 
-                        if (frameCount >= SettleFrames)
+                        if (frameCount >= settleFrames)
                         {
                             tcs.TrySetResult(true);
                         }
@@ -162,8 +162,7 @@ public sealed partial class ScreenCaptureService : IScreenCaptureService
             session?.Dispose();
             framePool?.Dispose();
             stagingTexture?.Dispose();
-            device?.Dispose();
-            d3dDevice?.Dispose();
+            // The D3D device pair is process-shared (see WgcInterop.GetSharedDevice); do not dispose.
         }
     }
 
@@ -189,12 +188,26 @@ public sealed partial class ScreenCaptureService : IScreenCaptureService
             var pixels = new byte[width * height * 4];
             var src = (byte*)mapped.DataPointer;
             int srcPitch = (int)mapped.RowPitch;
+            int rowBytes = width * 4;
 
-            for (int row = 0; row < height; row++)
+            fixed (byte* dst = pixels)
             {
-                int srcOffset = ((y + row) * srcPitch) + (x * 4);
-                int dstOffset = row * width * 4;
-                Marshal.Copy(new nint(src + srcOffset), pixels, dstOffset, width * 4);
+                if (x == 0 && srcPitch == rowBytes)
+                {
+                    // Tightly packed source: one contiguous copy.
+                    Buffer.MemoryCopy(src + ((long)y * srcPitch), dst, pixels.Length, (long)height * rowBytes);
+                }
+                else
+                {
+                    for (int row = 0; row < height; row++)
+                    {
+                        Buffer.MemoryCopy(
+                            src + ((long)(y + row) * srcPitch) + (x * 4),
+                            dst + ((long)row * rowBytes),
+                            rowBytes,
+                            rowBytes);
+                    }
+                }
             }
 
             return new CapturedFrame(pixels, width, height);

--- a/windows/src/TinyClips.Core/Capture/ScreenshotService.cs
+++ b/windows/src/TinyClips.Core/Capture/ScreenshotService.cs
@@ -49,15 +49,22 @@ public sealed class ScreenshotService : IScreenshotService
         var frame = await _capture
             .CaptureAsync(captureTarget, region, includeCursor: false, cancellationToken)
             .ConfigureAwait(false);
+        CaptureFlowTrace.Mark("screenshot: frame captured");
 
+        return await SaveFrameAsync(frame, applyBranding: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string> SaveFrameAsync(CapturedFrame frame, bool applyBranding = true, CancellationToken cancellationToken = default)
+    {
         var path = _storage.GenerateFilePath(CaptureType.Screenshot);
 
-        if (_settings.ShowBrandingOverlay)
+        if (applyBranding && _settings.ShowBrandingOverlay)
         {
             new BrandingOverlayCompositor().Draw(frame.BgraPixels, frame.Width, frame.Height);
         }
 
         var encoded = await EncodeAsync(frame).ConfigureAwait(false);
+        CaptureFlowTrace.Mark("screenshot: encoded");
 
         var directory = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory))
@@ -66,6 +73,7 @@ public sealed class ScreenshotService : IScreenshotService
         }
 
         await File.WriteAllBytesAsync(path, encoded, cancellationToken).ConfigureAwait(false);
+        CaptureFlowTrace.Mark("screenshot: written to disk");
         _analytics.RecordCapture(CaptureType.Screenshot);
         return path;
     }

--- a/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
@@ -42,6 +42,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
     private Timer? _limitTimer;
     private int _stopping;
     private int _discardRequested;
+    private PreparedPipeline? _prepared;
 
     private MouseClickMonitor? _clickMonitor;
     private MouseClickOverlayStyle _clickStyle;
@@ -96,7 +97,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
 
     public event EventHandler<string>? WebcamCaptureFailed;
 
-    public async Task StartAsync(CaptureTarget? target = null, PixelRect? region = null, double? timeLimitMinutesOverride = null, CancellationToken cancellationToken = default)
+    public async Task PrepareAsync(CaptureTarget? target = null, PixelRect? region = null, CancellationToken cancellationToken = default)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -106,124 +107,20 @@ public sealed class VideoRecordingService : IVideoRecordingService
                 throw new InvalidOperationException("A recording is already in progress.");
             }
 
-            Interlocked.Exchange(ref _discardRequested, 0);
+            var captureTarget = ResolveTarget(target);
+            if (_prepared is { } existing)
+            {
+                if (existing.Matches(captureTarget, region))
+                {
+                    return;
+                }
 
-            var captureTarget = target ?? CaptureTarget.Monitor(
-                (_monitors.GetPrimaryMonitor()
-                    ?? throw new InvalidOperationException("No monitor was found to record.")).HMonitor);
-
-            var fps = Math.Clamp(_settings.VideoFrameRate, 1, 60);
-            _frameDuration = TimeSpan.FromSeconds(1.0 / fps);
+                await CleanupFailedStartAsync().ConfigureAwait(false);
+            }
 
             try
             {
-                _channel = Channel.CreateBounded<TimestampedFrame>(new BoundedChannelOptions(fps * 4)
-                {
-                    FullMode = BoundedChannelFullMode.DropWrite,
-                    SingleReader = true,
-                    SingleWriter = true,
-                });
-
-                _capture = new ContinuousCaptureSession(captureTarget, region, fps, includeCursor: true);
-                _capture.FrameReady += OnFrameReady;
-                _capture.Start();
-
-                StartMouseClickOverlay(captureTarget, region);
-                _branding = _settings.ShowBrandingOverlay ? new BrandingOverlayCompositor() : null;
-                await StartWebcamOverlayAsync(cancellationToken).ConfigureAwait(false);
-
-                var width = _capture.OutputWidth;
-                var height = _capture.OutputHeight;
-
-                _outputPath = _storage.GenerateFilePath(CaptureType.Video);
-                var directory = Path.GetDirectoryName(_outputPath);
-                if (!string.IsNullOrEmpty(directory))
-                {
-                    Directory.CreateDirectory(directory);
-                }
-
-                _fileStream = new FileStream(_outputPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
-                var randomAccessStream = _fileStream.AsRandomAccessStream();
-
-                _audioEnding = false;
-                _audioFramesRead = 0;
-                _audioSamplesRequested = 0;
-                _audioNonSilentChunks = 0;
-                _loggedFirstAudioChunk = false;
-                StartAudioCapture();
-
-                var includeAudio = _hasAudio;
-                var profile = CreateEncodingProfile(width, height, fps, includeAudio);
-                var mediaStreamSource = CreateMediaStreamSource(width, height, fps);
-
-                var transcoder = new MediaTranscoder { HardwareAccelerationEnabled = true };
-                PrepareTranscodeResult prepare;
-                var usedFallbackProfile = false;
-                try
-                {
-                    prepare = await PrepareTranscodeAsync(
-                        transcoder,
-                        mediaStreamSource,
-                        randomAccessStream,
-                        profile,
-                        cancellationToken).ConfigureAwait(false);
-                }
-                catch (COMException ex) when (ex.HResult == MfTransformTypeNotSet)
-                {
-                    prepare = await RetryPrepareWithBaselineAsync(
-                        randomAccessStream,
-                        width,
-                        height,
-                        fps,
-                        includeAudio,
-                        cancellationToken,
-                        ex).ConfigureAwait(false);
-                    usedFallbackProfile = true;
-                }
-
-                if (!prepare.CanTranscode && !usedFallbackProfile)
-                {
-                    prepare = await RetryPrepareWithBaselineAsync(
-                        randomAccessStream,
-                        width,
-                        height,
-                        fps,
-                        includeAudio,
-                        cancellationToken,
-                        null).ConfigureAwait(false);
-                }
-
-                if (!prepare.CanTranscode)
-                {
-                    throw new InvalidOperationException($"Cannot encode video: {prepare.FailureReason}.");
-                }
-
-                // The encoder is now ready to consume frames. Wait briefly for the first webcam
-                // frame, then give screen, webcam, loopback, and microphone one shared QPC origin.
-                // Audio packets retain their source timestamp offsets rather than being flattened
-                // by independent buffers. This anchors the recorded timeline to the real start
-                // moment — without it, the capture clock,
-                // encoder prep and camera warm-up were baked in as several seconds of dead pre-roll
-                // (frozen screen, no webcam) at the front of every clip, and that pre-roll saturated
-                // the bounded frame channel so real frames near the end were dropped.
-                await WaitForFirstWebcamFrameAsync(cancellationToken).ConfigureAwait(false);
-                _recordingTimeline = RecordingTimeline.StartNow();
-                _webcamPlacements = new WebcamPlacementTimeline(_settings.WebcamCornerPosition);
-                _audio?.BeginTimeline(_recordingTimeline);
-                _capture.BeginEmitting(_recordingTimeline);
-
-                _transcodeTask = prepare.TranscodeAsync().AsTask();
-                IsRecording = true;
-
-                var limitMinutes = timeLimitMinutesOverride ?? _settings.VideoRecordingTimeLimitMinutes;
-                if (limitMinutes > 0)
-                {
-                    _limitTimer = new Timer(
-                        _ => _ = StopAsync(),
-                        null,
-                        TimeSpan.FromMinutes(limitMinutes),
-                        Timeout.InfiniteTimeSpan);
-                }
+                await PrepareCoreAsync(captureTarget, region, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -235,6 +132,206 @@ public sealed class VideoRecordingService : IVideoRecordingService
         {
             _gate.Release();
         }
+    }
+
+    public async Task DiscardPreparedAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!IsRecording && _prepared is not null)
+            {
+                await CleanupFailedStartAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task StartAsync(CaptureTarget? target = null, PixelRect? region = null, double? timeLimitMinutesOverride = null, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (IsRecording)
+            {
+                throw new InvalidOperationException("A recording is already in progress.");
+            }
+
+            var captureTarget = ResolveTarget(target);
+            try
+            {
+                if (_prepared is null || !_prepared.Matches(captureTarget, region))
+                {
+                    if (_prepared is not null)
+                    {
+                        await CleanupFailedStartAsync().ConfigureAwait(false);
+                    }
+
+                    await PrepareCoreAsync(captureTarget, region, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    CaptureFlowTrace.Mark("video: using pre-warmed pipeline");
+                }
+
+                await BeginPreparedAsync(timeLimitMinutesOverride, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                await CleanupFailedStartAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private CaptureTarget ResolveTarget(CaptureTarget? target) => target ?? CaptureTarget.Monitor(
+        (_monitors.GetPrimaryMonitor()
+            ?? throw new InvalidOperationException("No monitor was found to record.")).HMonitor);
+
+    /// <summary>
+    /// Builds the whole pipeline up to "encoder ready": capture session (capturing but not
+    /// emitting), webcam, audio devices, output file and a prepared transcoder. Safe to run during
+    /// the countdown because nothing is written to the timeline until <see cref="BeginPreparedAsync"/>.
+    /// </summary>
+    private async Task PrepareCoreAsync(CaptureTarget captureTarget, PixelRect? region, CancellationToken cancellationToken)
+    {
+        Interlocked.Exchange(ref _discardRequested, 0);
+
+        var fps = Math.Clamp(_settings.VideoFrameRate, 1, 60);
+        _frameDuration = TimeSpan.FromSeconds(1.0 / fps);
+
+        _channel = Channel.CreateBounded<TimestampedFrame>(new BoundedChannelOptions(fps * 4)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = true,
+        });
+
+        _capture = new ContinuousCaptureSession(captureTarget, region, fps, includeCursor: true);
+        _capture.FrameReady += OnFrameReady;
+        _capture.Start();
+        CaptureFlowTrace.Mark("video: capture session started");
+
+        StartMouseClickOverlay(captureTarget, region);
+        _branding = _settings.ShowBrandingOverlay ? new BrandingOverlayCompositor() : null;
+        await StartWebcamOverlayAsync(cancellationToken).ConfigureAwait(false);
+        CaptureFlowTrace.Mark("video: webcam overlay started");
+
+        var width = _capture.OutputWidth;
+        var height = _capture.OutputHeight;
+
+        _outputPath = _storage.GenerateFilePath(CaptureType.Video);
+        var directory = Path.GetDirectoryName(_outputPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _fileStream = new FileStream(_outputPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+        var randomAccessStream = _fileStream.AsRandomAccessStream();
+
+        _audioEnding = false;
+        _audioFramesRead = 0;
+        _audioSamplesRequested = 0;
+        _audioNonSilentChunks = 0;
+        _loggedFirstAudioChunk = false;
+        StartAudioCapture();
+        CaptureFlowTrace.Mark("video: audio capture started");
+
+        var includeAudio = _hasAudio;
+        var profile = CreateEncodingProfile(width, height, fps, includeAudio);
+        var mediaStreamSource = CreateMediaStreamSource(width, height, fps);
+
+        var transcoder = new MediaTranscoder { HardwareAccelerationEnabled = true };
+        PrepareTranscodeResult prepare;
+        var usedFallbackProfile = false;
+        try
+        {
+            prepare = await PrepareTranscodeAsync(
+                transcoder,
+                mediaStreamSource,
+                randomAccessStream,
+                profile,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (COMException ex) when (ex.HResult == MfTransformTypeNotSet)
+        {
+            prepare = await RetryPrepareWithBaselineAsync(
+                randomAccessStream,
+                width,
+                height,
+                fps,
+                includeAudio,
+                cancellationToken,
+                ex).ConfigureAwait(false);
+            usedFallbackProfile = true;
+        }
+
+        if (!prepare.CanTranscode && !usedFallbackProfile)
+        {
+            prepare = await RetryPrepareWithBaselineAsync(
+                randomAccessStream,
+                width,
+                height,
+                fps,
+                includeAudio,
+                cancellationToken,
+                null).ConfigureAwait(false);
+        }
+
+        if (!prepare.CanTranscode)
+        {
+            throw new InvalidOperationException($"Cannot encode video: {prepare.FailureReason}.");
+        }
+
+        CaptureFlowTrace.Mark("video: transcoder prepared");
+        _prepared = new PreparedPipeline(captureTarget, region, prepare);
+    }
+
+    private async Task BeginPreparedAsync(double? timeLimitMinutesOverride, CancellationToken cancellationToken)
+    {
+        var prepared = _prepared ?? throw new InvalidOperationException("Pipeline has not been prepared.");
+        _prepared = null;
+
+        // The encoder is ready to consume frames. Wait briefly for the first webcam frame, then
+        // give screen, webcam, loopback, and microphone one shared QPC origin. Audio packets retain
+        // their source timestamp offsets rather than being flattened by independent buffers. This
+        // anchors the recorded timeline to the real start moment — without it, the capture clock,
+        // encoder prep and camera warm-up were baked in as several seconds of dead pre-roll
+        // (frozen screen, no webcam) at the front of every clip, and that pre-roll saturated the
+        // bounded frame channel so real frames near the end were dropped.
+        await WaitForFirstWebcamFrameAsync(cancellationToken).ConfigureAwait(false);
+        _recordingTimeline = RecordingTimeline.StartNow();
+        _webcamPlacements = new WebcamPlacementTimeline(_settings.WebcamCornerPosition);
+        _audio?.BeginTimeline(_recordingTimeline);
+        _capture!.BeginEmitting(_recordingTimeline);
+
+        _transcodeTask = prepared.Transcode.TranscodeAsync().AsTask();
+        IsRecording = true;
+        CaptureFlowTrace.Mark("video: recording started (emitting)");
+
+        var limitMinutes = timeLimitMinutesOverride ?? _settings.VideoRecordingTimeLimitMinutes;
+        if (limitMinutes > 0)
+        {
+            _limitTimer = new Timer(
+                _ => _ = StopAsync(),
+                null,
+                TimeSpan.FromMinutes(limitMinutes),
+                Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private sealed record PreparedPipeline(CaptureTarget Target, PixelRect? Region, PrepareTranscodeResult Transcode)
+    {
+        public bool Matches(CaptureTarget target, PixelRect? region) =>
+            Target.HMonitor == target.HMonitor && Target.Hwnd == target.Hwnd && Region == region;
     }
 
     private void OnFrameReady(CapturedFrame frame, TimeSpan pts)
@@ -458,6 +555,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
 
     private async Task CleanupFailedStartAsync()
     {
+        _prepared = null;
         DetachMediaStreamSource();
         _limitTimer?.Dispose();
         _limitTimer = null;
@@ -917,6 +1015,13 @@ public sealed class VideoRecordingService : IVideoRecordingService
             if (!IsRecording)
             {
                 IsPaused = false;
+
+                if (_prepared is not null)
+                {
+                    // A pre-warmed pipeline that never started (e.g. countdown cancelled).
+                    await CleanupFailedStartAsync().ConfigureAwait(false);
+                    return null;
+                }
 
                 if (ConsumeDiscardRequested(discard))
                 {

--- a/windows/src/TinyClips.Core/Capture/WgcInterop.cs
+++ b/windows/src/TinyClips.Core/Capture/WgcInterop.cs
@@ -76,14 +76,24 @@ internal static partial class WgcInterop
 
             var d3d = CreateD3D11Device()
                 ?? throw new InvalidOperationException("Failed to create a Direct3D 11 device.");
+
+            // The device is shared across concurrent WGC sessions whose frame-pool callbacks run
+            // on different threads, so multithread protection on the immediate context is
+            // required — not best-effort. Without it, sharing would be unsafe; fail instead.
             try
             {
-                using var multithread = d3d.QueryInterfaceOrNull<ID3D11Multithread>();
-                multithread?.SetMultithreadProtected(true);
+                using var multithread = d3d.QueryInterfaceOrNull<ID3D11Multithread>()
+                    ?? throw new NotSupportedException("ID3D11Multithread is not available on this device.");
+                multithread.SetMultithreadProtected(true);
+                if (!multithread.GetMultithreadProtected())
+                {
+                    throw new NotSupportedException("Failed to enable multithread protection on the Direct3D 11 device.");
+                }
             }
             catch
             {
-                // Best-effort; consumers also serialize their own context use.
+                d3d.Dispose();
+                throw;
             }
 
             var winrt = CreateDirect3DDevice(d3d);

--- a/windows/src/TinyClips.Core/Capture/WgcInterop.cs
+++ b/windows/src/TinyClips.Core/Capture/WgcInterop.cs
@@ -45,6 +45,73 @@ internal static partial class WgcInterop
         int GetInterface(in Guid iid, out nint ppvObject);
     }
 
+    private static readonly object SharedDeviceGate = new();
+    private static ID3D11Device? _sharedD3DDevice;
+    private static IDirect3DDevice? _sharedDirect3DDevice;
+
+    /// <summary>
+    /// Returns a process-wide shared Direct3D 11 device pair for WGC capture. Creating a D3D11
+    /// device costs tens of milliseconds (driver load, adapter enumeration), and the capture flow
+    /// used to do it three or four times per capture (one per monitor backdrop, one for the
+    /// screenshot, one for the recorder). The shared device is multithread-protected so the
+    /// immediate context can be used from the WGC frame-pool threads of concurrent sessions, and it
+    /// is recreated transparently if the GPU reports device removal. Callers must not dispose it.
+    /// </summary>
+    internal static (ID3D11Device D3D, IDirect3DDevice WinRT) GetSharedDevice()
+    {
+        lock (SharedDeviceGate)
+        {
+            if (_sharedD3DDevice is not null && _sharedDirect3DDevice is not null)
+            {
+                if (_sharedD3DDevice.DeviceRemovedReason.Success)
+                {
+                    return (_sharedD3DDevice, _sharedDirect3DDevice);
+                }
+
+                _sharedDirect3DDevice.Dispose();
+                _sharedD3DDevice.Dispose();
+                _sharedDirect3DDevice = null;
+                _sharedD3DDevice = null;
+            }
+
+            var d3d = CreateD3D11Device()
+                ?? throw new InvalidOperationException("Failed to create a Direct3D 11 device.");
+            try
+            {
+                using var multithread = d3d.QueryInterfaceOrNull<ID3D11Multithread>();
+                multithread?.SetMultithreadProtected(true);
+            }
+            catch
+            {
+                // Best-effort; consumers also serialize their own context use.
+            }
+
+            var winrt = CreateDirect3DDevice(d3d);
+            if (winrt is null)
+            {
+                d3d.Dispose();
+                throw new InvalidOperationException("Failed to create the WinRT IDirect3DDevice.");
+            }
+
+            _sharedD3DDevice = d3d;
+            _sharedDirect3DDevice = winrt;
+            return (d3d, winrt);
+        }
+    }
+
+    /// <summary>Creates the shared device ahead of time (e.g. at app launch) so the first capture doesn't pay for it.</summary>
+    internal static void WarmUpSharedDevice()
+    {
+        try
+        {
+            _ = GetSharedDevice();
+        }
+        catch
+        {
+            // Warm-up is opportunistic; the real capture path surfaces errors.
+        }
+    }
+
     internal static ID3D11Device? CreateD3D11Device()
     {
         var featureLevels = new[]

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -323,6 +323,12 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("showScreenshotEditor", value);
     }
 
+    public bool ScreenshotUsesLiveCapture
+    {
+        get => _settings.Get("screenshotUsesLiveCapture", false);
+        set => _settings.Set("screenshotUsesLiveCapture", value);
+    }
+
     public bool ShowGifTrimmer
     {
         get => _settings.Get("showGifTrimmer", true);
@@ -718,6 +724,7 @@ public sealed class CaptureSettings : ICaptureSettings
         WebcamCornerPosition = WebcamCornerPosition.BottomRight;
         WebcamCornerRadius = null;
         ShowScreenshotEditor = true;
+        ScreenshotUsesLiveCapture = false;
         ShowGifTrimmer = true;
         SaveImmediatelyScreenshot = true;
         SaveImmediatelyVideo = true;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -46,6 +46,13 @@ public interface ICaptureSettings
     WebcamCornerPosition WebcamCornerPosition { get; set; }
     double? WebcamCornerRadius { get; set; }
     bool ShowScreenshotEditor { get; set; }
+
+    /// <summary>
+    /// When true, a region screenshot re-captures the screen after the selection overlay closes
+    /// (reflects changes made while selecting, slower). When false (default), the frozen frame
+    /// shown behind the overlay is cropped and saved directly — no second capture.
+    /// </summary>
+    bool ScreenshotUsesLiveCapture { get; set; }
     bool ShowGifTrimmer { get; set; }
     bool SaveImmediatelyScreenshot { get; set; }
     bool SaveImmediatelyVideo { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -346,6 +346,23 @@ public sealed class CaptureSettingsTests
     }
 
     [Fact]
+    public void ScreenshotUsesLiveCapture_DefaultsFalse_RoundTrips_AndResetRestoresDefault()
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        Assert.False(settings.ScreenshotUsesLiveCapture);
+
+        settings.ScreenshotUsesLiveCapture = true;
+        Assert.True(settings.ScreenshotUsesLiveCapture);
+        Assert.True(settingsService.Get("screenshotUsesLiveCapture", false));
+
+        settings.ResetToDefaults();
+        Assert.False(settings.ScreenshotUsesLiveCapture);
+        Assert.False(settingsService.Get("screenshotUsesLiveCapture", true));
+    }
+
+    [Fact]
     public void TeleprompterSettings_RoundTripThroughPersistedKeys()
     {
         var settingsService = new TestSettingsService();

--- a/windows/tests/TinyClips.Core.Tests/CapturedFrameTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CapturedFrameTests.cs
@@ -1,0 +1,66 @@
+using TinyClips.Core.Capture;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class CapturedFrameTests
+{
+    private static CapturedFrame MakeFrame(int width, int height)
+    {
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var i = ((y * width) + x) * 4;
+                pixels[i] = (byte)x;      // B
+                pixels[i + 1] = (byte)y;  // G
+                pixels[i + 2] = 0xAA;     // R
+                pixels[i + 3] = 0xFF;     // A
+            }
+        }
+
+        return new CapturedFrame(pixels, width, height);
+    }
+
+    [Fact]
+    public void Crop_ReturnsTightlyPackedSubRectangle()
+    {
+        var frame = MakeFrame(8, 6);
+
+        var cropped = frame.Crop(new PixelRect(2, 1, 3, 4));
+
+        Assert.Equal(3, cropped.Width);
+        Assert.Equal(4, cropped.Height);
+        Assert.Equal(3 * 4 * 4, cropped.BgraPixels.Length);
+        // Top-left of crop is source pixel (2,1).
+        Assert.Equal(2, cropped.BgraPixels[0]);
+        Assert.Equal(1, cropped.BgraPixels[1]);
+        // Bottom-right of crop is source pixel (4,4).
+        var last = ((3 * 3) + 2) * 4;
+        Assert.Equal(4, cropped.BgraPixels[last]);
+        Assert.Equal(4, cropped.BgraPixels[last + 1]);
+    }
+
+    [Fact]
+    public void Crop_ClampsRegionToFrameBounds()
+    {
+        var frame = MakeFrame(5, 5);
+
+        var cropped = frame.Crop(new PixelRect(3, 3, 10, 10));
+
+        Assert.Equal(2, cropped.Width);
+        Assert.Equal(2, cropped.Height);
+        Assert.Equal(3, cropped.BgraPixels[0]);
+        Assert.Equal(3, cropped.BgraPixels[1]);
+    }
+
+    [Fact]
+    public void Crop_FullFrameReturnsSameInstance()
+    {
+        var frame = MakeFrame(4, 3);
+
+        var cropped = frame.Crop(new PixelRect(0, 0, 4, 3));
+
+        Assert.Same(frame, cropped);
+    }
+}


### PR DESCRIPTION
## Summary

A Windows-only performance pass over the entire capture flow — hotkey/tray → picker → region overlay → countdown → recorder/screenshot → editor/trimmer. The goal is to remove every fixed `Task.Delay` and redundant piece of work between the user's intent and the capture actually happening, and to make the remaining latency measurable.

**27 files changed, +1223 / −307.** `windows/**` only; no mac changes.

## Analysis: where the time was going

Instrumenting the old flow with `CaptureFlowTrace` (added in this PR) showed the lag was not one big cost but a stack of small, serial ones:

| Stage | Before | Root cause |
|---|---|---|
| Hotkey → picker | ~150 ms fixed delay | Waiting for the tray menu to dismiss so it wouldn't be in the capture |
| Picker → region overlay visible | 250 ms + 50 ms fixed delays + backdrop capture | Overlay created *after* backdrop capture, then slept to "let it paint"; backdrop copied into a `WriteableBitmap` on the UI thread |
| Every capture | 3–4 × D3D11 device creation (tens of ms each) | Each monitor backdrop, the screenshot, and the recorder created their own device |
| Single-frame capture | 2 frames | Waited for a second frame to "settle" |
| Region screenshot | Second full WGC capture | Overlay already had a frozen frame of exactly this screen |
| Screenshot → editor | PNG encode + disk write + clipboard, serially, before editor opened | Editor was file-backed |
| Countdown → recording | 140 ms fade + 80 ms + full recorder setup (capture session, MF transcoder, webcam, audio) | Recorder setup began only at zero |
| Every picker open | Window + acrylic backdrop created/destroyed | Not pooled |
| GIF trimmer open | Decode *all* frames serially | Window unusable until done |
| Picker re-open after capture | 2 × 150 ms | Two stacked delays |
| First capture after launch | JIT for every overlay window type | No R2R |

## What changed

### Core (`TinyClips.Core`)
- **`CaptureFlowTrace`** (new) — `Begin`/`Mark` latency instrumentation. Always writes to `Debug`; also writes `%LOCALAPPDATA%\TinyClips\Temp\capture-flow-trace.log` in Debug builds or when `TINYCLIPS_CAPTURE_TRACE` is set, so packaged builds can be profiled.
- **`WgcInterop.GetSharedDevice()`** — one process-wide D3D11 + WinRT `IDirect3DDevice`, `ID3D11Multithread`-protected, transparently recreated on `DeviceRemovedReason` failure. `IScreenCaptureService.WarmUp()` creates it at app launch.
- **`ScreenCaptureService`** — single-frame captures settle after one frame; readback uses a single contiguous copy when pitch == width×4.
- **`CapturedFrame.Crop(PixelRect)`** — tightly-packed sub-rectangle copy with clamping; returns `this` for full-frame.
- **`IScreenshotService.SaveFrameAsync`** — encode/save an existing frame (branding, format, scale, quality) so region screenshots crop the overlay backdrop instead of re-capturing.
- **`IVideoRecordingService` / `IGifRecordingService`: `PrepareAsync` + `DiscardPreparedAsync`** — pre-warm capture session, H.264 transcoder, webcam, and audio during the countdown; `StartAsync` reuses the prepared pipeline when target/region match, otherwise tears it down and starts fresh.
- **`ICaptureSettings.ScreenshotUsesLiveCapture`** (default `false`) — opt-in to re-capture the live screen after the overlay closes (old behavior).

### App (`TinyClips.App`)
- **`App.xaml.cs`** — removed the 150 ms tray-dismiss delay; tray popup, picker, and overlay set `WDA_EXCLUDEFROMCAPTURE`; backdrop captured *while the picker is still showing* and handed to the overlay; screenshot editor opens from the in-memory frame while encode/write/clipboard run in the background (Save / Save a copy / Open folder await the pending write); recorders `PrepareAsync` during countdown; `DiscardPreparedAsync` on cancel.
- **`RegionSelectWindow` / `RegionSelectController`** — overlay created immediately, reveals on first-paint event instead of fixed delays; `SoftwareBitmapSource` off-thread instead of `WriteableBitmap`.
- **`CapturePickerWindow`** — single pooled instance hidden/shown between captures.
- **`CountdownWindow`** — signals completion at zero (card is already capture-excluded) rather than after fade.
- **`GifTrimmerWindow`** — shows first frame immediately, decodes rest in background.
- **`ScreenshotEditorWindow` / `EditorController`** — accepts an in-memory frame with a deferred file path. Stays file-backed when a downscale is configured so editor pixels match the saved file.
- **Settings UI** — Screenshot → *Re-capture screen after region selection* toggle (bound, accessible name set).
- **`TinyClips.App.csproj`** — `PublishReadyToRun=True` for Release `dotnet publish` (MSIX CI build path is unaffected).

## Behavior changes to be aware of
- **Region screenshots default to the frozen backdrop** (Snipping Tool behavior). Anything that changes on screen *during* selection won't appear unless the new setting is on or a countdown ran. This is intentional and documented in the changelog/settings.
- Countdown no longer fades out before recording starts — the card is excluded from capture so it can't leak into the first frame.
- Screenshot save is now asynchronous relative to the editor appearing. All file-consuming actions await the pending write; nothing reads the path before it exists.

## Risk areas / review focus
- **Shared D3D device lifetime** — `WgcInterop.GetSharedDevice` is never disposed by callers; device-removed recovery path is only exercised on GPU reset/driver update. Please eyeball the lock scope and the multithread-protect call.
- **Prepared-pipeline reuse** in `VideoRecordingService` / `GifRecordingService` — the target/region equality check decides reuse vs. teardown; mismatches fall back to the old cold-start path.
- **Pooled picker window** — verify it re-positions correctly across monitor/DPI changes between captures.
- **Editor deferred file** — Save-a-copy / Open-folder / Copy-to-clipboard while the background write is still in flight.

## Validation
- `dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64` — 0 warnings, 0 errors
- `dotnet test windows/tests/TinyClips.Core.Tests` — **97 passed** (3 new `CapturedFrameTests` for `Crop`: sub-rect packing, clamping, full-frame identity)
- Manual: hotkey → picker → region → screenshot editor; region/monitor video with countdown (cancel and complete); GIF with trimmer; OCR region; tray capture actions; Settings toggle round-trips.
- `windows/CHANGELOG.md` updated under Unreleased (Added + Changed).

## Not in scope
- mac app untouched.
- No change to the MSIX/CI build; R2R only affects `dotnet publish` Release.
