### PR TITLE
[Windows] Add soft-knee microphone limiter to prevent audio clipping

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,12 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Microphone soft-knee limiter** — Video recordings now run microphone audio through a
+  per-sample soft-knee limiter (knee at 0.98 FS, `atan` roll-off toward full scale) before mixing
+  so hot microphones round off instead of hard-clipping. On by default; toggle with Settings →
+  Video → Audio → Microphone → *Prevent microphone clipping (limiter)*. Matches the macOS 1.6.0
+  limiter curve, never alters sample count or timing (A/V sync unchanged), leaves system audio
+  untouched, and falls back to the unprocessed buffer if processing ever fails.
 - **Capture flow latency instrumentation** — `CaptureFlowTrace` records elapsed/delta timings at
   every transition of the capture flow (picker, region overlay, backdrop, countdown, recorder
   start/stop, editor/trimmer). Output goes to the debugger always, and to

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -9,9 +9,8 @@ own `CHANGELOG.md` at the repository root.
 - **Microphone soft-knee limiter** — Video recordings now run microphone audio through a
   per-sample soft-knee limiter (knee at 0.98 FS, `atan` roll-off toward full scale) before mixing
   so hot microphones round off instead of hard-clipping. On by default; toggle with Settings →
-  Video → Audio → Microphone → *Prevent microphone clipping (limiter)*. Matches the macOS 1.6.0
-  limiter curve, never alters sample count or timing (A/V sync unchanged), leaves system audio
-  untouched, and falls back to the unprocessed buffer if processing ever fails.
+  Video → Audio → Microphone → *Limit microphone peaks*. Matches the macOS 1.6.0 limiter curve,
+  never alters sample count or timing (A/V sync unchanged), and leaves system audio untouched.
 - **Capture flow latency instrumentation** — `CaptureFlowTrace` records elapsed/delta timings at
   every transition of the capture flow (picker, region overlay, backdrop, countdown, recorder
   start/stop, editor/trimmer). Output goes to the debugger always, and to

--- a/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
@@ -87,6 +87,15 @@
                                     Visibility="{x:Bind ViewModel.MicrophoneSelectorVisibility, Mode=OneWay}" />
                             </Grid>
                         </controls:SettingsCard>
+                        <controls:SettingsCard ContentAlignment="Left">
+                            <CheckBox
+                                AutomationProperties.AutomationId="MicrophoneLimiterToggle"
+                                AutomationProperties.Name="Prevent microphone clipping (limiter)"
+                                Content="Prevent microphone clipping (limiter)"
+                                IsChecked="{x:Bind ViewModel.MicrophoneLimiterEnabled, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.RecordMicrophone, Mode=OneWay}"
+                                ToolTipService.ToolTip="Softly rounds off loud microphone peaks so hot input doesn't distort. Does not affect timing or system audio." />
+                        </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
             </StackPanel>

--- a/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
@@ -90,8 +90,8 @@
                         <controls:SettingsCard ContentAlignment="Left">
                             <CheckBox
                                 AutomationProperties.AutomationId="MicrophoneLimiterToggle"
-                                AutomationProperties.Name="Prevent microphone clipping (limiter)"
-                                Content="Prevent microphone clipping (limiter)"
+                                AutomationProperties.Name="Limit microphone peaks"
+                                Content="Limit microphone peaks"
                                 IsChecked="{x:Bind ViewModel.MicrophoneLimiterEnabled, Mode=TwoWay}"
                                 IsEnabled="{x:Bind ViewModel.RecordMicrophone, Mode=OneWay}"
                                 ToolTipService.ToolTip="Softly rounds off loud microphone peaks so hot input doesn't distort. Does not affect timing or system audio." />

--- a/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
@@ -384,6 +384,10 @@ public sealed partial class SettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(MicrophoneSelectorEnabled))]
     private bool _recordMicrophone;
 
+    /// <summary>Soft-knee limiter on the microphone path so hot input rounds off instead of clipping.</summary>
+    [ObservableProperty]
+    private bool _microphoneLimiterEnabled = true;
+
     /// <summary>Microphone devices for the picker (first entry is the system default).</summary>
     public System.Collections.ObjectModel.ObservableCollection<AudioInputDevice> Microphones { get; } = new();
 
@@ -749,6 +753,7 @@ public sealed partial class SettingsViewModel : ObservableObject
             KeepDisplayAwakeWhileRecording = _settings.KeepDisplayAwakeWhileRecording;
             RecordAudio = _settings.RecordAudio;
             RecordMicrophone = _settings.RecordMicrophone;
+            MicrophoneLimiterEnabled = _settings.MicrophoneLimiterEnabled;
 
             _savedMicrophoneId = _settings.SelectedMicrophoneId ?? string.Empty;
             WebcamEnabled = _settings.WebcamEnabled;
@@ -1131,6 +1136,8 @@ public sealed partial class SettingsViewModel : ObservableObject
     partial void OnRecordAudioChanged(bool value) => Persist(() => _settings.RecordAudio = value);
 
     partial void OnRecordMicrophoneChanged(bool value) => Persist(() => _settings.RecordMicrophone = value);
+
+    partial void OnMicrophoneLimiterEnabledChanged(bool value) => Persist(() => _settings.MicrophoneLimiterEnabled = value);
 
     partial void OnSelectedMicrophoneChanged(AudioInputDevice? value) =>
         Persist(() => _settings.SelectedMicrophoneId = value?.Id ?? string.Empty);

--- a/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
@@ -20,6 +20,7 @@ public sealed class AudioCaptureService : IDisposable
     private readonly bool _captureSystem;
     private readonly bool _captureMic;
     private readonly string? _micDeviceId;
+    private readonly bool _limitMicrophone;
     private readonly object _gate = new();
     private readonly List<TimelineAlignedWaveProvider> _buffers = new();
 
@@ -32,11 +33,17 @@ public sealed class AudioCaptureService : IDisposable
     private int _systemMuted;
     private int _microphoneMuted;
 
-    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId)
+    /// <param name="limitMicrophone">
+    /// When true, a soft-knee limiter (<see cref="SoftKneeLimiterSampleProvider"/>) is applied to
+    /// the microphone source before mixing so hot input rounds off instead of hard-clipping.
+    /// System/loopback audio is never limited.
+    /// </param>
+    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId, bool limitMicrophone = true)
     {
         _captureSystem = captureSystem;
         _captureMic = captureMic;
         _micDeviceId = micDeviceId;
+        _limitMicrophone = limitMicrophone;
     }
 
     /// <summary>True once at least one requested source started successfully.</summary>
@@ -117,8 +124,14 @@ public sealed class AudioCaptureService : IDisposable
                 }
             };
 
+            ISampleProvider source = ToStereo48k(buffer.ToSampleProvider());
+            if (!isLoopback && _limitMicrophone)
+            {
+                source = new SoftKneeLimiterSampleProvider(source);
+            }
+
             var provider = new MuteableSampleProvider(
-                ToStereo48k(buffer.ToSampleProvider()),
+                source,
                 () => isLoopback
                     ? Volatile.Read(ref _systemMuted) != 0
                     : Volatile.Read(ref _microphoneMuted) != 0);
@@ -145,7 +158,7 @@ public sealed class AudioCaptureService : IDisposable
             }
 
             IsActive = true;
-            WebcamDiagnostics.Log($"Audio source '{sourceName}' started: {capture.WaveFormat.SampleRate}Hz {capture.WaveFormat.Channels}ch {capture.WaveFormat.BitsPerSample}bit {capture.WaveFormat.Encoding}.");
+            WebcamDiagnostics.Log($"Audio source '{sourceName}' started: {capture.WaveFormat.SampleRate}Hz {capture.WaveFormat.Channels}ch {capture.WaveFormat.BitsPerSample}bit {capture.WaveFormat.Encoding}{(!isLoopback ? $" limiter={(_limitMicrophone ? "on" : "off")}" : string.Empty)}.");
         }
         catch (Exception ex)
         {

--- a/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
@@ -38,7 +38,7 @@ public sealed class AudioCaptureService : IDisposable
     /// the microphone source before mixing so hot input rounds off instead of hard-clipping.
     /// System/loopback audio is never limited.
     /// </param>
-    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId, bool limitMicrophone = true)
+    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId, bool limitMicrophone)
     {
         _captureSystem = captureSystem;
         _captureMic = captureMic;

--- a/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using NAudio.Wave;
 
 namespace TinyClips.Core.Capture;
@@ -8,8 +7,7 @@ namespace TinyClips.Core.Capture;
 /// through untouched; anything hotter is compressed along an <c>atan</c> curve that approaches
 /// full scale asymptotically, so a hot microphone rounds off instead of hard-clipping. Mirrors
 /// the macOS <c>VideoRecorder.softKneeLimitedSample</c> curve. Sample count and timing are
-/// never altered, so A/V sync is unaffected. If processing ever throws, the untouched source
-/// samples are returned as-is rather than dropping audio.
+/// never altered, so A/V sync is unaffected.
 /// </summary>
 public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
 {
@@ -37,51 +35,30 @@ public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
             return read;
         }
 
-        // Transform into a pooled scratch buffer and copy back only on success so a failure
-        // forwards the untouched source samples rather than a partially-limited mix.
-        var scratch = ArrayPool<float>.Shared.Rent(read);
         try
         {
-            var source = buffer.AsSpan(offset, read);
-            var destination = scratch.AsSpan(0, read);
-            Limit(source, destination);
-            destination.CopyTo(source);
+            LimitInPlace(buffer.AsSpan(offset, read));
         }
         catch (Exception ex)
         {
-            // Never drop audio: the original samples are still in the buffer, so they flow
-            // through unlimited.
+            // Limit() is pure arithmetic and cannot fail mid-buffer, so any samples already in
+            // the buffer are either untouched or fully limited; never drop audio either way.
             if (!_loggedFailure)
             {
                 _loggedFailure = true;
                 WebcamDiagnostics.Log($"Microphone limiter failed; passing audio through unlimited: {ex.GetType().Name}: {ex.Message}");
             }
         }
-        finally
-        {
-            ArrayPool<float>.Shared.Return(scratch);
-        }
 
         return read;
     }
 
     /// <summary>Applies <see cref="Limit(float)"/> to every sample in <paramref name="samples"/>.</summary>
-    public static void LimitInPlace(Span<float> samples) => Limit(samples, samples);
-
-    /// <summary>
-    /// Writes the limited form of each sample in <paramref name="source"/> to the matching index
-    /// of <paramref name="destination"/>. The spans may alias.
-    /// </summary>
-    public static void Limit(ReadOnlySpan<float> source, Span<float> destination)
+    public static void LimitInPlace(Span<float> samples)
     {
-        if (destination.Length < source.Length)
+        for (var i = 0; i < samples.Length; i++)
         {
-            throw new ArgumentException("Destination is shorter than source.", nameof(destination));
-        }
-
-        for (var i = 0; i < source.Length; i++)
-        {
-            destination[i] = Limit(source[i]);
+            samples[i] = Limit(samples[i]);
         }
     }
 

--- a/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
@@ -1,0 +1,88 @@
+using NAudio.Wave;
+
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// Per-sample soft-knee limiter for float PCM. Samples at or below <see cref="Knee"/> pass
+/// through untouched; anything hotter is compressed along an <c>atan</c> curve that approaches
+/// full scale asymptotically, so a hot microphone rounds off instead of hard-clipping. Mirrors
+/// the macOS <c>VideoRecorder.softKneeLimitedSample</c> curve. Sample count and timing are
+/// never altered, so A/V sync is unaffected. If processing ever throws, the untouched source
+/// samples are returned as-is rather than dropping audio.
+/// </summary>
+public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
+{
+    public const float Knee = 0.98f;
+
+    private const float Headroom = 1f - Knee;
+    private const float TwoOverPi = 2f / MathF.PI;
+    private const float HalfPi = MathF.PI / 2f;
+
+    private readonly ISampleProvider _source;
+    private bool _loggedFailure;
+
+    public SoftKneeLimiterSampleProvider(ISampleProvider source)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public WaveFormat WaveFormat => _source.WaveFormat;
+
+    public int Read(float[] buffer, int offset, int count)
+    {
+        var read = _source.Read(buffer, offset, count);
+        if (read <= 0)
+        {
+            return read;
+        }
+
+        try
+        {
+            LimitInPlace(buffer.AsSpan(offset, read));
+        }
+        catch (Exception ex)
+        {
+            // Never drop audio: the source samples are already in the buffer, so just forward
+            // them unlimited. Partially-limited samples are still valid PCM.
+            if (!_loggedFailure)
+            {
+                _loggedFailure = true;
+                WebcamDiagnostics.Log($"Microphone limiter failed; passing audio through unlimited: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        return read;
+    }
+
+    /// <summary>Applies <see cref="Limit"/> to every sample in <paramref name="samples"/>.</summary>
+    public static void LimitInPlace(Span<float> samples)
+    {
+        for (var i = 0; i < samples.Length; i++)
+        {
+            samples[i] = Limit(samples[i]);
+        }
+    }
+
+    /// <summary>
+    /// Soft-knee transfer function. Below the knee the sample is unchanged; above it the overage
+    /// is mapped through <c>atan</c> so the magnitude approaches (but never reaches) 1.0.
+    /// Non-finite input is returned unchanged.
+    /// </summary>
+    public static float Limit(float sample)
+    {
+        if (!float.IsFinite(sample))
+        {
+            return sample;
+        }
+
+        var magnitude = MathF.Abs(sample);
+        if (magnitude <= Knee)
+        {
+            return sample;
+        }
+
+        var normalizedOverage = (magnitude - Knee) / Headroom;
+        var limited = Knee + Headroom * TwoOverPi * MathF.Atan(HalfPi * normalizedOverage);
+        return sample < 0f ? -limited : limited;
+    }
+}

--- a/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using NAudio.Wave;
 
 namespace TinyClips.Core.Capture;
@@ -36,30 +37,51 @@ public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
             return read;
         }
 
+        // Transform into a pooled scratch buffer and copy back only on success so a failure
+        // forwards the untouched source samples rather than a partially-limited mix.
+        var scratch = ArrayPool<float>.Shared.Rent(read);
         try
         {
-            LimitInPlace(buffer.AsSpan(offset, read));
+            var source = buffer.AsSpan(offset, read);
+            var destination = scratch.AsSpan(0, read);
+            Limit(source, destination);
+            destination.CopyTo(source);
         }
         catch (Exception ex)
         {
-            // Never drop audio: the source samples are already in the buffer, so just forward
-            // them unlimited. Partially-limited samples are still valid PCM.
+            // Never drop audio: the original samples are still in the buffer, so they flow
+            // through unlimited.
             if (!_loggedFailure)
             {
                 _loggedFailure = true;
                 WebcamDiagnostics.Log($"Microphone limiter failed; passing audio through unlimited: {ex.GetType().Name}: {ex.Message}");
             }
         }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(scratch);
+        }
 
         return read;
     }
 
-    /// <summary>Applies <see cref="Limit"/> to every sample in <paramref name="samples"/>.</summary>
-    public static void LimitInPlace(Span<float> samples)
+    /// <summary>Applies <see cref="Limit(float)"/> to every sample in <paramref name="samples"/>.</summary>
+    public static void LimitInPlace(Span<float> samples) => Limit(samples, samples);
+
+    /// <summary>
+    /// Writes the limited form of each sample in <paramref name="source"/> to the matching index
+    /// of <paramref name="destination"/>. The spans may alias.
+    /// </summary>
+    public static void Limit(ReadOnlySpan<float> source, Span<float> destination)
     {
-        for (var i = 0; i < samples.Length; i++)
+        if (destination.Length < source.Length)
         {
-            samples[i] = Limit(samples[i]);
+            throw new ArgumentException("Destination is shorter than source.", nameof(destination));
+        }
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            destination[i] = Limit(source[i]);
         }
     }
 

--- a/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
@@ -882,7 +882,8 @@ public sealed class VideoRecordingService : IVideoRecordingService
     {
         var wantSystem = _settings.RecordAudio;
         var wantMic = _settings.RecordMicrophone;
-        WebcamDiagnostics.Log($"StartAudioCapture: RecordAudio={wantSystem} RecordMicrophone={wantMic} micDeviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedMicrophoneId) ? "(default)" : _settings.SelectedMicrophoneId)}'");
+        var limitMic = _settings.MicrophoneLimiterEnabled;
+        WebcamDiagnostics.Log($"StartAudioCapture: RecordAudio={wantSystem} RecordMicrophone={wantMic} MicrophoneLimiter={limitMic} micDeviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedMicrophoneId) ? "(default)" : _settings.SelectedMicrophoneId)}'");
         if (!wantSystem && !wantMic)
         {
             WebcamDiagnostics.Log("StartAudioCapture: no audio sources requested; recording will have no audio track.");
@@ -891,7 +892,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
 
         try
         {
-            var audio = new AudioCaptureService(wantSystem, wantMic, _settings.SelectedMicrophoneId);
+            var audio = new AudioCaptureService(wantSystem, wantMic, _settings.SelectedMicrophoneId, limitMic);
             if (audio.TryStart())
             {
                 _audio = audio;

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -277,6 +277,12 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("selectedMicrophoneID", value);
     }
 
+    public bool MicrophoneLimiterEnabled
+    {
+        get => _settings.Get("microphoneLimiterEnabled", true);
+        set => _settings.Set("microphoneLimiterEnabled", value);
+    }
+
     public bool WebcamEnabled
     {
         get => _settings.Get("webcamEnabled", false);
@@ -717,6 +723,7 @@ public sealed class CaptureSettings : ICaptureSettings
         RecordAudio = false;
         RecordMicrophone = false;
         SelectedMicrophoneId = string.Empty;
+        MicrophoneLimiterEnabled = true;
         WebcamEnabled = false;
         SelectedWebcamId = string.Empty;
         WebcamShape = WebcamShape.Circle;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -39,6 +39,8 @@ public interface ICaptureSettings
     bool RecordAudio { get; set; }
     bool RecordMicrophone { get; set; }
     string SelectedMicrophoneId { get; set; }
+    /// <summary>Apply a soft-knee limiter to microphone audio so hot input rounds off instead of clipping. Default true.</summary>
+    bool MicrophoneLimiterEnabled { get; set; }
     bool WebcamEnabled { get; set; }
     string SelectedWebcamId { get; set; }
     WebcamShape WebcamShape { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -31,6 +31,7 @@ public sealed class CaptureSettingsTests
         Assert.Equal(100, settings.ScreenshotScale);
         Assert.Equal("TinyClips {date} at {time}", settings.FileNameTemplate);
         Assert.True(settings.ShowTrimmer);
+        Assert.True(settings.MicrophoneLimiterEnabled);
         Assert.False(settings.WebcamEnabled);
         Assert.Equal(string.Empty, settings.SelectedWebcamId);
         Assert.Equal(WebcamShape.Circle, settings.WebcamShape);
@@ -97,6 +98,22 @@ public sealed class CaptureSettingsTests
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Screenshot));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Video));
         Assert.False(settings.ShouldShowCapturePickerAfterCapture(CaptureType.Gif));
+    }
+
+    [Fact]
+    public void MicrophoneLimiterEnabled_RoundTripsAndResetsToTrue()
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        settings.MicrophoneLimiterEnabled = false;
+
+        Assert.False(settings.MicrophoneLimiterEnabled);
+        Assert.False(settingsService.Get("microphoneLimiterEnabled", true));
+
+        settings.ResetToDefaults();
+
+        Assert.True(settings.MicrophoneLimiterEnabled);
     }
 
     [Fact]

--- a/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
@@ -1,0 +1,127 @@
+using NAudio.Wave;
+using TinyClips.Core.Capture;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class SoftKneeLimiterSampleProviderTests
+{
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(0.5f)]
+    [InlineData(-0.5f)]
+    [InlineData(0.98f)]
+    [InlineData(-0.98f)]
+    public void Limit_AtOrBelowKnee_PassesThroughUnchanged(float sample)
+    {
+        Assert.Equal(sample, SoftKneeLimiterSampleProvider.Limit(sample));
+    }
+
+    [Theory]
+    [InlineData(0.99f)]
+    [InlineData(1.0f)]
+    [InlineData(1.5f)]
+    [InlineData(4.0f)]
+    [InlineData(100f)]
+    public void Limit_AboveKnee_StaysBetweenKneeAndFullScale(float sample)
+    {
+        var limited = SoftKneeLimiterSampleProvider.Limit(sample);
+
+        Assert.True(limited > SoftKneeLimiterSampleProvider.Knee, $"{sample} -> {limited}");
+        Assert.True(limited < 1f, $"{sample} -> {limited}");
+        Assert.True(limited < sample, $"{sample} -> {limited}");
+    }
+
+    [Fact]
+    public void Limit_PreservesSign()
+    {
+        var positive = SoftKneeLimiterSampleProvider.Limit(1.3f);
+        var negative = SoftKneeLimiterSampleProvider.Limit(-1.3f);
+
+        Assert.Equal(positive, -negative);
+        Assert.True(negative < 0f);
+    }
+
+    [Fact]
+    public void Limit_IsMonotonicAndApproachesFullScale()
+    {
+        var previous = SoftKneeLimiterSampleProvider.Limit(0.98f);
+        for (var input = 0.981f; input < 50f; input *= 1.1f)
+        {
+            var current = SoftKneeLimiterSampleProvider.Limit(input);
+            Assert.True(current >= previous, $"{input}: {current} < {previous}");
+            previous = current;
+        }
+
+        Assert.True(previous > 0.999f);
+        Assert.True(previous < 1f);
+    }
+
+    [Fact]
+    public void Limit_MatchesReferenceCurve()
+    {
+        // Reference: knee + (1 - knee) * (2/π) * atan(π/2 * overage), overage = (|x| - knee)/(1 - knee).
+        const float knee = 0.98f;
+        const float input = 1.0f;
+        var expected = knee + (1f - knee) * (2f / MathF.PI) * MathF.Atan(MathF.PI / 2f * ((input - knee) / (1f - knee)));
+
+        Assert.Equal(expected, SoftKneeLimiterSampleProvider.Limit(input), 6);
+    }
+
+    [Fact]
+    public void Limit_NonFiniteInput_PassesThrough()
+    {
+        Assert.True(float.IsNaN(SoftKneeLimiterSampleProvider.Limit(float.NaN)));
+        Assert.Equal(float.PositiveInfinity, SoftKneeLimiterSampleProvider.Limit(float.PositiveInfinity));
+        Assert.Equal(float.NegativeInfinity, SoftKneeLimiterSampleProvider.Limit(float.NegativeInfinity));
+    }
+
+    [Fact]
+    public void Read_ReturnsSameSampleCountAndLimitsOnlyHotSamples()
+    {
+        var source = new ArraySampleProvider(new[] { 0.25f, -0.5f, 1.5f, -2.0f, 0.98f, 0.0f });
+        var limiter = new SoftKneeLimiterSampleProvider(source);
+        var buffer = new float[8];
+
+        var read = limiter.Read(buffer, 1, 6);
+
+        Assert.Equal(6, read);
+        Assert.Equal(0f, buffer[0]);
+        Assert.Equal(0.25f, buffer[1]);
+        Assert.Equal(-0.5f, buffer[2]);
+        Assert.InRange(buffer[3], 0.98f, 1f);
+        Assert.InRange(buffer[4], -1f, -0.98f);
+        Assert.Equal(0.98f, buffer[5]);
+        Assert.Equal(0f, buffer[6]);
+        Assert.Equal(0f, buffer[7]);
+        Assert.Same(source.WaveFormat, limiter.WaveFormat);
+    }
+
+    [Fact]
+    public void Read_EmptySource_ReturnsZero()
+    {
+        var limiter = new SoftKneeLimiterSampleProvider(new ArraySampleProvider(Array.Empty<float>()));
+
+        Assert.Equal(0, limiter.Read(new float[4], 0, 4));
+    }
+
+    private sealed class ArraySampleProvider : ISampleProvider
+    {
+        private readonly float[] _samples;
+        private int _position;
+
+        public ArraySampleProvider(float[] samples)
+        {
+            _samples = samples;
+        }
+
+        public WaveFormat WaveFormat { get; } = WaveFormat.CreateIeeeFloatWaveFormat(48000, 2);
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var available = Math.Min(count, _samples.Length - _position);
+            Array.Copy(_samples, _position, buffer, offset, available);
+            _position += available;
+            return available;
+        }
+    }
+}

--- a/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
@@ -105,24 +105,15 @@ public sealed class SoftKneeLimiterSampleProviderTests
     }
 
     [Fact]
-    public void Limit_SpanOverload_WritesToDestinationAndLeavesSourceUntouched()
+    public void LimitInPlace_LimitsOnlyHotSamples()
     {
-        var source = new[] { 0.5f, 1.5f, -1.5f };
-        var destination = new float[3];
+        var samples = new[] { 0.5f, 1.5f, -1.5f };
 
-        SoftKneeLimiterSampleProvider.Limit(source, destination);
+        SoftKneeLimiterSampleProvider.LimitInPlace(samples);
 
-        Assert.Equal(new[] { 0.5f, 1.5f, -1.5f }, source);
-        Assert.Equal(0.5f, destination[0]);
-        Assert.InRange(destination[1], 0.98f, 1f);
-        Assert.InRange(destination[2], -1f, -0.98f);
-    }
-
-    [Fact]
-    public void Limit_SpanOverload_ShortDestination_Throws()
-    {
-        Assert.Throws<ArgumentException>(() =>
-            SoftKneeLimiterSampleProvider.Limit(new float[4], new float[2]));
+        Assert.Equal(0.5f, samples[0]);
+        Assert.InRange(samples[1], 0.98f, 1f);
+        Assert.InRange(samples[2], -1f, -0.98f);
     }
 
     private sealed class ArraySampleProvider : ISampleProvider

--- a/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
@@ -104,6 +104,27 @@ public sealed class SoftKneeLimiterSampleProviderTests
         Assert.Equal(0, limiter.Read(new float[4], 0, 4));
     }
 
+    [Fact]
+    public void Limit_SpanOverload_WritesToDestinationAndLeavesSourceUntouched()
+    {
+        var source = new[] { 0.5f, 1.5f, -1.5f };
+        var destination = new float[3];
+
+        SoftKneeLimiterSampleProvider.Limit(source, destination);
+
+        Assert.Equal(new[] { 0.5f, 1.5f, -1.5f }, source);
+        Assert.Equal(0.5f, destination[0]);
+        Assert.InRange(destination[1], 0.98f, 1f);
+        Assert.InRange(destination[2], -1f, -0.98f);
+    }
+
+    [Fact]
+    public void Limit_SpanOverload_ShortDestination_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SoftKneeLimiterSampleProvider.Limit(new float[4], new float[2]));
+    }
+
     private sealed class ArraySampleProvider : ISampleProvider
     {
         private readonly float[] _samples;


### PR DESCRIPTION
Closes #271

## Summary
Adds a default-on soft-knee limiter to the Windows microphone audio path, matching the macOS 1.6.0 `VideoRecorder.softKneeLimitedSample` curve (knee 0.98 FS, `atan` roll-off toward full scale). Hot microphones now round off instead of hard-clipping.

## Changes
- **`Core/Capture/SoftKneeLimiterSampleProvider.cs`** (new) — NAudio `ISampleProvider` wrapper with pure static `Limit()`; `Read` applies the curve in place inside `try/catch` and forwards the untouched buffer on any failure (never drops audio). Sample count and timing are never altered, so A/V sync is unchanged.
- **`AudioCaptureService`** — new `limitMicrophone` ctor arg; wraps only the microphone source before mixing. System/loopback audio is untouched. Logs limiter state at start.
- **`VideoRecordingService.StartAudioCapture`** — passes `MicrophoneLimiterEnabled` through.
- **`ICaptureSettings` / `CaptureSettings`** — `MicrophoneLimiterEnabled` (key `microphoneLimiterEnabled`, default `true`; `ResetToDefaults` restores `true`).
- **`SettingsViewModel` + `VideoSettingsSection.xaml`** — "Prevent microphone clipping (limiter)" checkbox under Settings → Video → Audio → Microphone, with AutomationId/Name and tooltip; enabled only when mic recording is on.
- **Tests** — `SoftKneeLimiterSampleProviderTests` (pass-through below knee, bounds above knee, sign, monotonic/asymptote, reference-curve equality, non-finite pass-through, `Read` offset/count semantics) plus `CaptureSettings` default/round-trip/reset coverage.
- **`windows/CHANGELOG.md`** — Unreleased entry.

## Validation
- `dotnet test windows/tests/TinyClips.Core.Tests` → 115/115 passed
- `dotnet build windows/src/TinyClips.App -c Debug -p:Platform=x64` → 0 warnings / 0 errors

## Manual checks still recommended
- Record with a deliberately hot mic level and confirm no flat-top clipping in the waveform.
- Hand-clap A/V sync test (should be identical to before).
- Toggle the setting off and confirm the raw path is restored.