### PR TITLE
Fix white hairlines in padded JPEG exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Fixed macOS screenshot editor exports showing white hairline borders around padded screenshots in JPEG format. Fractional export frame sizes and image origins left sub-pixel slivers at the canvas edges, which flattened to white when JPEG encoding discarded transparency. Export layouts are now snapped to whole pixels.
+
 ## v1.6.1-mac - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Fixed
-- Fixed macOS screenshot editor exports showing white hairline borders around padded screenshots in JPEG format. Fractional export frame sizes and image origins left sub-pixel slivers at the canvas edges, which flattened to white when JPEG encoding discarded transparency. Export layouts are now snapped to whole pixels.
+- Fixed macOS screenshot editor exports showing a light hairline around the screenshot card when centered in a preset frame (for example 16:9 or 9:16) with an odd amount of leftover space. The card origin could land on a half pixel, anti-aliasing its edge; on a transparent background exported as JPEG that edge flattened to a visible line. Export layouts are now snapped to whole pixels while the live preview keeps fractional geometry.
 
 ## v1.6.1-mac - 2026-08-18
 

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -247,13 +247,10 @@ struct ExportFrameLayout {
         padding: CGFloat,
         preset: ExportFramePreset,
         horizontalAlignment: ExportHorizontalAlignment,
-        verticalAlignment: ExportVerticalAlignment
+        verticalAlignment: ExportVerticalAlignment,
+        snapsToPixels: Bool = false
     ) -> Self {
-        // Snap the layout to whole pixels: fractional frame sizes or image origins
-        // leave sub-pixel slivers at the canvas edges. Those slivers are invisible
-        // in alpha formats but render as white hairlines when exported to JPEG
-        // (which flattens transparency onto white).
-        let safePadding = max(0, padding).rounded(.up)
+        let safePadding = max(0, padding)
         let baseSize = CGSize(
             width: imageSize.width + (safePadding * 2),
             height: imageSize.height + (safePadding * 2)
@@ -267,17 +264,24 @@ struct ExportFrameLayout {
                 frameSize.height = ceil(baseSize.width / targetRatio)
             }
         }
-        frameSize.width = frameSize.width.rounded(.up)
-        frameSize.height = frameSize.height.rounded(.up)
 
-        let extraHorizontalSpace = max(0, frameSize.width - baseSize.width)
-        let extraVerticalSpace = max(0, frameSize.height - baseSize.height)
-        let originX = (safePadding + (extraHorizontalSpace * horizontalAlignment.placementFactor))
-            .rounded()
-            .clamped(to: 0...max(0, frameSize.width - imageSize.width))
-        let originY = (safePadding + (extraVerticalSpace * verticalAlignment.placementFactor))
-            .rounded()
-            .clamped(to: 0...max(0, frameSize.height - imageSize.height))
+        var originX = safePadding + (max(0, frameSize.width - baseSize.width) * horizontalAlignment.placementFactor)
+        var originY = safePadding + (max(0, frameSize.height - baseSize.height) * verticalAlignment.placementFactor)
+
+        if snapsToPixels {
+            // Snap to whole pixels so bitmap exports never contain sub-pixel
+            // slivers at the canvas edges. Those slivers are invisible in alpha
+            // formats but render as white hairlines when exported to JPEG
+            // (which flattens transparency onto white). The display-space
+            // preview path keeps fractional geometry so it scales proportionally.
+            frameSize.width = frameSize.width.rounded(.up)
+            frameSize.height = frameSize.height.rounded(.up)
+            originX = originX.rounded()
+                .clamped(to: 0...Swift.max(0, frameSize.width - imageSize.width))
+            originY = originY.rounded()
+                .clamped(to: 0...Swift.max(0, frameSize.height - imageSize.height))
+        }
+
         return Self(
             frameSize: frameSize,
             imageRect: CGRect(

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -269,10 +269,11 @@ struct ExportFrameLayout {
         var originY = safePadding + (max(0, frameSize.height - baseSize.height) * verticalAlignment.placementFactor)
 
         if snapsToPixels {
-            // Snap to whole pixels so bitmap exports never contain sub-pixel
-            // slivers at the canvas edges. Those slivers are invisible in alpha
-            // formats but render as white hairlines when exported to JPEG
-            // (which flattens transparency onto white). The display-space
+            // Snap to whole pixels for bitmap export. Centering the card inside an odd
+            // amount of leftover preset space lands its origin on a half pixel, and
+            // Core Graphics then anti-aliases the card edge across two columns/rows
+            // at 50% alpha. On a transparent background exported as JPEG that edge
+            // flattens to a light hairline around the screenshot. The display-space
             // preview path keeps fractional geometry so it scales proportionally.
             frameSize.width = frameSize.width.rounded(.up)
             frameSize.height = frameSize.height.rounded(.up)

--- a/mac/TinyClips/Views/ScreenshotEditorModels.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorModels.swift
@@ -249,7 +249,11 @@ struct ExportFrameLayout {
         horizontalAlignment: ExportHorizontalAlignment,
         verticalAlignment: ExportVerticalAlignment
     ) -> Self {
-        let safePadding = max(0, padding)
+        // Snap the layout to whole pixels: fractional frame sizes or image origins
+        // leave sub-pixel slivers at the canvas edges. Those slivers are invisible
+        // in alpha formats but render as white hairlines when exported to JPEG
+        // (which flattens transparency onto white).
+        let safePadding = max(0, padding).rounded(.up)
         let baseSize = CGSize(
             width: imageSize.width + (safePadding * 2),
             height: imageSize.height + (safePadding * 2)
@@ -263,18 +267,32 @@ struct ExportFrameLayout {
                 frameSize.height = ceil(baseSize.width / targetRatio)
             }
         }
+        frameSize.width = frameSize.width.rounded(.up)
+        frameSize.height = frameSize.height.rounded(.up)
 
         let extraHorizontalSpace = max(0, frameSize.width - baseSize.width)
         let extraVerticalSpace = max(0, frameSize.height - baseSize.height)
+        let originX = (safePadding + (extraHorizontalSpace * horizontalAlignment.placementFactor))
+            .rounded()
+            .clamped(to: 0...max(0, frameSize.width - imageSize.width))
+        let originY = (safePadding + (extraVerticalSpace * verticalAlignment.placementFactor))
+            .rounded()
+            .clamped(to: 0...max(0, frameSize.height - imageSize.height))
         return Self(
             frameSize: frameSize,
             imageRect: CGRect(
-                x: safePadding + (extraHorizontalSpace * horizontalAlignment.placementFactor),
-                y: safePadding + (extraVerticalSpace * verticalAlignment.placementFactor),
+                x: originX,
+                y: originY,
                 width: imageSize.width,
                 height: imageSize.height
             )
         )
+    }
+}
+
+private extension CGFloat {
+    func clamped(to range: ClosedRange<CGFloat>) -> CGFloat {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
     }
 }
 

--- a/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorViewModel.swift
@@ -1530,7 +1530,8 @@ class ScreenshotEditorViewModel: ObservableObject {
             padding: canvasPadding,
             preset: exportFramePreset,
             horizontalAlignment: horizontalExportAlignment,
-            verticalAlignment: verticalExportAlignment
+            verticalAlignment: verticalExportAlignment,
+            snapsToPixels: true
         )
     }
 

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -293,6 +293,49 @@ final class CaptureMathTests: XCTestCase {
         )
     }
 
+    func testExportFrameLayoutSnapsToWholePixels() {
+        // Fractional padding and preset ratios must not produce fractional frame
+        // sizes or image origins: sub-pixel slivers at the canvas edge render as
+        // white hairlines in formats without alpha (e.g. JPEG).
+        let cases: [(padding: CGFloat, preset: ExportFramePreset, h: ExportHorizontalAlignment, v: ExportVerticalAlignment)] = [
+            (10.4, .square, .center, .center),
+            (12.75, .landscapeSixteenByNine, .trailing, .bottom),
+            (7.2, .portraitNineBySixteen, .leading, .top),
+            (0.5, .original, .center, .center),
+        ]
+
+        for testCase in cases {
+            let imageSize = CGSize(width: 503, height: 331)
+            let layout = ExportFrameLayout.make(
+                imageSize: imageSize,
+                padding: testCase.padding,
+                preset: testCase.preset,
+                horizontalAlignment: testCase.h,
+                verticalAlignment: testCase.v
+            )
+
+            XCTAssertEqual(
+                layout.frameSize.width.rounded(), layout.frameSize.width,
+                "frame width must be integral for padding \(testCase.padding)"
+            )
+            XCTAssertEqual(
+                layout.frameSize.height.rounded(), layout.frameSize.height,
+                "frame height must be integral for padding \(testCase.padding)"
+            )
+            XCTAssertEqual(
+                layout.imageRect.minX.rounded(), layout.imageRect.minX,
+                "image origin x must be integral"
+            )
+            XCTAssertEqual(
+                layout.imageRect.minY.rounded(), layout.imageRect.minY,
+                "image origin y must be integral"
+            )
+            // The image must sit fully inside the frame.
+            XCTAssertTrue(layout.frameSize.width >= layout.imageRect.maxX)
+            XCTAssertTrue(layout.frameSize.height >= layout.imageRect.maxY)
+        }
+    }
+
     func testExportFrameLayoutPlacesImageAlongAvailableAxis() {
         let horizontalOrigins: [ExportHorizontalAlignment: CGPoint] = [
             .leading: CGPoint(x: 10, y: 10),

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -337,6 +337,55 @@ final class CaptureMathTests: XCTestCase {
         }
     }
 
+    func testExportFrameLayoutSnapsCenteredImageOriginToWholePixels() {
+        // Padding comes from a `step: 2` slider and the crop rect is `.integral`, so
+        // the only fractional value the export path can produce is a centered origin
+        // when the preset leaves an odd amount of extra space (e.g. 101 / 2 = 50.5).
+        let imageSize = CGSize(width: 503, height: 331)
+
+        // Extra horizontal space is 624 - 523 = 101 (odd).
+        let landscape = ExportFrameLayout.make(
+            imageSize: imageSize,
+            padding: 10,
+            preset: .landscapeSixteenByNine,
+            horizontalAlignment: .center,
+            verticalAlignment: .center,
+            snapsToPixels: true
+        )
+        XCTAssertEqual(landscape.frameSize, CGSize(width: 624, height: 351))
+        XCTAssertEqual(landscape.imageRect.origin, CGPoint(x: 61, y: 10))
+
+        // Extra vertical space is 930 - 351 = 579 (odd).
+        let portrait = ExportFrameLayout.make(
+            imageSize: imageSize,
+            padding: 10,
+            preset: .portraitNineBySixteen,
+            horizontalAlignment: .center,
+            verticalAlignment: .center,
+            snapsToPixels: true
+        )
+        XCTAssertEqual(portrait.frameSize, CGSize(width: 523, height: 930))
+        XCTAssertEqual(portrait.imageRect.origin, CGPoint(x: 10, y: 300))
+
+        // Even leftover space (523 - 351 = 172) is unchanged by the snap.
+        let square = ExportFrameLayout.make(
+            imageSize: imageSize,
+            padding: 10,
+            preset: .square,
+            horizontalAlignment: .center,
+            verticalAlignment: .center,
+            snapsToPixels: true
+        )
+        XCTAssertEqual(square.frameSize, CGSize(width: 523, height: 523))
+        XCTAssertEqual(square.imageRect.origin, CGPoint(x: 10, y: 96))
+
+        for layout in [landscape, portrait, square] {
+            XCTAssertEqual(layout.imageRect.size, imageSize)
+            XCTAssertLessThanOrEqual(layout.imageRect.maxX, layout.frameSize.width)
+            XCTAssertLessThanOrEqual(layout.imageRect.maxY, layout.frameSize.height)
+        }
+    }
+
     func testExportFrameLayoutKeepsFractionalGeometryForDisplay() {
         // The display-space preview path keeps fractional geometry so preview
         // padding and scaling stay proportional to point-scaled sizes.

--- a/mac/TinyClipsTests/CaptureMathTests.swift
+++ b/mac/TinyClipsTests/CaptureMathTests.swift
@@ -295,8 +295,8 @@ final class CaptureMathTests: XCTestCase {
 
     func testExportFrameLayoutSnapsToWholePixels() {
         // Fractional padding and preset ratios must not produce fractional frame
-        // sizes or image origins: sub-pixel slivers at the canvas edge render as
-        // white hairlines in formats without alpha (e.g. JPEG).
+        // sizes or image origins when snapping to pixels: sub-pixel slivers at the
+        // canvas edge render as white hairlines in formats without alpha (e.g. JPEG).
         let cases: [(padding: CGFloat, preset: ExportFramePreset, h: ExportHorizontalAlignment, v: ExportVerticalAlignment)] = [
             (10.4, .square, .center, .center),
             (12.75, .landscapeSixteenByNine, .trailing, .bottom),
@@ -311,7 +311,8 @@ final class CaptureMathTests: XCTestCase {
                 padding: testCase.padding,
                 preset: testCase.preset,
                 horizontalAlignment: testCase.h,
-                verticalAlignment: testCase.v
+                verticalAlignment: testCase.v,
+                snapsToPixels: true
             )
 
             XCTAssertEqual(
@@ -334,6 +335,23 @@ final class CaptureMathTests: XCTestCase {
             XCTAssertTrue(layout.frameSize.width >= layout.imageRect.maxX)
             XCTAssertTrue(layout.frameSize.height >= layout.imageRect.maxY)
         }
+    }
+
+    func testExportFrameLayoutKeepsFractionalGeometryForDisplay() {
+        // The display-space preview path keeps fractional geometry so preview
+        // padding and scaling stay proportional to point-scaled sizes.
+        let layout = ExportFrameLayout.make(
+            imageSize: CGSize(width: 503.5, height: 331.25),
+            padding: 10.4,
+            preset: .original,
+            horizontalAlignment: .center,
+            verticalAlignment: .center
+        )
+
+        XCTAssertEqual(layout.frameSize.width, 524.3, accuracy: 0.001)
+        XCTAssertEqual(layout.frameSize.height, 352.05, accuracy: 0.001)
+        XCTAssertEqual(layout.imageRect.minX, 10.4, accuracy: 0.001)
+        XCTAssertEqual(layout.imageRect.minY, 10.4, accuracy: 0.001)
     }
 
     func testExportFrameLayoutPlacesImageAlongAvailableAxis() {


### PR DESCRIPTION
## Summary

`ExportFrameLayout.make` could produce fractional frame sizes and image origins (fractional padding values, `ceil()`-adjusted preset ratios, alignment extra-space factors). The sub-pixel slivers this leaves at the canvas edges are invisible in alpha formats like PNG — but when exporting to **JPEG**, which has no alpha channel, those partially-covered edge rows/columns flatten to white hairlines around the padded screenshot.

This PR snaps the export layout to whole pixels:

- Round padding up to an integral value
- Round frame size up after preset ratio adjustment
- Round the image origin and clamp it so the card always sits fully inside the integral frame

No visible layout change at normal sizes; edges are now always exactly on pixel boundaries.

## Testing

- Added regression test `testExportFrameLayoutSnapsToWholePixels` covering fractional paddings × presets × alignments
- All 47 unit tests pass
- Both `TinyClips` and `TinyClipsMAS` schemes build

## Before / After

Edge strips at 4× zoom from real exports (JPEG):
<img width="1720" height="744" alt="image" src="https://github.com/user-attachments/assets/17d5e30c-110e-4081-9cf5-c13f25dbdc14" />
