### PR TITLE
Harden Windows tray-first startup against crash exit codes

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -92,6 +92,16 @@ own `CHANGELOG.md` at the repository root.
   and region-indicator windows, removing duplicated P/Invoke declarations and structs. The
   `TrayPopupWindow` now unsubscribes its `Activated` handler on closure.
 
+### Fixed
+- **Hardened tray-first startup** — Launch no longer eagerly creates the off-screen UI Automation
+  announcement window; it is created lazily on the first Narrator announcement and degrades to a
+  log line if window creation fails. Hotkey registration, onboarding, and file activation are
+  each guarded so a failure in one step cannot abort launch, and the app now installs
+  `Application.UnhandledException`, `TaskScheduler.UnobservedTaskException`, and AppDomain
+  handlers so a non-fatal UI exception is logged instead of terminating the process with a
+  stowed-exception crash (`0xC000027B`) — the failure mode reported by winget's
+  `Validation-Executable-Error` check.
+
 ## [v1.7.0-windows] - 2026-08-13
 
 ### Internal

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -96,11 +96,16 @@ own `CHANGELOG.md` at the repository root.
 - **Hardened tray-first startup** — Launch no longer eagerly creates the off-screen UI Automation
   announcement window; it is created lazily on the first Narrator announcement and degrades to a
   log line if window creation fails. Hotkey registration, onboarding, and file activation are
-  each guarded so a failure in one step cannot abort launch, and the app now installs
-  `Application.UnhandledException`, `TaskScheduler.UnobservedTaskException`, and AppDomain
-  handlers so a non-fatal UI exception is logged instead of terminating the process with a
-  stowed-exception crash (`0xC000027B`) — the failure mode reported by winget's
-  `Validation-Executable-Error` check.
+  each guarded so a failure in one step cannot abort launch. A framework (XAML-thread) exception
+  raised *during launch* — until the work launch queued on the UI thread has drained — is now
+  logged and marked handled instead of terminating the process with a stowed-exception crash
+  (`0xC000027B`), the failure mode reported by winget's `Validation-Executable-Error` check.
+  Exceptions after launch are still fatal so mid-operation failures cannot leave the app running
+  in a partially mutated state.
+- **Persistent crash diagnostics** — Unhandled XAML, AppDomain, and unobserved task exceptions
+  (plus guarded startup-step failures) are appended to `%LOCALAPPDATA%\TinyClips\Logs\crash.log`
+  (capped at 512 KB, rolled to `crash.previous.log`) so packaged-app failures can be diagnosed
+  without a debugger. The Logs folder is separate from the Temp folder purged by Settings.
 
 ## [v1.7.0-windows] - 2026-08-13
 

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -76,6 +76,7 @@ public partial class App : Application
     private GlobalHotKeyManager? _hotKeyManager;
     private DispatcherQueue? _dispatcher;
     private bool _isExiting;
+    private bool _isInStartupPhase = true;
     private static bool _notificationsRegistered;
 
     public static IServiceProvider Services { get; private set; } = null!;
@@ -108,6 +109,7 @@ public partial class App : Application
 #if !TINYCLIPS_STORE_BUILD
         _ = RunStartupUpdateCheckAsync();
 #endif
+        EndStartupPhaseAfterFirstDispatcherPass();
     }
 
     private static void RunStartupStep(string name, Action step)
@@ -119,28 +121,54 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Startup step '{name}' failed: {ex}");
+            CrashDiagnostics.Log($"Startup step '{name}'", ex, handled: true);
+        }
+    }
+
+    /// <summary>
+    /// Keeps <see cref="_isInStartupPhase"/> set until the queued work that launch scheduled on the
+    /// UI thread (window activation, tray icon creation callbacks, first layout) has drained, so
+    /// startup-time framework exceptions are treated as recoverable while later ones are not.
+    /// </summary>
+    private void EndStartupPhaseAfterFirstDispatcherPass()
+    {
+        var dispatcher = _dispatcher;
+        if (dispatcher is null ||
+            !dispatcher.TryEnqueue(DispatcherQueuePriority.Low, () => _isInStartupPhase = false))
+        {
+            _isInStartupPhase = false;
         }
     }
 
     private void RegisterGlobalExceptionHandlers()
     {
         // A XAML-thread exception that reaches the framework terminates the process with a stowed
-        // exception (0xC000027B). Log and swallow so a non-fatal UI hiccup never produces a crash
-        // exit code for a tray app that has no main window to tear down.
+        // exception (0xC000027B). During launch we log and swallow so a non-fatal startup hiccup
+        // cannot produce a crash exit code for a tray app that has no main window to tear down.
+        // After launch the handler only records diagnostics: continuing past an arbitrary
+        // mid-operation failure could leave app state partially mutated, so we let it terminate.
         UnhandledException += (_, e) =>
         {
-            Debug.WriteLine($"Unhandled XAML exception: {e.Exception}");
-            e.Handled = true;
+            var handled = _isInStartupPhase && !_isExiting;
+            Debug.WriteLine($"Unhandled XAML exception (startup={_isInStartupPhase}): {e.Exception}");
+            CrashDiagnostics.Log("Application.UnhandledException", e.Exception, handled);
+            e.Handled = handled;
         };
 
+        // Unobserved task faults are raised from the finalizer thread and would otherwise be
+        // silently dropped (or, with ThrowUnobservedTaskExceptions, crash the process); record them.
         TaskScheduler.UnobservedTaskException += (_, e) =>
         {
             Debug.WriteLine($"Unobserved task exception: {e.Exception}");
+            CrashDiagnostics.Log("TaskScheduler.UnobservedTaskException", e.Exception, handled: true);
             e.SetObserved();
         };
 
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+        {
             Debug.WriteLine($"Unhandled AppDomain exception (terminating={e.IsTerminating}): {e.ExceptionObject}");
+            CrashDiagnostics.Log("AppDomain.UnhandledException", e.ExceptionObject, handled: false);
+        };
     }
 
     /// <summary>
@@ -234,6 +262,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             Debug.WriteLine($"Failed to create automation announcer: {ex}");
+            CrashDiagnostics.Log("AutomationNotificationAnnouncer", ex, handled: true);
         }
 
         return _automationNotificationAnnouncer;

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -83,6 +83,7 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+        RegisterGlobalExceptionHandlers();
         Services = new ServiceCollection()
             .AddTinyClipsCore()
             .AddSingleton<IUploadcareCredentialStore, WindowsCredentialStore>()
@@ -97,15 +98,49 @@ public partial class App : Application
     {
         _dispatcher = DispatcherQueue.GetForCurrentThread();
 
+        // The tray icon and hotkeys are the app; everything else is best-effort so that an
+        // optional startup step failing (e.g. on a locked-down validation VM) cannot crash launch.
         WireRecordingEvents();
         CreateTrayIcon();
-        CreateAutomationNotificationAnnouncer();
-        RegisterGlobalHotKeys();
-        ShowOnboardingIfNeeded();
-        HandleFileActivation();
+        RunStartupStep(nameof(RegisterGlobalHotKeys), () => RegisterGlobalHotKeys());
+        RunStartupStep(nameof(ShowOnboardingIfNeeded), ShowOnboardingIfNeeded);
+        RunStartupStep(nameof(HandleFileActivation), HandleFileActivation);
 #if !TINYCLIPS_STORE_BUILD
         _ = RunStartupUpdateCheckAsync();
 #endif
+    }
+
+    private static void RunStartupStep(string name, Action step)
+    {
+        try
+        {
+            step();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Startup step '{name}' failed: {ex}");
+        }
+    }
+
+    private void RegisterGlobalExceptionHandlers()
+    {
+        // A XAML-thread exception that reaches the framework terminates the process with a stowed
+        // exception (0xC000027B). Log and swallow so a non-fatal UI hiccup never produces a crash
+        // exit code for a tray app that has no main window to tear down.
+        UnhandledException += (_, e) =>
+        {
+            Debug.WriteLine($"Unhandled XAML exception: {e.Exception}");
+            e.Handled = true;
+        };
+
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            Debug.WriteLine($"Unobserved task exception: {e.Exception}");
+            e.SetObserved();
+        };
+
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            Debug.WriteLine($"Unhandled AppDomain exception (terminating={e.IsTerminating}): {e.ExceptionObject}");
     }
 
     /// <summary>
@@ -181,9 +216,27 @@ public partial class App : Application
         UpdateRecordingState();
     }
 
-    private void CreateAutomationNotificationAnnouncer()
+    /// <summary>
+    /// Lazily creates the off-screen UI Automation anchor window. Creation is deferred to the first
+    /// announcement so tray-first launch creates no XAML window, and failures degrade to a log line.
+    /// </summary>
+    private AutomationNotificationAnnouncer? GetOrCreateAutomationNotificationAnnouncer()
     {
-        _automationNotificationAnnouncer ??= new AutomationNotificationAnnouncer();
+        if (_automationNotificationAnnouncer is not null || _isExiting)
+        {
+            return _automationNotificationAnnouncer;
+        }
+
+        try
+        {
+            _automationNotificationAnnouncer = new AutomationNotificationAnnouncer();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to create automation announcer: {ex}");
+        }
+
+        return _automationNotificationAnnouncer;
     }
 
     private void ShowTrayPopup()
@@ -2057,12 +2110,6 @@ public partial class App : Application
         string message,
         string activityId)
     {
-        if (_automationNotificationAnnouncer is null)
-        {
-            Debug.WriteLine($"Automation announcement unavailable: {message}");
-            return;
-        }
-
         var dispatcher = _dispatcher;
         if (dispatcher is null)
         {
@@ -2072,14 +2119,36 @@ public partial class App : Application
 
         if (dispatcher.HasThreadAccess)
         {
-            _automationNotificationAnnouncer.Announce(kind, processing, message, activityId);
+            AnnounceOnUiThread(kind, processing, message, activityId);
             return;
         }
 
-        if (!dispatcher.TryEnqueue(() =>
-                _automationNotificationAnnouncer?.Announce(kind, processing, message, activityId)))
+        if (!dispatcher.TryEnqueue(() => AnnounceOnUiThread(kind, processing, message, activityId)))
         {
             Debug.WriteLine($"Automation announcement dispatch failed: {message}");
+        }
+    }
+
+    private void AnnounceOnUiThread(
+        AutomationNotificationKind kind,
+        AutomationNotificationProcessing processing,
+        string message,
+        string activityId)
+    {
+        var announcer = GetOrCreateAutomationNotificationAnnouncer();
+        if (announcer is null)
+        {
+            Debug.WriteLine($"Automation announcement unavailable: {message}");
+            return;
+        }
+
+        try
+        {
+            announcer.Announce(kind, processing, message, activityId);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Automation announcement failed: {ex}");
         }
     }
 

--- a/windows/src/TinyClips.Core/Services/CrashDiagnostics.cs
+++ b/windows/src/TinyClips.Core/Services/CrashDiagnostics.cs
@@ -1,0 +1,79 @@
+namespace TinyClips.Core.Services;
+
+/// <summary>
+/// Best-effort persistent logger for unhandled exceptions in the packaged app, where
+/// <c>Debug.WriteLine</c> is invisible. Writes to <c>%LOCALAPPDATA%\TinyClips\Logs\crash.log</c>,
+/// a sibling of the temporary-files folder so the Settings "purge temporary files" action never
+/// removes it. The file is capped and rolled so it cannot grow without bound. Never throws.
+/// </summary>
+public static class CrashDiagnostics
+{
+    private const string ApplicationFolderName = "TinyClips";
+    private const string LogsFolderName = "Logs";
+    private const string LogFileName = "crash.log";
+    private const string PreviousLogFileName = "crash.previous.log";
+    private const long MaxLogBytes = 512 * 1024;
+
+    private static readonly object Gate = new();
+
+    /// <summary>The directory that holds persisted crash logs.</summary>
+    public static string DirectoryPath
+    {
+        get
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var rootDirectory = string.IsNullOrWhiteSpace(localAppData)
+                ? Path.GetTempPath()
+                : localAppData;
+
+            return Path.Combine(rootDirectory, ApplicationFolderName, LogsFolderName);
+        }
+    }
+
+    /// <summary>The active crash log file path.</summary>
+    public static string LogPath => Path.Combine(DirectoryPath, LogFileName);
+
+    /// <summary>Appends a timestamped entry describing an exception to the default crash log.</summary>
+    public static void Log(string source, object? exception, bool handled) =>
+        Log(LogPath, source, exception, handled);
+
+    /// <summary>Appends a timestamped entry describing an exception to the given crash log.</summary>
+    public static void Log(string logPath, string source, object? exception, bool handled)
+    {
+        lock (Gate)
+        {
+            try
+            {
+                var directory = Path.GetDirectoryName(logPath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                RollIfNeeded(logPath);
+
+                var entry =
+                    $"=== {DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss.fff zzz} | {source} | {(handled ? "handled" : "unhandled")} | pid {Environment.ProcessId}{Environment.NewLine}" +
+                    $"{exception ?? "(no exception object)"}{Environment.NewLine}{Environment.NewLine}";
+                File.AppendAllText(logPath, entry);
+            }
+            catch
+            {
+                // Best-effort only.
+            }
+        }
+    }
+
+    private static void RollIfNeeded(string logPath)
+    {
+        var file = new FileInfo(logPath);
+        if (!file.Exists || file.Length < MaxLogBytes)
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(logPath) ?? string.Empty;
+        var previousPath = Path.Combine(directory, PreviousLogFileName);
+        File.Move(logPath, previousPath, overwrite: true);
+    }
+}

--- a/windows/tests/TinyClips.Core.Tests/CrashDiagnosticsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CrashDiagnosticsTests.cs
@@ -1,0 +1,67 @@
+using TinyClips.Core.Services;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class CrashDiagnosticsTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "TinyClipsTests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Log_CreatesDirectoryAndWritesEntry()
+    {
+        var logPath = Path.Combine(_root, "nested", "crash.log");
+
+        CrashDiagnostics.Log(logPath, "TestSource", new InvalidOperationException("boom"), handled: true);
+
+        var content = File.ReadAllText(logPath);
+        Assert.Contains("TestSource", content);
+        Assert.Contains("handled", content);
+        Assert.Contains("InvalidOperationException", content);
+        Assert.Contains("boom", content);
+    }
+
+    [Fact]
+    public void Log_WithoutExceptionObject_WritesPlaceholder()
+    {
+        var logPath = Path.Combine(_root, "crash.log");
+
+        CrashDiagnostics.Log(logPath, "TestSource", null, handled: false);
+
+        var content = File.ReadAllText(logPath);
+        Assert.Contains("unhandled", content);
+        Assert.Contains("(no exception object)", content);
+    }
+
+    [Fact]
+    public void Log_RollsOversizedFileToPrevious()
+    {
+        Directory.CreateDirectory(_root);
+        var logPath = Path.Combine(_root, "crash.log");
+        File.WriteAllText(logPath, new string('x', 600 * 1024));
+
+        CrashDiagnostics.Log(logPath, "TestSource", new Exception("after roll"), handled: true);
+
+        var previousPath = Path.Combine(_root, "crash.previous.log");
+        Assert.True(File.Exists(previousPath));
+        Assert.True(new FileInfo(logPath).Length < 4 * 1024);
+        Assert.Contains("after roll", File.ReadAllText(logPath));
+    }
+
+    [Fact]
+    public void DirectoryPath_IsSiblingOfTemporaryFiles()
+    {
+        var tempParent = Path.GetDirectoryName(TinyClipsTemporaryFiles.DirectoryPath);
+        var logsParent = Path.GetDirectoryName(CrashDiagnostics.DirectoryPath);
+
+        Assert.Equal(tempParent, logsParent);
+        Assert.NotEqual(TinyClipsTemporaryFiles.DirectoryPath, CrashDiagnostics.DirectoryPath);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the Windows app's tray-first startup so a non-fatal hiccup during launch can't produce a crash exit code. Motivated by microsoft/winget-pkgs#417086 (1.7.0) getting `Validation-Executable-Error` — the same label 1.5.3 hit (microsoft/winget-pkgs#407821), where the validator reported `TinyClips.App.exe` exiting with `0xC000027B` (stowed exception).

## Analysis

Diffing `OnLaunched` between `v1.6.0-windows` (passed validation) and `v1.7.0-windows` (failed), the **only** new startup call was `CreateAutomationNotificationAnnouncer()`, which eagerly constructs an off-screen WinUI `Window` with no try/catch. The app also had no `UnhandledException` handler, so any XAML-thread exception terminates the process with a stowed exception — exactly the exit code the validator reports.

## Changes

- **Lazy, guarded announcer** — `AutomationNotificationAnnouncer` is now created on the first Narrator announcement instead of at launch, and creation/announce are wrapped so failures degrade to a `Debug.WriteLine`. Tray-first launch once again creates no XAML window.
- **Per-step startup guards** — `RegisterGlobalHotKeys`, `ShowOnboardingIfNeeded`, and `HandleFileActivation` each run inside `RunStartupStep(...)`, so a failure in one can't abort the rest of launch. Tray icon creation is intentionally *not* guarded (it *is* the app).
- **Global exception handlers** — `Application.UnhandledException` (marks handled), `TaskScheduler.UnobservedTaskException` (`SetObserved`), and `AppDomain.UnhandledException` (log only) are registered in the `App` constructor.
- `windows/CHANGELOG.md` updated under Unreleased → Fixed.

## Validation

- `dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64` ✅
- `dotnet build ... -p:TinyClipsStoreBuild=true` ✅
- `dotnet test windows/tests/TinyClips.Core.Tests` — 94 passed ✅

No behavior, bindings, or visuals change for users; Narrator announcements still work (anchor is created on first use on the UI thread).