### PR TITLE
Add Windows scrolling (panorama) capture

### DIFF
--- a/plans/windows-scrolling-capture.md
+++ b/plans/windows-scrolling-capture.md
@@ -1,0 +1,150 @@
+# Windows Scrolling (Panorama) Capture Plan
+
+Tracks [#272](https://github.com/jamesmontemagno/tiny-clips/issues/272). Goal: parity with the macOS v1.6.0 scrolling capture — select a region, scroll normally, get one tall stitched screenshot that flows into the existing screenshot editor / save pipeline.
+
+## Reference implementation (mac)
+
+| mac file | Role | Windows counterpart |
+| --- | --- | --- |
+| `mac/TinyClips/Capture/ScrollingPanoramaCapture.swift` | `PanoramaFrame`, `PanoramaAccumulator` (stitching), `ScrollingPanoramaCapture` (SCStream loop) | `TinyClips.Core/Capture/Panorama*.cs` + `ScrollingCaptureSession.cs` |
+| `mac/TinyClips/Views/ScrollingCapturePanel.swift` | Floating Done/Cancel panel with frame count + status | `TinyClips.App/Views/ScrollingCaptureWindow.xaml(.cs)` |
+| `mac/TinyClips/Views/CapturePickerPanel.swift` (`.scrolling`, key `P`) | Picker entry point, screenshot mode only | `CapturePickerWindow` new `Scrolling` mode + button + `P` key |
+| `mac/TinyClips/CaptureManager.swift` `startScrollingCapture` / `finishScrollingCapture` | Orchestration | `App.xaml.cs` `BeginCaptureAsync` switch + new helpers |
+| `mac/TinyClipsTests/CaptureMathTests.swift` `testPanorama*` | Algorithm tests | `TinyClips.Core.Tests/PanoramaStitcherTests.cs` |
+
+The mac algorithm is deliberately simple and well-tested; the plan is a **faithful port** rather than the heavier NCC/SAD two-pass described in the issue. The row-luma SAD search + pixel verification already handles the issue's acceptance criteria (seamless output, periodic content, sticky footer suppression) and is what the mac tests lock in. NCC can be a later refinement if real-world captures show drift.
+
+## Architecture
+
+```
+TinyClips.Core/Capture/
+  PanoramaCaptureLimits.cs     record: MaxFrames, MaxOutputHeight, MaxMemoryBytes, NoMovementTimeout
+  PanoramaCaptureException.cs  + PanoramaCaptureError enum (Cancelled, NoMovement, OutputTooLarge, MemoryLimit, NoFrames, AlignmentFailed)
+  PanoramaCaptureLimitReason.cs enum + Message extension
+  PanoramaFrame.cs             BGRA8 pixels + precomputed float[] RowLuma (from CapturedFrame)
+  PanoramaAccumulator.cs       incremental stitcher (pure, testable, no WinRT)
+  PanoramaStitcher.cs          convenience: stitch(IEnumerable<PanoramaFrame>) -> PanoramaResult
+  IScrollingCaptureService.cs  StartAsync(target, region, ct) / StopAsync() -> CapturedFrame / Cancel(); events
+  ScrollingCaptureService.cs   WGC loop using a new ContinuousCaptureSession-style reader
+
+TinyClips.App/
+  Views/CapturePickerWindow.xaml(.cs)   "Scroll" button (screenshot only) + P key + CapturePickerMode.Scrolling
+  Views/ScrollingCaptureWindow.xaml(.cs) floating panel: mode label, pulsing dot + frame count, status, Done, Cancel
+  App.xaml.cs                            BeginCaptureAsync: case Scrolling -> StartScrollingCaptureAsync(...)
+```
+
+### Core: PanoramaFrame
+
+- Constructed from `CapturedFrame` (tightly packed BGRA8). Note mac pixels are RGBA; Windows is **BGRA** — luma weights must be applied as `B=29, G=150, R=77` (integer Rec.601 ×256) on indices `[0],[1],[2]`.
+- `RowLuma`: mean luma per row, sampling every `max(1, width/160)` column, matching mac.
+- `ByteCount` for memory accounting.
+
+### Core: PanoramaAccumulator (direct port)
+
+- `Append(PanoramaFrame) -> PanoramaAppendOutcome { Accepted, Skipped, LimitReached(reason) }`
+- `Finish() -> PanoramaResult { CapturedFrame Image, int FrameCount, int OutputHeight, bool ReachedLimit }`
+- `EstimateVerticalShift(prev, cur) -> Alignment? { Shift, Score, FixedBottomHeight }`
+  - Ignore top/bottom `height/20` bands; shift range `[2, height - height/10]`; min samples `max(8, height/8)`.
+  - SAD over `RowLuma` for every shift (plain loops / `Span<float>`; optionally `System.Numerics.Vector<float>` — no vDSP).
+  - Acceptance band `max(best*1.6, best+0.5)`; iterate local minima ascending; verify with `PixelAlignmentScore <= 12`; give up after 6 verifications. **Smallest credible shift wins** (periodic content).
+  - `StationaryBottomBand` up to `min(shift/2, height/4)` rows with per-row mean luma diff `<= 2`.
+- `AreMeaningfullyDifferent(a, b)`: 80×80 sample grid, mean |Δluma| > 2.5 → different (duplicate-frame rejection).
+- Output buffer: a growing `byte[]` via `ArrayBufferWriter<byte>`/`MemoryStream`-style doubling, committed rows + held footer band exactly as mac. Memory check `outputBytes*2 + frameBytes*2 <= MaxMemoryBytes`.
+- Defaults: `MaxFrames=600`, `MaxMemoryBytes=1_200_000_000` (issue says ~1.2 GB; mac uses 1.5 GB), `NoMovementTimeout=8s`, `MaxOutputHeight` — see open question 1.
+
+### Core: ScrollingCaptureService (WGC loop)
+
+- Reuse the `ContinuousCaptureSession` pattern but **without the pump timer**: WGC only fires `FrameArrived` on change, which is exactly what we want. Add an internal `WgcFrameReader` (or a `ContinuousCaptureSession` ctor flag `emitOnArrivalOnly`) that crops to the region and raises raw frames as they arrive, throttled to ≤ 12 fps (mac uses `minimumFrameInterval = 1/12`) by dropping frames closer than 83 ms to the last processed one.
+- Cursor excluded (`TryConfigureSession(session, includeCursor: false)`).
+- Processing happens on a dedicated single-consumer `Channel<CapturedFrame>` (bounded, `DropOldest`) so stitching never blocks WGC delivery; accumulator state lives on that consumer only (no locks on hot path).
+- Per frame: build `PanoramaFrame`; if `!AreMeaningfullyDifferent(previous, frame)` → skip; if idle > `NoMovementTimeout` **after at least one accepted frame** → raise `Failed(NoMovement)`? Mac raises failure; for Windows prefer raising `LimitReached`-style auto-stop only if frames ≥ 2, otherwise keep waiting (user may be reading the panel). Decide in open question 3.
+- Events (marshalled by the App to the UI thread): `Progress(int acceptedFrames)`, `LimitReached(PanoramaCaptureLimitReason)`, `Failed(Exception)`.
+- `StopAsync()` → stops WGC, drains channel, `accumulator.Finish()` → `CapturedFrame`. `Cancel()` → stops and discards. Both idempotent.
+- Registered in `ServiceCollectionExtensions` as transient `IScrollingCaptureService`.
+
+### App: Capture picker
+
+- `CapturePickerMode.Scrolling`; new `ScrollButton` between Window and Recognize Text with glyph `\uE74B` (Down) or `\uE8A1` (Page) — pick in design pass; `AutomationProperties.Name="Scrolling capture"`, tooltip "Scrolling capture (P)"; key `P`.
+- Visible only when `captureType == Screenshot` (same as `RecognizeTextButton` should be — verify and align both in `Configure`).
+- Countdown is **not** applied to scrolling (mac passes `countdownEnabled: false`); the picker result ignores the timer for this mode.
+
+### App: Flow in `App.xaml.cs`
+
+```
+case CapturePickerMode.Scrolling (CaptureType.Screenshot):
+  selection = ResolveTargetAsync(CapturePickerMode.Region, earlyBackdrop)   // reuse region overlay
+  → StartScrollingCaptureAsync(selection, settings, wasPickerInitiated)
+```
+
+`StartScrollingCaptureAsync`:
+1. Guard `_scrollingCapture is null`; mark `_captureFlowCts` busy so hotkeys don't start another capture; `IsAnyRecordingActive()` should treat scrolling as active (tray menu state).
+2. Show `RegionIndicatorWindow` for the region if `settings.ShowRegionIndicator` (mac parity) — it's already excluded from capture.
+3. Show `ScrollingCaptureWindow` near the bottom-center of the selected monitor's work area (remember last dragged position per session like mac `scrollingCapturePanelPosition`). Announce "Scrolling capture started. Scroll the page, then press Enter to finish." via `AutomationNotificationAnnouncer`.
+4. `await service.StartAsync(selection.Target, selection.Region, ct)`.
+5. Wire events → `panel.UpdateFrameCount`, `panel.ShowStatus(reason.Message)` + auto-stop, failure → teardown + `ShowErrorToast` (unless Cancelled).
+6. Done (button / Enter / global hotkey?) → `panel.MarkFinishing()`; `frame = await service.StopAsync()`; teardown panel + indicator; then **reuse `CaptureScreenshotAndPresentAsync`'s tail**: brand if enabled, `SaveScreenshotFrameAsync`, open editor from memory (or from file if scale < 100), else reveal + toast; `ReopenPickerAfterCaptureIfNeeded(Screenshot, wasPickerInitiated)`. Extract that tail into `PresentCapturedScreenshotAsync(CapturedFrame, settings, wasPickerInitiated)` so both paths share it.
+7. Cancel (button / Esc) → `service.Cancel()`, teardown, reopen picker if configured.
+8. Record analytics as `CaptureType.Screenshot` (same as mac).
+
+### App: `ScrollingCaptureWindow`
+
+- Model on `RecordingIndicatorWindow`: `OverlappedPresenter.CreateForContextMenu()`, always-on-top, `ExcludeFromCapture`, `FloatingWindowDragger`, acrylic/Mica-alt backdrop, rounded corners, not in switchers.
+- Layout (single row, mirrors mac): `FontIcon` + "Scrolling" label · separator · pulsing red dot + "N frames" (monospace digits) · status `TextBlock` (260 px, orange when limit message) · separator · accent **Done** button (✓, Enter) · subtle **Cancel** icon button (✕, Esc).
+- Disable both buttons + set status "Saving…" while finishing.
+- Accessibility: `AutomationProperties.Name` on all buttons, `LiveSetting="Polite"` on status, frame-count `AutomationProperties.Name="Captured frames"`; Enter/Esc handled in `KeyDown` on root; window takes focus on show so keys work without clicking (the page keeps receiving wheel scroll since wheel goes to the window under the cursor).
+- Global Enter/Esc (mac installs global monitors): Windows equivalent would be a low-level keyboard hook — **out of scope for v1**; Done/Cancel buttons + focus-on-show are sufficient. Document in README.
+
+### Editor / output size limits
+
+`ScreenshotEditorWindow` renders via `SoftwareBitmap` → XAML `Image`, which is backed by a D3D texture with a **16384 px** max dimension. A 50 000-px-tall panorama (mac default) will fail to display. Options for open question 1.
+
+## Tests (`TinyClips.Core.Tests/PanoramaStitcherTests.cs`)
+
+Port every mac test with synthetic frames (40×100 gradient with `(row*7 + x*13) % 251`, BGRA):
+
+- `StitchesKnownVerticalShift` (2 frames, shift 20 → height 120)
+- `RejectsFramesWithoutCredibleAlignment` → `AlignmentFailed`
+- `SuppressesStationaryFooterCopies` (footer 5 rows, check pixel at y=95 and y=119)
+- `EnforcesPeakMemoryBudget` → `MemoryLimit`
+- `KeepsPartialResultWhenMemoryLimitIsReached` / `…WhenOutputHeightIsReached`
+- `PrefersSmallestShiftOnRepeatingContent` (period 30)
+- `AlignsSmallScrollSteps` (shift 4 → height 104)
+- `AlignsPeriodicContentAcrossShiftSizes` (320×900, shifts 6/37/120/480)
+- `AreMeaningfullyDifferent` true/false cases
+- `PanoramaFrame.RowLuma` uses BGRA channel order (red-only vs blue-only rows differ as expected)
+- `Finish` with a single frame → `NoMovement`; with zero frames → `NoFrames`
+
+No tests for the WGC session (hardware) — consistent with existing `ContinuousCaptureSession`.
+
+## Docs / changelog
+
+- `windows/CHANGELOG.md`: "Added scrolling capture (Screenshot picker → Scroll / `P`): stitches a scrolled region into one tall image."
+- `windows/README.md`: feature list + picker shortcut table; note Enter/Esc require the panel focused.
+- Update `docs/` parity table if one lists scrolling capture as mac-only.
+
+## Validation
+
+```powershell
+dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64
+dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64 -p:TinyClipsStoreBuild=true
+dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Debug
+```
+
+Manual: long web page at normal speed (seamless); page with sticky header + footer (no repeats); cancel discards; Done after 1 frame → "no movement" error; memory limit message with a huge region at 150 % DPI; editor disabled → direct save + toast; mixed-DPI secondary monitor region.
+
+## Work breakdown (suggested PR order — can be one PR or split Core/App)
+
+1. Core models + `PanoramaFrame` + `PanoramaAccumulator` + `PanoramaStitcher` + tests.
+2. `ScrollingCaptureService` (WGC loop) + DI registration.
+3. Picker mode/button/key.
+4. `ScrollingCaptureWindow`.
+5. `App.xaml.cs` orchestration + shared `PresentCapturedScreenshotAsync` refactor.
+6. Changelog/README, manual validation pass.
+
+## Decisions (2026-08-21)
+
+1. **Max output height (adaptive cap)**: Win2D/XAML textures cap at 16 384 px, which affects the editor's preview *and* Save/Export. When `ShowScreenshotEditor` is on, the capture auto-stops at 16 384 px ("Maximum height reached, saving what was captured") so the editor can open it; when the editor is off (direct save) the mac default of 50 000 px applies.
+2. **Picker entry**: inline "Scroll" button after Window, `P` key, screenshot mode only.
+3. **No-movement timeout**: none. A live test showed a blinking caret inside the region trips a repaint-without-scroll timeout while the user lines up Done; the capture stays open until Done/Cancel or a size/frame/memory limit. (`NoMovement` is still reported when Done is pressed after a single frame.)
+4. **Hotkey**: none (mac parity; avoids ZoomIt chords).
+5. **Scope**: single PR.

--- a/plans/windows-scrolling-capture.md
+++ b/plans/windows-scrolling-capture.md
@@ -145,6 +145,7 @@ Manual: long web page at normal speed (seamless); page with sticky header + foot
 
 1. **Max output height (adaptive cap)**: Win2D/XAML textures cap at 16 384 px, which affects the editor's preview *and* Save/Export. When `ShowScreenshotEditor` is on, the capture auto-stops at 16 384 px ("Maximum height reached, saving what was captured") so the editor can open it; when the editor is off (direct save) the mac default of 50 000 px applies.
 2. **Picker entry**: inline "Scroll" button after Window, `P` key, screenshot mode only.
-3. **No-movement timeout**: none. A live test showed a blinking caret inside the region trips a repaint-without-scroll timeout while the user lines up Done; the capture stays open until Done/Cancel or a size/frame/memory limit. (`NoMovement` is still reported when Done is pressed after a single frame.)
+3. **No-movement timeout**: none. A live test showed a blinking caret inside the region trips a repaint-without-scroll timeout while the user lines up Done; the capture stays open until Done/Cancel or a size/frame/memory limit. Done always yields an image — a single frame is returned as-is when nothing scrolled.
+6. **Review follow-ups (PR #293)**: per-capture session state so Stop drains every queued frame; memory guard accounts for actual buffer capacity (growth capped at 1.5x, first stitch reserved exactly); sticky-footer detection is independent of the scroll step (bounded to height/4, growth per frame bounded by the step) so tall footers survive slow scrolls; results taller than the texture cap bypass the editor even if the setting changed mid-capture; Alt+F4 on the panel cancels.
 4. **Hotkey**: none (mac parity; avoids ZoomIt chords).
 5. **Scope**: single PR.

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,13 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Scrolling capture** — The Screenshot picker gains a **Scroll** action (`P`). Select a region,
+  scroll the page normally, and press **Done** (Enter) on the floating panel to stitch every frame
+  into one tall image that flows into the usual save / editor / clipboard path; **Cancel** (Esc)
+  discards. Frames are aligned with the same row-signature algorithm as macOS 1.6.0 (sticky
+  headers and footers are not repeated), and guardrails stop growth automatically at 600 frames,
+  a ~1.2 GB memory budget, or the maximum height (16 384 px when the editor is enabled, 50 000 px
+  for direct save), saving what was captured so far. Mirrors the macOS scrolling capture.
 - **Microphone soft-knee limiter** — Video recordings now run microphone audio through a
   per-sample soft-knee limiter (knee at 0.98 FS, `atan` roll-off toward full scale) before mixing
   so hot microphones round off instead of hard-clipping. On by default; toggle with Settings →

--- a/windows/README.md
+++ b/windows/README.md
@@ -18,6 +18,11 @@ A native **WinUI 3 / Windows App SDK** port of Tiny Clips — a tray-based scree
   mirroring the macOS picker. Video/GIF captures then show a pre-record setup panel before countdown.
 - **Screenshot** (PNG/JPEG, scale, quality) — full screen, a specific window, or a drag-selected **region**.
   The region selector shows a live snapshot of the screen and dims only outside the selection.
+- **Scrolling capture** — pick **Scroll** (P) in the Screenshot picker, select a region, then scroll
+  the page; a floating panel shows the frame count with **Done** (Enter) to stitch everything into
+  one tall image and **Cancel** (Esc) to discard. Sticky headers/footers are suppressed and memory
+  use is bounded (the capture stops and saves automatically when a limit is reached). Enter/Esc
+  apply while the panel has focus; use its buttons after clicking into the page.
 - **Video recording** → hardware-accelerated **H.264 MP4** (configurable frame rate, audio sources,
   microphone device, mouse-click visuals, and time limit before each recording).
 - **GIF recording** → animated GIF (frame rate, max-width downscale, infinite loop).

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -57,6 +57,13 @@ public partial class App : Application
     private WebcamPreviewWindow? _webcamPreview;
     private ProcessingIndicatorWindow? _processingIndicator;
     private RegionIndicatorWindow? _recordingRegionIndicator;
+    private ScrollingCaptureWindow? _scrollingPanel;
+    private RegionIndicatorWindow? _scrollingRegionIndicator;
+    private bool _scrollingWasPickerInitiated;
+    private bool _scrollingStopping;
+    private Action<int>? _scrollingProgressHandler;
+    private Action<PanoramaCaptureLimitReason>? _scrollingLimitHandler;
+    private Action<Exception>? _scrollingFailedHandler;
     private CancellationTokenSource? _captureFlowCts;
     private DispatcherTimer? _recordingTimer;
     private DateTime _recordingStartedUtc;
@@ -606,7 +613,7 @@ public partial class App : Application
         CapturePickerMode? forcedMode = null,
         bool abortIfRecording = false)
     {
-        if (_captureFlowCts is not null)
+        if (_captureFlowCts is not null || _scrollingPanel is not null)
         {
             return;
         }
@@ -661,11 +668,12 @@ public partial class App : Application
             }
 
             var isTextRecognition = pick.Mode == CapturePickerMode.RecognizeText;
+            var isScrolling = type == CaptureType.Screenshot && pick.Mode == CapturePickerMode.Scrolling;
             var earlyBackdrop = earlyBackdrops is null
                 ? null
                 : new EarlyBackdrop(earlyBackdropMonitors!, earlyBackdrops, earlyBackdropStarted);
             var resolved = await ResolveTargetAsync(
-                isTextRecognition ? CapturePickerMode.Region : pick.Mode,
+                isTextRecognition || isScrolling ? CapturePickerMode.Region : pick.Mode,
                 earlyBackdrop);
             CaptureFlowTrace.Mark($"target: {(resolved is null ? "cancelled" : "resolved")}");
             if (resolved is not { } selection)
@@ -701,7 +709,8 @@ public partial class App : Application
             }
 
             RegionIndicatorWindow? regionIndicator = null;
-            var countdownRan = pick.CountdownEnabled && pick.CountdownDuration > 0;
+            // Scrolling capture has no countdown: the user controls timing by scrolling.
+            var countdownRan = pick.CountdownEnabled && pick.CountdownDuration > 0 && !isScrolling;
             if (countdownRan)
             {
                 try
@@ -746,6 +755,11 @@ public partial class App : Application
                         ShowTextRecognitionNotification("Couldn't recognize text");
                     }
 
+                    break;
+
+                case CaptureType.Screenshot when isScrolling:
+                    captureFlowCts.Token.ThrowIfCancellationRequested();
+                    await StartScrollingCaptureAsync(selection, settings, wasPickerInitiated, captureFlowCts.Token);
                     break;
 
                 case CaptureType.Screenshot:
@@ -925,7 +939,6 @@ public partial class App : Application
         bool wasPickerInitiated,
         CancellationToken cancellationToken)
     {
-        var screenshots = Services.GetRequiredService<IScreenshotService>();
         CapturedFrame frame;
         if (selection.Backdrop is { } backdrop && !countdownRan && !settings.ScreenshotUsesLiveCapture)
         {
@@ -945,7 +958,22 @@ public partial class App : Application
             new BrandingOverlayCompositor().Draw(frame.BgraPixels, frame.Width, frame.Height);
         }
 
-        var saveTask = SaveScreenshotFrameAsync(screenshots, frame, alreadyBranded: true);
+        await PresentScreenshotFrameAsync(frame, settings, wasPickerInitiated, alreadyBranded: true);
+    }
+
+    /// <summary>
+    /// Shared post-capture path for screenshots and scrolling captures: save (and copy to the
+    /// clipboard) in the background, then open the editor from memory or from the saved file, or
+    /// reveal + toast when the editor is disabled.
+    /// </summary>
+    private async Task PresentScreenshotFrameAsync(
+        CapturedFrame frame,
+        ICaptureSettings settings,
+        bool wasPickerInitiated,
+        bool alreadyBranded)
+    {
+        var screenshots = Services.GetRequiredService<IScreenshotService>();
+        var saveTask = SaveScreenshotFrameAsync(screenshots, frame, alreadyBranded);
         if (settings.ShowScreenshotEditor)
         {
             // With a downscale configured, the saved file's dimensions differ from the frame; keep
@@ -986,6 +1014,242 @@ public partial class App : Application
         await CopyToClipboardAsync(path, CaptureType.Screenshot);
         CaptureFlowTrace.Mark("screenshot: saved + clipboard");
         return path;
+    }
+
+    // -- Scrolling (panorama) capture --------------------------------------------------------
+
+    /// <summary>
+    /// Starts a scrolling capture of the selected region and shows the floating Done/Cancel
+    /// panel. Returns as soon as capture is streaming; the panel's callbacks drive stop/cancel.
+    /// </summary>
+    private async Task StartScrollingCaptureAsync(
+        TargetSelection selection,
+        ICaptureSettings settings,
+        bool wasPickerInitiated,
+        CancellationToken cancellationToken)
+    {
+        var service = Services.GetRequiredService<IScrollingCaptureService>();
+        if (service.IsActive || _scrollingPanel is not null)
+        {
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The editor renders through Win2D/XAML textures, which cap at 16 384 px; only let the
+        // panorama grow past that when it will be saved straight to disk.
+        var limits = settings.ShowScreenshotEditor
+            ? PanoramaCaptureLimits.ForEditor
+            : PanoramaCaptureLimits.Default;
+
+        var panel = new ScrollingCaptureWindow();
+        _scrollingPanel = panel;
+        _scrollingWasPickerInitiated = wasPickerInitiated;
+        _scrollingStopping = false;
+        panel.StopRequested = () => _ = StopScrollingCaptureAsync();
+        panel.CancelRequested = CancelScrollingCapture;
+
+        _scrollingProgressHandler = count => _dispatcher?.TryEnqueue(() =>
+        {
+            if (ReferenceEquals(_scrollingPanel, panel))
+            {
+                panel.UpdateFrameCount(count);
+            }
+        });
+        _scrollingLimitHandler = reason => _dispatcher?.TryEnqueue(() =>
+        {
+            if (!ReferenceEquals(_scrollingPanel, panel))
+            {
+                return;
+            }
+
+            var message = reason.ToMessage();
+            panel.ShowStatus(message);
+            Announce(
+                AutomationNotificationKind.Other,
+                AutomationNotificationProcessing.ImportantMostRecent,
+                message,
+                "ScrollingCaptureLimit");
+            _ = StopScrollingCaptureAsync();
+        });
+        _scrollingFailedHandler = error => _dispatcher?.TryEnqueue(() =>
+        {
+            if (!ReferenceEquals(_scrollingPanel, panel))
+            {
+                return;
+            }
+
+            service.Cancel();
+            FinishScrollingCapture(error);
+        });
+        service.Progress += _scrollingProgressHandler;
+        service.LimitReached += _scrollingLimitHandler;
+        service.Failed += _scrollingFailedHandler;
+
+        if (settings.ShowRegionIndicator)
+        {
+            _scrollingRegionIndicator = ShowRegionIndicator(selection);
+        }
+
+        var monitor = selection.Monitor ?? ResolveMonitorForTarget(selection.Target);
+        PixelRect? regionInVirtualDesktop = selection.Region is { } region
+            ? ToVirtualDesktopRegion(selection.Target, region)
+            : null;
+        panel.ShowNear(monitor, regionInVirtualDesktop);
+        Announce(
+            AutomationNotificationKind.Other,
+            AutomationNotificationProcessing.MostRecent,
+            "Scrolling capture started. Scroll the page, then press Enter to finish.",
+            "ScrollingCaptureStarted");
+
+        try
+        {
+            await service.StartAsync(selection.Target, selection.Region, limits, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            FinishScrollingCapture(ex);
+            if (ex is OperationCanceledException)
+            {
+                throw;
+            }
+        }
+    }
+
+    private async Task StopScrollingCaptureAsync()
+    {
+        if (_scrollingStopping || _scrollingPanel is not { } panel)
+        {
+            return;
+        }
+
+        _scrollingStopping = true;
+        panel.MarkFinishing();
+        CaptureFlowTrace.Mark("scrolling: stop requested");
+
+        var service = Services.GetRequiredService<IScrollingCaptureService>();
+        CapturedFrame frame;
+        try
+        {
+            frame = await service.StopAsync();
+        }
+        catch (Exception ex)
+        {
+            FinishScrollingCapture(ex);
+            return;
+        }
+
+        var wasPickerInitiated = _scrollingWasPickerInitiated;
+        FinishScrollingCapture(null);
+
+        var settings = Services.GetRequiredService<ICaptureSettings>();
+        try
+        {
+            if (settings.ShowBrandingOverlay)
+            {
+                new BrandingOverlayCompositor().Draw(frame.BgraPixels, frame.Width, frame.Height);
+            }
+
+            await PresentScreenshotFrameAsync(frame, settings, wasPickerInitiated, alreadyBranded: true);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Scrolling capture save failed: {ex}");
+            ShowSaveFailureNotification("the scrolling capture");
+            ReopenPickerAfterCaptureIfNeeded(CaptureType.Screenshot, wasPickerInitiated);
+        }
+    }
+
+    private void CancelScrollingCapture()
+    {
+        if (_scrollingPanel is null)
+        {
+            return;
+        }
+
+        Services.GetRequiredService<IScrollingCaptureService>().Cancel();
+        FinishScrollingCapture(new PanoramaCaptureException(PanoramaCaptureError.Cancelled));
+    }
+
+    /// <summary>
+    /// Tears down the scrolling panel, region indicator and service subscriptions. With an
+    /// <paramref name="error"/>, reports it (unless it is a cancellation) and reopens the picker
+    /// if configured; on success the caller presents the stitched image instead.
+    /// </summary>
+    private void FinishScrollingCapture(Exception? error)
+    {
+        var service = Services.GetRequiredService<IScrollingCaptureService>();
+        if (_scrollingProgressHandler is { } progress)
+        {
+            service.Progress -= progress;
+        }
+
+        if (_scrollingLimitHandler is { } limit)
+        {
+            service.LimitReached -= limit;
+        }
+
+        if (_scrollingFailedHandler is { } failed)
+        {
+            service.Failed -= failed;
+        }
+
+        _scrollingProgressHandler = null;
+        _scrollingLimitHandler = null;
+        _scrollingFailedHandler = null;
+
+        var panel = _scrollingPanel;
+        _scrollingPanel = null;
+        panel?.ClosePanel();
+
+        var indicator = _scrollingRegionIndicator;
+        _scrollingRegionIndicator = null;
+        indicator?.ClosePanel();
+
+        var wasPickerInitiated = _scrollingWasPickerInitiated;
+        _scrollingWasPickerInitiated = false;
+        _scrollingStopping = false;
+
+        if (error is null)
+        {
+            return;
+        }
+
+        if (error is PanoramaCaptureException { IsCancellation: true } || error is OperationCanceledException)
+        {
+            CaptureFlowTrace.Mark("scrolling: cancelled");
+        }
+        else
+        {
+            Debug.WriteLine($"Scrolling capture failed: {error}");
+            CaptureFlowTrace.Mark($"scrolling: failed ({error.GetType().Name})");
+            ShowScrollingCaptureFailureNotification(error.Message);
+        }
+
+        ReopenPickerAfterCaptureIfNeeded(CaptureType.Screenshot, wasPickerInitiated);
+    }
+
+    private void ShowScrollingCaptureFailureNotification(string details)
+    {
+        Announce(
+            AutomationNotificationKind.ActionAborted,
+            AutomationNotificationProcessing.ImportantMostRecent,
+            $"Scrolling capture failed. {details}",
+            "ScrollingCaptureFailed");
+
+        try
+        {
+            EnsureNotificationsRegistered();
+            AppNotificationManager.Default.Show(
+                new AppNotificationBuilder()
+                    .AddText("Scrolling capture failed")
+                    .AddText(details)
+                    .BuildNotification());
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to show scrolling capture notification: {ex}");
+        }
     }
 
     private async Task<RecordingSetupResult?> ShowRecordingSetupAsync(CaptureType type, TargetSelection selection, ICaptureSettings settings)
@@ -2668,6 +2932,12 @@ public partial class App : Application
         _isExiting = true;
         try
         {
+            Services.GetRequiredService<IScrollingCaptureService>().Cancel();
+            _scrollingPanel?.ClosePanel();
+            _scrollingPanel = null;
+            _scrollingRegionIndicator?.ClosePanel();
+            _scrollingRegionIndicator = null;
+
             var video = Services.GetRequiredService<IVideoRecordingService>();
             var gif = Services.GetRequiredService<IGifRecordingService>();
             if (video.IsRecording)

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -964,17 +964,18 @@ public partial class App : Application
     /// <summary>
     /// Shared post-capture path for screenshots and scrolling captures: save (and copy to the
     /// clipboard) in the background, then open the editor from memory or from the saved file, or
-    /// reveal + toast when the editor is disabled.
+    /// reveal + toast when the editor is disabled (or <paramref name="allowEditor"/> is false).
     /// </summary>
     private async Task PresentScreenshotFrameAsync(
         CapturedFrame frame,
         ICaptureSettings settings,
         bool wasPickerInitiated,
-        bool alreadyBranded)
+        bool alreadyBranded,
+        bool allowEditor = true)
     {
         var screenshots = Services.GetRequiredService<IScreenshotService>();
         var saveTask = SaveScreenshotFrameAsync(screenshots, frame, alreadyBranded);
-        if (settings.ShowScreenshotEditor)
+        if (settings.ShowScreenshotEditor && allowEditor)
         {
             // With a downscale configured, the saved file's dimensions differ from the frame; keep
             // the editor file-backed so Save/Reset/Copy operate on the same pixels as the file.
@@ -1150,7 +1151,11 @@ public partial class App : Application
                 new BrandingOverlayCompositor().Draw(frame.BgraPixels, frame.Width, frame.Height);
             }
 
-            await PresentScreenshotFrameAsync(frame, settings, wasPickerInitiated, alreadyBranded: true);
+            // The editor setting is re-read here; if it was toggled on mid-capture the image may
+            // exceed the Win2D/XAML texture cap, so fall back to a direct save in that case.
+            var fitsEditor = frame.Width <= PanoramaCaptureLimits.EditorMaxOutputHeight
+                && frame.Height <= PanoramaCaptureLimits.EditorMaxOutputHeight;
+            await PresentScreenshotFrameAsync(frame, settings, wasPickerInitiated, alreadyBranded: true, allowEditor: fitsEditor);
         }
         catch (Exception ex)
         {

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
@@ -81,6 +81,18 @@
                 </Button>
 
                 <Button
+                    x:Name="ScrollButton"
+                    AutomationProperties.AutomationId="CaptureScrollButton"
+                    AutomationProperties.Name="Scrolling capture"
+                    Click="OnScrolling"
+                    ToolTipService.ToolTip="Scrolling capture: stitch a scrolled region into one tall image (P)">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE8A1;" />
+                        <TextBlock Text="Scroll" />
+                    </StackPanel>
+                </Button>
+
+                <Button
                     x:Name="RecognizeTextButton"
                     AutomationProperties.AutomationId="RecognizeTextButton"
                     AutomationProperties.Name="Recognize text and copy it to the clipboard"

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml
@@ -100,7 +100,7 @@
                     ToolTipService.ToolTip="Recognize text in a region (T)">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE8D2;" />
-                        <TextBlock Text="Recognize Text" />
+                        <TextBlock Text="Text" />
                     </StackPanel>
                 </Button>
 

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -18,6 +18,8 @@ public enum CapturePickerMode
     Screen,
     Window,
     RecognizeText,
+    /// <summary>Screenshot only: select a region, scroll, and stitch the frames into one tall image.</summary>
+    Scrolling,
 }
 
 /// <summary>The user's choice from the capture picker bar.</summary>
@@ -99,8 +101,11 @@ public sealed partial class CapturePickerWindow : Window
 
         UpdateTimerLabel();
         LimitButton.Visibility = captureType == CaptureType.Video ? Visibility.Visible : Visibility.Collapsed;
+        ScrollButton.Visibility = captureType == CaptureType.Screenshot ? Visibility.Visible : Visibility.Collapsed;
         UpdateLimitLabel();
     }
+
+    private bool IsScrollingAvailable => ScrollButton.Visibility == Visibility.Visible;
 
     public static Task<CapturePickerResult?> RunAsync(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes = 0)
     {
@@ -236,6 +241,8 @@ public sealed partial class CapturePickerWindow : Window
 
     private void OnRecognizeText(object sender, RoutedEventArgs e) => Complete(CapturePickerMode.RecognizeText);
 
+    private void OnScrolling(object sender, RoutedEventArgs e) => Complete(CapturePickerMode.Scrolling);
+
     private void OnCancel(object sender, RoutedEventArgs e) => Complete(null);
 
     // Drag-anywhere support: the R / S / W / timer / cancel buttons handle their own
@@ -267,6 +274,9 @@ public sealed partial class CapturePickerWindow : Window
                 break;
             case VirtualKey.T:
                 Complete(CapturePickerMode.RecognizeText);
+                break;
+            case VirtualKey.P when IsScrollingAvailable:
+                Complete(CapturePickerMode.Scrolling);
                 break;
         }
     }

--- a/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/CapturePickerWindow.xaml.cs
@@ -101,11 +101,15 @@ public sealed partial class CapturePickerWindow : Window
 
         UpdateTimerLabel();
         LimitButton.Visibility = captureType == CaptureType.Video ? Visibility.Visible : Visibility.Collapsed;
-        ScrollButton.Visibility = captureType == CaptureType.Screenshot ? Visibility.Visible : Visibility.Collapsed;
+        var isScreenshot = captureType == CaptureType.Screenshot;
+        ScrollButton.Visibility = isScreenshot ? Visibility.Visible : Visibility.Collapsed;
+        RecognizeTextButton.Visibility = isScreenshot ? Visibility.Visible : Visibility.Collapsed;
         UpdateLimitLabel();
     }
 
     private bool IsScrollingAvailable => ScrollButton.Visibility == Visibility.Visible;
+
+    private bool IsRecognizeTextAvailable => RecognizeTextButton.Visibility == Visibility.Visible;
 
     public static Task<CapturePickerResult?> RunAsync(CaptureType captureType, bool countdownEnabled, int countdownDuration, double videoTimeLimitMinutes = 0)
     {
@@ -272,7 +276,7 @@ public sealed partial class CapturePickerWindow : Window
             case VirtualKey.W:
                 Complete(CapturePickerMode.Window);
                 break;
-            case VirtualKey.T:
+            case VirtualKey.T when IsRecognizeTextAvailable:
                 Complete(CapturePickerMode.RecognizeText);
                 break;
             case VirtualKey.P when IsScrollingAvailable:

--- a/windows/src/TinyClips.App/Views/GuideWindow.xaml
+++ b/windows/src/TinyClips.App/Views/GuideWindow.xaml
@@ -90,6 +90,10 @@
                             Subtitle="Press W to capture a specific application window."
                             Title="Window" />
                         <local:GuideRow
+                            Glyph="&#xE8A1;"
+                            Subtitle="Press P (screenshots only) to select a region, scroll the page, then press Done to stitch the frames into one tall image."
+                            Title="Scroll" />
+                        <local:GuideRow
                             Glyph="&#xE8D2;"
                             Subtitle="Press T to select a region and copy its recognized text to the clipboard."
                             Title="Recognize Text" />

--- a/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml
@@ -80,7 +80,7 @@
                         MinWidth="72"
                         VerticalAlignment="Center"
                         AutomationProperties.LiveSetting="Polite"
-                        AutomationProperties.Name="Captured frames"
+                        AutomationProperties.Name="Captured frames: 0 frames"
                         Style="{StaticResource BodyStrongTextBlockStyle}"
                         Text="0 frames" />
                 </StackPanel>

--- a/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="TinyClips.App.ScrollingCaptureWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Window.SystemBackdrop>
+        <DesktopAcrylicBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid
+        x:Name="RootGrid"
+        AutomationProperties.Name="Scrolling capture in progress"
+        Background="Transparent"
+        IsTabStop="True"
+        PointerCanceled="OnPointerCaptureEnded"
+        PointerCaptureLost="OnPointerCaptureEnded"
+        PointerMoved="OnPointerMoved"
+        PointerPressed="OnPointerPressed"
+        PointerReleased="OnPointerReleased">
+        <Grid.Resources>
+            <Storyboard x:Name="PulseStoryboard" RepeatBehavior="Forever" AutoReverse="True">
+                <DoubleAnimation
+                    Duration="0:0:0.8"
+                    From="1"
+                    Storyboard.TargetName="LiveDot"
+                    Storyboard.TargetProperty="Opacity"
+                    To="0.35">
+                    <DoubleAnimation.EasingFunction>
+                        <SineEase EasingMode="EaseInOut" />
+                    </DoubleAnimation.EasingFunction>
+                </DoubleAnimation>
+            </Storyboard>
+        </Grid.Resources>
+
+        <Border
+            Padding="14,8"
+            Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Border.Shadow>
+                <ThemeShadow />
+            </Border.Shadow>
+
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <StackPanel
+                    VerticalAlignment="Center"
+                    AutomationProperties.Name="Scrolling capture mode"
+                    Orientation="Horizontal"
+                    Spacing="6">
+                    <FontIcon
+                        FontFamily="Segoe Fluent Icons"
+                        FontSize="13"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Glyph="&#xE8A1;" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="Scrolling" />
+                </StackPanel>
+
+                <Rectangle
+                    Width="1"
+                    Height="22"
+                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                <StackPanel
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal"
+                    Spacing="6">
+                    <Ellipse
+                        x:Name="LiveDot"
+                        Width="8"
+                        Height="8"
+                        VerticalAlignment="Center"
+                        Fill="{ThemeResource SystemFillColorCriticalBrush}" />
+                    <TextBlock
+                        x:Name="FrameCountText"
+                        MinWidth="72"
+                        VerticalAlignment="Center"
+                        AutomationProperties.LiveSetting="Polite"
+                        AutomationProperties.Name="Captured frames"
+                        Style="{StaticResource BodyStrongTextBlockStyle}"
+                        Text="0 frames" />
+                </StackPanel>
+
+                <TextBlock
+                    x:Name="StatusText"
+                    Width="260"
+                    VerticalAlignment="Center"
+                    AutomationProperties.LiveSetting="Assertive"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="Scroll the page, then press Enter"
+                    TextTrimming="CharacterEllipsis"
+                    TextWrapping="NoWrap" />
+
+                <Rectangle
+                    Width="1"
+                    Height="22"
+                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                <Button
+                    x:Name="DoneButton"
+                    AutomationProperties.AutomationId="ScrollingCaptureDoneButton"
+                    AutomationProperties.Name="Finish scrolling capture"
+                    AutomationProperties.HelpText="Stops scrolling capture and stitches the captured frames."
+                    Click="OnDoneClick"
+                    Style="{StaticResource AccentButtonStyle}"
+                    ToolTipService.ToolTip="Finish scrolling capture (Enter)">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon FontFamily="Segoe Fluent Icons" FontSize="12" Glyph="&#xE73E;" />
+                        <TextBlock Text="Done" />
+                    </StackPanel>
+                </Button>
+
+                <Button
+                    x:Name="CancelButton"
+                    Width="32"
+                    Height="32"
+                    Padding="0"
+                    AutomationProperties.AutomationId="ScrollingCaptureCancelButton"
+                    AutomationProperties.Name="Cancel scrolling capture"
+                    AutomationProperties.HelpText="Discards the capture without saving."
+                    Click="OnCancelClick"
+                    ToolTipService.ToolTip="Cancel (Esc)">
+                    <FontIcon FontFamily="Segoe Fluent Icons" FontSize="12" Glyph="&#xE711;" />
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml.cs
@@ -1,0 +1,223 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Input;
+using TinyClips.Core.Capture;
+using Windows.Graphics;
+using Windows.System;
+using WinRT.Interop;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Floating always-on-top panel shown while a scrolling capture is running: live frame count,
+/// status, and Done (Enter) / Cancel (Esc). Mirrors the macOS <c>ScrollingCapturePanel</c>.
+/// </summary>
+public sealed partial class ScrollingCaptureWindow : Window
+{
+    private const int RegionOutsideOffsetDip = 12;
+    private const int BottomOffsetDip = 32;
+    private const string DefaultStatus = "Scroll the page, then press Enter";
+
+    // Remembered across captures within a session so a dragged panel stays where the user put it.
+    private static PointInt32? _lastPosition;
+
+    private readonly FloatingWindowDragger _dragger;
+    private bool _completed;
+    private bool _closed;
+
+    public ScrollingCaptureWindow()
+    {
+        InitializeComponent();
+
+        var presenter = OverlappedPresenter.CreateForContextMenu();
+        presenter.IsAlwaysOnTop = true;
+        AppWindow.SetPresenter(presenter);
+        AppWindow.IsShownInSwitchers = false;
+
+        _dragger = new FloatingWindowDragger(AppWindow);
+        RootGrid.KeyDown += OnKeyDown;
+        Activated += OnActivated;
+        Closed += OnClosed;
+    }
+
+    public Action? StopRequested { get; set; }
+
+    public Action? CancelRequested { get; set; }
+
+    /// <summary>Shows the panel just outside the captured region (or at the bottom of the monitor's work area).</summary>
+    public void ShowNear(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        Position(monitor, regionInVirtualDesktop);
+        AppWindow.Show(true);
+        Activate();
+
+        var hwnd = WindowNative.GetWindowHandle(this);
+        OverlayWindowHelpers.ExcludeFromCapture(hwnd);
+        PulseStoryboard.Begin();
+    }
+
+    public void UpdateFrameCount(int count)
+    {
+        var label = count == 1 ? "1 frame" : $"{count} frames";
+        FrameCountText.Text = label;
+    }
+
+    public void ShowStatus(string message)
+    {
+        StatusText.Text = message;
+        StatusText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCautionBrush"];
+    }
+
+    /// <summary>Disables the controls and shows "Saving…" while the frames are stitched and written.</summary>
+    public void MarkFinishing()
+    {
+        _completed = true;
+        DoneButton.IsEnabled = false;
+        CancelButton.IsEnabled = false;
+        PulseStoryboard.Stop();
+        if (StatusText.Text == DefaultStatus)
+        {
+            StatusText.Text = "Saving…";
+        }
+
+        AutomationProperties.SetName(RootGrid, "Scrolling capture saving");
+        AutomationProperties.SetHelpText(DoneButton, "Saving captured frames.");
+        AutomationProperties.SetHelpText(CancelButton, "Saving captured frames.");
+    }
+
+    public void ClosePanel()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        _closed = true;
+        StopRequested = null;
+        CancelRequested = null;
+        RememberPosition();
+        Close();
+    }
+
+    private void OnDoneClick(object sender, RoutedEventArgs e) => Finish(stop: true);
+
+    private void OnCancelClick(object sender, RoutedEventArgs e) => Finish(stop: false);
+
+    // Drag-anywhere support: the buttons mark their own pointer events handled, so a drag only
+    // starts on the panel surface.
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerPressed(sender, e);
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerMoved(sender, e);
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerReleased(sender, e);
+
+    private void OnPointerCaptureEnded(object sender, PointerRoutedEventArgs e) => _dragger.OnPointerCaptureEnded(sender, e);
+
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case VirtualKey.Enter:
+                Finish(stop: true);
+                e.Handled = true;
+                break;
+            case VirtualKey.Escape:
+                Finish(stop: false);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void Finish(bool stop)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        if (stop)
+        {
+            MarkFinishing();
+            StopRequested?.Invoke();
+        }
+        else
+        {
+            _completed = true;
+            var cancel = CancelRequested;
+            ClosePanel();
+            cancel?.Invoke();
+        }
+    }
+
+    private void OnActivated(object sender, WindowActivatedEventArgs args)
+    {
+        if (args.WindowActivationState != WindowActivationState.Deactivated)
+        {
+            RootGrid.Focus(FocusState.Programmatic);
+        }
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        _closed = true;
+        StopRequested = null;
+        CancelRequested = null;
+    }
+
+    private void RememberPosition()
+    {
+        try
+        {
+            _lastPosition = AppWindow.Position;
+        }
+        catch
+        {
+            // The window may already be gone.
+        }
+    }
+
+    private void Position(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    {
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var target = AppWindowPlacement.PrepareForTargetMonitor(AppWindow, hwnd, monitor);
+        var work = target.WorkArea;
+        var scale = target.Scale;
+
+        RootGrid.UpdateLayout();
+        RootGrid.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
+        var width = Math.Max((int)Math.Ceiling(RootGrid.DesiredSize.Width * scale), AppWindowPlacement.DipToPixels(420, scale));
+        var height = Math.Max((int)Math.Ceiling(RootGrid.DesiredSize.Height * scale), AppWindowPlacement.DipToPixels(56, scale));
+
+        int x;
+        int y;
+        if (_lastPosition is { } remembered)
+        {
+            x = remembered.X;
+            y = remembered.Y;
+        }
+        else
+        {
+            var regionOutsideOffset = AppWindowPlacement.DipToPixels(RegionOutsideOffsetDip, scale);
+            x = work.X + Math.Max(0, (work.Width - width) / 2);
+            y = work.Y + Math.Max(0, work.Height - height - AppWindowPlacement.DipToPixels(BottomOffsetDip, scale));
+
+            if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
+            {
+                x = region.X + Math.Max(0, (region.Width - width) / 2);
+                var preferredBelow = region.Y + region.Height + regionOutsideOffset;
+                var preferredAbove = region.Y - height - regionOutsideOffset;
+                if (preferredBelow <= work.Y + Math.Max(0, work.Height - height))
+                {
+                    y = preferredBelow;
+                }
+                else if (preferredAbove >= work.Y)
+                {
+                    y = preferredAbove;
+                }
+            }
+        }
+
+        AppWindow.MoveAndResize(AppWindowPlacement.ClampToWorkArea(work, x, y, width, height));
+    }
+}

--- a/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScrollingCaptureWindow.xaml.cs
@@ -61,6 +61,8 @@ public sealed partial class ScrollingCaptureWindow : Window
     {
         var label = count == 1 ? "1 frame" : $"{count} frames";
         FrameCountText.Text = label;
+        // The live region announces its name, so keep it in sync with the visible label.
+        AutomationProperties.SetName(FrameCountText, $"Captured frames: {label}");
     }
 
     public void ShowStatus(string message)
@@ -160,9 +162,22 @@ public sealed partial class ScrollingCaptureWindow : Window
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
+        if (_closed)
+        {
+            return;
+        }
+
+        // An external close (Alt+F4, shell) must not leave the capture running headless.
         _closed = true;
+        var cancel = CancelRequested;
         StopRequested = null;
         CancelRequested = null;
+        RememberPosition();
+        if (!_completed)
+        {
+            _completed = true;
+            cancel?.Invoke();
+        }
     }
 
     private void RememberPosition()

--- a/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
+++ b/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
@@ -52,6 +52,14 @@ internal sealed class ContinuousCaptureSession : IDisposable
     /// <summary>Raised at the target frame rate: tightly-packed BGRA8 + relative PTS.</summary>
     public event Action<CapturedFrame, TimeSpan>? FrameReady;
 
+    /// <summary>
+    /// Raised whenever WGC delivers a new frame (i.e. only when the screen content changes),
+    /// independent of <see cref="BeginEmitting"/>. Consumers that only care about change —
+    /// such as the scrolling capture — subscribe here and never start the steady-rate pump.
+    /// Raised on the WGC frame-pool thread; handlers must return quickly.
+    /// </summary>
+    public event Action<CapturedFrame>? FrameArrived;
+
     /// <summary>Output width in pixels (region width, or full monitor width), rounded down to even.</summary>
     public int OutputWidth { get; private set; }
 
@@ -163,6 +171,7 @@ internal sealed class ContinuousCaptureSession : IDisposable
                 return;
             }
 
+            CapturedFrame captured;
             lock (_sync)
             {
                 if (!_running || _context is null || _d3dDevice is null)
@@ -192,11 +201,15 @@ internal sealed class ContinuousCaptureSession : IDisposable
 
                 _context.CopyResource(_stagingTexture, frameTexture);
 
-                var captured = ReadStaging((int)desc.Width, (int)desc.Height);
+                captured = ReadStaging((int)desc.Width, (int)desc.Height);
                 _latestPixels = captured.BgraPixels;
                 _latestWidth = captured.Width;
                 _latestHeight = captured.Height;
             }
+
+            // The pump clones _latestPixels before emitting, so handing the same buffer to
+            // FrameArrived subscribers is safe as long as they treat it as read-only.
+            FrameArrived?.Invoke(captured);
         }
         catch
         {

--- a/windows/src/TinyClips.Core/Capture/IScrollingCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/IScrollingCaptureService.cs
@@ -1,0 +1,36 @@
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// Scrolling (panorama) screenshot capture: streams a region while the user scrolls and
+/// stitches the frames into one tall image. Mirrors the macOS <c>ScrollingPanoramaCapture</c>.
+/// One session at a time.
+/// </summary>
+public interface IScrollingCaptureService
+{
+    /// <summary>True between a successful <see cref="StartAsync"/> and the matching stop/cancel.</summary>
+    bool IsActive { get; }
+
+    /// <summary>Raised (on a background thread) with the accepted frame count each time a frame is stitched.</summary>
+    event Action<int>? Progress;
+
+    /// <summary>
+    /// Raised once (on a background thread) when a guardrail stops growth; the caller should
+    /// stop and keep what exists.
+    /// </summary>
+    event Action<PanoramaCaptureLimitReason>? LimitReached;
+
+    /// <summary>Raised once (on a background thread) when the capture cannot continue; the caller should cancel.</summary>
+    event Action<Exception>? Failed;
+
+    /// <summary>Starts streaming the monitor-relative <paramref name="region"/> of <paramref name="target"/>.</summary>
+    Task StartAsync(CaptureTarget target, PixelRect? region, PanoramaCaptureLimits limits, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops capturing and returns the stitched image. Throws <see cref="PanoramaCaptureException"/>
+    /// when nothing usable was captured.
+    /// </summary>
+    Task<CapturedFrame> StopAsync();
+
+    /// <summary>Stops capturing and discards everything. Safe to call when not active.</summary>
+    void Cancel();
+}

--- a/windows/src/TinyClips.Core/Capture/PanoramaAccumulator.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaAccumulator.cs
@@ -34,7 +34,6 @@ public sealed class PanoramaAccumulator
     private long _outputLength;
     private int _committedRows;
     private int _heldBottomBand;
-    private int _rejectedFrameCount;
 
     public PanoramaAccumulator(PanoramaCaptureLimits limits)
     {
@@ -87,29 +86,32 @@ public sealed class PanoramaAccumulator
 
         if (frame.Width != previous.Width || frame.Height != previous.Height)
         {
-            _rejectedFrameCount++;
             return PanoramaAppendOutcome.Skipped;
         }
 
         if (EstimateVerticalShift(previous, frame) is not { } alignment)
         {
-            _rejectedFrameCount++;
             return PanoramaAppendOutcome.Skipped;
         }
 
         var height = frame.Height;
         var isFirstCommit = _committedRows == 0;
-        var baseRows = isFirstCommit ? height - alignment.FixedBottomHeight : _committedRows;
         var previousBand = isFirstCommit ? alignment.FixedBottomHeight : _heldBottomBand;
-        var appendCount = alignment.Shift + previousBand - alignment.FixedBottomHeight;
+        // The stationary band is detected independently of the scroll step, so a footer taller
+        // than the step is still fully suppressed. It can only grow by the rows that scrolled in
+        // since the last frame, which keeps every committed row accounted for exactly once.
+        var fixedBottomHeight = isFirstCommit
+            ? alignment.FixedBottomHeight
+            : Math.Min(alignment.FixedBottomHeight, alignment.Shift + previousBand);
+        var baseRows = isFirstCommit ? height - fixedBottomHeight : _committedRows;
+        var appendCount = alignment.Shift + previousBand - fixedBottomHeight;
         var sourceStartRow = height - previousBand - alignment.Shift;
-        if (appendCount <= 0 || sourceStartRow < 0 || baseRows < 0)
+        if (appendCount < 0 || sourceStartRow < 0 || baseRows <= 0)
         {
-            _rejectedFrameCount++;
             return PanoramaAppendOutcome.Skipped;
         }
 
-        var prospectiveHeight = baseRows + appendCount + alignment.FixedBottomHeight;
+        var prospectiveHeight = baseRows + appendCount + fixedBottomHeight;
         if (prospectiveHeight > Limits.MaxOutputHeight)
         {
             LimitReason = PanoramaCaptureLimitReason.OutputHeight;
@@ -124,14 +126,15 @@ public sealed class PanoramaAccumulator
 
         if (isFirstCommit)
         {
-            EnsureCapacity((long)baseRows * frame.Width * 4);
+            // Reserve the whole first stitch at once so the actual capacity matches what Fits predicted.
+            EnsureCapacity((long)(baseRows + appendCount) * frame.Width * 4);
             AppendRows(previous, 0, baseRows);
             _committedRows = baseRows;
         }
 
         AppendRows(frame, sourceStartRow, appendCount);
         _committedRows += appendCount;
-        _heldBottomBand = alignment.FixedBottomHeight;
+        _heldBottomBand = fixedBottomHeight;
         PreviousFrame = frame;
         AcceptedFrameCount++;
 
@@ -144,7 +147,11 @@ public sealed class PanoramaAccumulator
         return PanoramaAppendOutcome.Accepted;
     }
 
-    /// <summary>Flushes the held footer band and materializes the panorama image.</summary>
+    /// <summary>
+    /// Flushes the held footer band and materializes the panorama image. Stopping always yields
+    /// an image when at least one frame was accepted: a single frame (nothing scrolled yet) is
+    /// returned as-is.
+    /// </summary>
     public PanoramaResult Finish()
     {
         if (PreviousFrame is not { } last)
@@ -154,16 +161,9 @@ public sealed class PanoramaAccumulator
 
         if (_committedRows == 0)
         {
-            if (LimitReason is { } reason)
-            {
-                throw new PanoramaCaptureException(reason == PanoramaCaptureLimitReason.Memory
-                    ? PanoramaCaptureError.MemoryLimit
-                    : PanoramaCaptureError.OutputTooLarge);
-            }
-
-            throw new PanoramaCaptureException(_rejectedFrameCount > 0
-                ? PanoramaCaptureError.AlignmentFailed
-                : PanoramaCaptureError.NoMovement);
+            // Nothing was stitched yet (no scroll, or a limit hit on the very first commit): the
+            // single retained frame is still a usable screenshot.
+            return new PanoramaResult(last.ToCapturedFrame(), AcceptedFrameCount, last.Height, ReachedLimit);
         }
 
         var bytesPerRow = last.Width * 4;
@@ -202,17 +202,28 @@ public sealed class PanoramaAccumulator
             return;
         }
 
-        var newCapacity = Math.Max(required, Math.Min(_output.LongLength * 2, Array.MaxLength));
-        var grown = new byte[newCapacity];
+        var grown = new byte[GrownCapacity(_output.LongLength, required)];
         Buffer.BlockCopy(_output, 0, grown, 0, (int)_outputLength);
         _output = grown;
     }
 
-    /// <summary>Peak memory is the output buffer plus the copy made for the final image, plus the retained and incoming frames.</summary>
+    /// <summary>Amortized growth: double, but never beyond 1.5x the required size, so over-allocation stays bounded and predictable for <see cref="Fits"/>.</summary>
+    private static long GrownCapacity(long current, long required)
+        => Math.Max(required, Math.Min(current * 2, Math.Min(required + (required / 2), Array.MaxLength)));
+
+    /// <summary>Capacity the output buffer will actually hold after growing to fit <paramref name="requiredBytes"/>.</summary>
+    private long PredictedCapacity(long requiredBytes)
+        => requiredBytes <= _output.LongLength ? _output.LongLength : GrownCapacity(_output.LongLength, requiredBytes);
+
+    /// <summary>
+    /// Peak memory is the (possibly over-allocated) output buffer plus the exact-size copy made for
+    /// the final image, plus the retained and incoming frames.
+    /// </summary>
     private bool Fits(int outputHeight, int width, PanoramaFrame frame)
     {
         var outputBytes = (long)width * outputHeight * 4;
-        return (outputBytes * 2) + (frame.ByteCount * 2) <= Limits.MaxMemoryBytes;
+        var bufferBytes = PredictedCapacity(outputBytes);
+        return bufferBytes + outputBytes + (frame.ByteCount * 2) <= Limits.MaxMemoryBytes;
     }
 
     /// <summary>
@@ -332,7 +343,9 @@ public sealed class PanoramaAccumulator
             return null;
         }
 
-        var fixedBottomHeight = StationaryBottomBand(previous, current, bestShift / 2);
+        // Sticky footers are detected independently of the scroll step (bounded to a quarter of
+        // the frame) so slow scrolls under a tall footer still suppress it completely.
+        var fixedBottomHeight = StationaryBottomBand(previous, current, previous.Height / 4);
         if (bestShift + fixedBottomHeight > height)
         {
             return null;

--- a/windows/src/TinyClips.Core/Capture/PanoramaAccumulator.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaAccumulator.cs
@@ -1,0 +1,434 @@
+namespace TinyClips.Core.Capture;
+
+public enum PanoramaAppendStatus
+{
+    Accepted,
+    Skipped,
+    LimitReached,
+}
+
+public readonly record struct PanoramaAppendOutcome(PanoramaAppendStatus Status, PanoramaCaptureLimitReason? LimitReason)
+{
+    public static PanoramaAppendOutcome Accepted { get; } = new(PanoramaAppendStatus.Accepted, null);
+
+    public static PanoramaAppendOutcome Skipped { get; } = new(PanoramaAppendStatus.Skipped, null);
+
+    public static PanoramaAppendOutcome LimitReached(PanoramaCaptureLimitReason reason)
+        => new(PanoramaAppendStatus.LimitReached, reason);
+}
+
+public sealed record PanoramaResult(CapturedFrame Image, int FrameCount, int OutputHeight, bool ReachedLimit);
+
+/// <summary>
+/// Stitches scrolling-capture frames into the output buffer as they arrive so that peak memory
+/// tracks the size of the panorama instead of the number of captured frames. Direct port of the
+/// macOS <c>PanoramaAccumulator</c>: vertical shift is found by comparing per-row luma
+/// signatures, verified against real pixels, and a stationary bottom band (sticky footer) is
+/// held back and written once at the end.
+/// </summary>
+public sealed class PanoramaAccumulator
+{
+    public readonly record struct Alignment(int Shift, double Score, int FixedBottomHeight);
+
+    private byte[] _output = Array.Empty<byte>();
+    private long _outputLength;
+    private int _committedRows;
+    private int _heldBottomBand;
+    private int _rejectedFrameCount;
+
+    public PanoramaAccumulator(PanoramaCaptureLimits limits)
+    {
+        Limits = limits;
+    }
+
+    public PanoramaCaptureLimits Limits { get; }
+
+    public PanoramaFrame? PreviousFrame { get; private set; }
+
+    public int AcceptedFrameCount { get; private set; }
+
+    public PanoramaCaptureLimitReason? LimitReason { get; private set; }
+
+    public bool ReachedLimit => LimitReason is not null;
+
+    /// <summary>Height the panorama would have if the capture stopped right now.</summary>
+    public int PendingOutputHeight
+    {
+        get
+        {
+            if (PreviousFrame is not { } previous)
+            {
+                return 0;
+            }
+
+            return _committedRows == 0 ? previous.Height : _committedRows + _heldBottomBand;
+        }
+    }
+
+    public PanoramaAppendOutcome Append(PanoramaFrame frame)
+    {
+        if (LimitReason is not null)
+        {
+            return PanoramaAppendOutcome.Skipped;
+        }
+
+        if (PreviousFrame is not { } previous)
+        {
+            if (!Fits(frame.Height, frame.Width, frame))
+            {
+                LimitReason = PanoramaCaptureLimitReason.Memory;
+                return PanoramaAppendOutcome.LimitReached(PanoramaCaptureLimitReason.Memory);
+            }
+
+            PreviousFrame = frame;
+            AcceptedFrameCount = 1;
+            return PanoramaAppendOutcome.Accepted;
+        }
+
+        if (frame.Width != previous.Width || frame.Height != previous.Height)
+        {
+            _rejectedFrameCount++;
+            return PanoramaAppendOutcome.Skipped;
+        }
+
+        if (EstimateVerticalShift(previous, frame) is not { } alignment)
+        {
+            _rejectedFrameCount++;
+            return PanoramaAppendOutcome.Skipped;
+        }
+
+        var height = frame.Height;
+        var isFirstCommit = _committedRows == 0;
+        var baseRows = isFirstCommit ? height - alignment.FixedBottomHeight : _committedRows;
+        var previousBand = isFirstCommit ? alignment.FixedBottomHeight : _heldBottomBand;
+        var appendCount = alignment.Shift + previousBand - alignment.FixedBottomHeight;
+        var sourceStartRow = height - previousBand - alignment.Shift;
+        if (appendCount <= 0 || sourceStartRow < 0 || baseRows < 0)
+        {
+            _rejectedFrameCount++;
+            return PanoramaAppendOutcome.Skipped;
+        }
+
+        var prospectiveHeight = baseRows + appendCount + alignment.FixedBottomHeight;
+        if (prospectiveHeight > Limits.MaxOutputHeight)
+        {
+            LimitReason = PanoramaCaptureLimitReason.OutputHeight;
+            return PanoramaAppendOutcome.LimitReached(PanoramaCaptureLimitReason.OutputHeight);
+        }
+
+        if (!Fits(prospectiveHeight, frame.Width, frame))
+        {
+            LimitReason = PanoramaCaptureLimitReason.Memory;
+            return PanoramaAppendOutcome.LimitReached(PanoramaCaptureLimitReason.Memory);
+        }
+
+        if (isFirstCommit)
+        {
+            EnsureCapacity((long)baseRows * frame.Width * 4);
+            AppendRows(previous, 0, baseRows);
+            _committedRows = baseRows;
+        }
+
+        AppendRows(frame, sourceStartRow, appendCount);
+        _committedRows += appendCount;
+        _heldBottomBand = alignment.FixedBottomHeight;
+        PreviousFrame = frame;
+        AcceptedFrameCount++;
+
+        if (AcceptedFrameCount >= Limits.MaxFrames)
+        {
+            LimitReason = PanoramaCaptureLimitReason.FrameCount;
+            return PanoramaAppendOutcome.LimitReached(PanoramaCaptureLimitReason.FrameCount);
+        }
+
+        return PanoramaAppendOutcome.Accepted;
+    }
+
+    /// <summary>Flushes the held footer band and materializes the panorama image.</summary>
+    public PanoramaResult Finish()
+    {
+        if (PreviousFrame is not { } last)
+        {
+            throw new PanoramaCaptureException(PanoramaCaptureError.NoFrames);
+        }
+
+        if (_committedRows == 0)
+        {
+            if (LimitReason is { } reason)
+            {
+                throw new PanoramaCaptureException(reason == PanoramaCaptureLimitReason.Memory
+                    ? PanoramaCaptureError.MemoryLimit
+                    : PanoramaCaptureError.OutputTooLarge);
+            }
+
+            throw new PanoramaCaptureException(_rejectedFrameCount > 0
+                ? PanoramaCaptureError.AlignmentFailed
+                : PanoramaCaptureError.NoMovement);
+        }
+
+        var bytesPerRow = last.Width * 4;
+        var outputHeight = _committedRows + _heldBottomBand;
+        var pixels = new byte[(long)outputHeight * bytesPerRow];
+        Buffer.BlockCopy(_output, 0, pixels, 0, (int)_outputLength);
+        if (_heldBottomBand > 0)
+        {
+            var start = (last.Height - _heldBottomBand) * bytesPerRow;
+            Buffer.BlockCopy(last.BgraPixels, start, pixels, (int)_outputLength, _heldBottomBand * bytesPerRow);
+        }
+
+        _output = Array.Empty<byte>();
+        _outputLength = 0;
+
+        return new PanoramaResult(
+            new CapturedFrame(pixels, last.Width, outputHeight),
+            AcceptedFrameCount,
+            outputHeight,
+            LimitReason is not null);
+    }
+
+    private void AppendRows(PanoramaFrame frame, int startRow, int rowCount)
+    {
+        var bytesPerRow = frame.Width * 4;
+        var byteCount = (long)rowCount * bytesPerRow;
+        EnsureCapacity(_outputLength + byteCount);
+        Buffer.BlockCopy(frame.BgraPixels, startRow * bytesPerRow, _output, (int)_outputLength, (int)byteCount);
+        _outputLength += byteCount;
+    }
+
+    private void EnsureCapacity(long required)
+    {
+        if (required <= _output.LongLength)
+        {
+            return;
+        }
+
+        var newCapacity = Math.Max(required, Math.Min(_output.LongLength * 2, Array.MaxLength));
+        var grown = new byte[newCapacity];
+        Buffer.BlockCopy(_output, 0, grown, 0, (int)_outputLength);
+        _output = grown;
+    }
+
+    /// <summary>Peak memory is the output buffer plus the copy made for the final image, plus the retained and incoming frames.</summary>
+    private bool Fits(int outputHeight, int width, PanoramaFrame frame)
+    {
+        var outputBytes = (long)width * outputHeight * 4;
+        return (outputBytes * 2) + (frame.ByteCount * 2) <= Limits.MaxMemoryBytes;
+    }
+
+    /// <summary>
+    /// Cheap duplicate-frame test: samples an 80x80 grid and reports whether the mean absolute
+    /// luma difference is large enough to be worth aligning.
+    /// </summary>
+    public static bool AreMeaningfullyDifferent(PanoramaFrame first, PanoramaFrame second)
+    {
+        if (first.Width != second.Width || first.Height != second.Height)
+        {
+            return true;
+        }
+
+        var rowStep = Math.Max(1, first.Height / 80);
+        var columnStep = Math.Max(1, first.Width / 80);
+        var difference = 0.0;
+        var samples = 0;
+        for (var y = 0; y < first.Height; y += rowStep)
+        {
+            for (var x = 0; x < first.Width; x += columnStep)
+            {
+                var index = ((y * first.Width) + x) * 4;
+                difference += Math.Abs(PanoramaFrame.Luma(first.BgraPixels, index) - PanoramaFrame.Luma(second.BgraPixels, index));
+                samples++;
+            }
+        }
+
+        return samples == 0 || difference / samples > 2.5;
+    }
+
+    public static Alignment? EstimateVerticalShift(PanoramaFrame previous, PanoramaFrame current)
+    {
+        var height = previous.Height;
+        if (height <= 8 || previous.RowLuma.Length != height || current.RowLuma.Length != height)
+        {
+            return null;
+        }
+
+        // Scrolling content is usually periodic (repeating rows, cards, table stripes), so the
+        // globally lowest score is often a later alias of the real shift. Overshooting duplicates
+        // rows that are already committed, so the smallest credible shift is always the right choice.
+        var ignoredTopBand = Math.Max(1, height / 20);
+        var ignoredBottomBand = Math.Max(1, height / 20);
+        const int minimumShift = 2;
+        var maximumShift = Math.Max(minimumShift, height - (height / 10));
+        var minimumSamples = Math.Max(8, height / 8);
+
+        var scores = new float[maximumShift + 1];
+        Array.Fill(scores, float.MaxValue);
+        var bestScore = float.MaxValue;
+        var previousRows = previous.RowLuma;
+        var currentRows = current.RowLuma;
+        for (var shift = minimumShift; shift <= maximumShift; shift++)
+        {
+            var comparisonEnd = height - ignoredBottomBand - shift;
+            var samples = comparisonEnd - ignoredTopBand;
+            if (samples < minimumSamples)
+            {
+                continue;
+            }
+
+            var total = 0f;
+            for (var y = ignoredTopBand; y < comparisonEnd; y++)
+            {
+                total += Math.Abs(currentRows[y] - previousRows[y + shift]);
+            }
+
+            var score = total / samples;
+            scores[shift] = score;
+            if (score < bestScore)
+            {
+                bestScore = score;
+            }
+        }
+
+        if (bestScore == float.MaxValue)
+        {
+            return null;
+        }
+
+        // Anything within this band of the best score is statistically the same match, so prefer
+        // the earliest one.
+        var acceptanceScore = Math.Max(bestScore * 1.6f, bestScore + 0.5f);
+        int? candidate = null;
+        var verificationAttempts = 0;
+        for (var shift = minimumShift; shift <= maximumShift; shift++)
+        {
+            if (scores[shift] > acceptanceScore)
+            {
+                continue;
+            }
+
+            var isLocalMinimum = (shift == minimumShift || scores[shift] <= scores[shift - 1])
+                && (shift == maximumShift || scores[shift] <= scores[shift + 1]);
+            if (!isLocalMinimum)
+            {
+                continue;
+            }
+
+            if (PixelAlignmentScore(previous, current, shift) <= 12)
+            {
+                candidate = shift;
+                break;
+            }
+
+            verificationAttempts++;
+            // Verification is the expensive part, so give up rather than scan a frame that is
+            // not a scroll of the previous one.
+            if (verificationAttempts >= 6)
+            {
+                break;
+            }
+        }
+
+        if (candidate is not { } bestShift)
+        {
+            return null;
+        }
+
+        var fixedBottomHeight = StationaryBottomBand(previous, current, bestShift / 2);
+        if (bestShift + fixedBottomHeight > height)
+        {
+            return null;
+        }
+
+        return new Alignment(bestShift, scores[bestShift], fixedBottomHeight);
+    }
+
+    /// <summary>
+    /// Confirms a row-signature candidate against real pixels, which rejects shifts where
+    /// unrelated rows happen to share the same average brightness.
+    /// </summary>
+    private static double PixelAlignmentScore(PanoramaFrame previous, PanoramaFrame current, int shift)
+    {
+        var height = previous.Height;
+        var width = previous.Width;
+        var ignoredTopBand = Math.Max(1, height / 20);
+        var comparisonEnd = height - Math.Max(1, height / 20) - shift;
+        if (comparisonEnd <= ignoredTopBand || width <= 0)
+        {
+            return double.MaxValue;
+        }
+
+        var columnStep = Math.Max(1, width / PanoramaFrame.SignatureColumns);
+        var rowStep = Math.Max(1, (comparisonEnd - ignoredTopBand) / 80);
+        var score = 0.0;
+        var samples = 0;
+        for (var y = ignoredTopBand; y < comparisonEnd; y += rowStep)
+        {
+            for (var x = 0; x < width; x += columnStep)
+            {
+                var previousIndex = (((y + shift) * width) + x) * 4;
+                var currentIndex = ((y * width) + x) * 4;
+                score += Math.Abs(PanoramaFrame.Luma(previous.BgraPixels, previousIndex) - PanoramaFrame.Luma(current.BgraPixels, currentIndex));
+                samples++;
+            }
+        }
+
+        return samples > 0 ? score / samples : double.MaxValue;
+    }
+
+    private static int StationaryBottomBand(PanoramaFrame previous, PanoramaFrame current, int maximumHeight)
+    {
+        var maximum = Math.Min(maximumHeight, previous.Height / 4);
+        if (maximum <= 0)
+        {
+            return 0;
+        }
+
+        var columnStep = Math.Max(1, previous.Width / PanoramaFrame.SignatureColumns);
+        var stationaryRows = 0;
+        for (var offset = 0; offset < maximum; offset++)
+        {
+            var y = previous.Height - 1 - offset;
+            var difference = 0.0;
+            var samples = 0;
+            for (var x = 0; x < previous.Width; x += columnStep)
+            {
+                var index = ((y * previous.Width) + x) * 4;
+                difference += Math.Abs(PanoramaFrame.Luma(previous.BgraPixels, index) - PanoramaFrame.Luma(current.BgraPixels, index));
+                samples++;
+            }
+
+            if (samples == 0 || difference / samples > 2)
+            {
+                break;
+            }
+
+            stationaryRows++;
+        }
+
+        return stationaryRows;
+    }
+}
+
+/// <summary>Convenience wrapper that stitches an already-captured sequence of frames.</summary>
+public sealed class PanoramaStitcher
+{
+    public PanoramaStitcher(PanoramaCaptureLimits limits)
+    {
+        Limits = limits;
+    }
+
+    public PanoramaCaptureLimits Limits { get; }
+
+    public PanoramaResult Stitch(IEnumerable<PanoramaFrame> frames)
+    {
+        var accumulator = new PanoramaAccumulator(Limits);
+        foreach (var frame in frames)
+        {
+            if (accumulator.Append(frame).Status == PanoramaAppendStatus.LimitReached)
+            {
+                break;
+            }
+        }
+
+        return accumulator.Finish();
+    }
+}

--- a/windows/src/TinyClips.Core/Capture/PanoramaCaptureException.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaCaptureException.cs
@@ -1,0 +1,35 @@
+namespace TinyClips.Core.Capture;
+
+public enum PanoramaCaptureError
+{
+    Cancelled,
+    NoMovement,
+    OutputTooLarge,
+    MemoryLimit,
+    NoFrames,
+    AlignmentFailed,
+}
+
+public sealed class PanoramaCaptureException : Exception
+{
+    public PanoramaCaptureException(PanoramaCaptureError error)
+        : base(Describe(error))
+    {
+        Error = error;
+    }
+
+    public PanoramaCaptureError Error { get; }
+
+    public bool IsCancellation => Error == PanoramaCaptureError.Cancelled;
+
+    private static string Describe(PanoramaCaptureError error) => error switch
+    {
+        PanoramaCaptureError.Cancelled => "Scrolling capture was cancelled.",
+        PanoramaCaptureError.NoMovement => "Scrolling capture stopped because no movement was detected.",
+        PanoramaCaptureError.OutputTooLarge => "Scrolling capture reached its maximum output size.",
+        PanoramaCaptureError.MemoryLimit => "Scrolling capture reached its memory limit.",
+        PanoramaCaptureError.NoFrames => "No frames were captured.",
+        PanoramaCaptureError.AlignmentFailed => "Could not align the scrolling frames.",
+        _ => "Scrolling capture failed.",
+    };
+}

--- a/windows/src/TinyClips.Core/Capture/PanoramaCaptureLimitReason.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaCaptureLimitReason.cs
@@ -1,0 +1,20 @@
+namespace TinyClips.Core.Capture;
+
+/// <summary>Reason a scrolling capture stopped growing before the user asked it to.</summary>
+public enum PanoramaCaptureLimitReason
+{
+    Memory,
+    OutputHeight,
+    FrameCount,
+}
+
+public static class PanoramaCaptureLimitReasonExtensions
+{
+    public static string ToMessage(this PanoramaCaptureLimitReason reason) => reason switch
+    {
+        PanoramaCaptureLimitReason.Memory => "Memory limit reached, saving what was captured",
+        PanoramaCaptureLimitReason.OutputHeight => "Maximum height reached, saving what was captured",
+        PanoramaCaptureLimitReason.FrameCount => "Frame limit reached, saving what was captured",
+        _ => "Limit reached, saving what was captured",
+    };
+}

--- a/windows/src/TinyClips.Core/Capture/PanoramaCaptureLimits.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaCaptureLimits.cs
@@ -1,0 +1,36 @@
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// Guardrails for a scrolling (panorama) capture. Mirrors the macOS <c>PanoramaCaptureLimits</c>.
+/// </summary>
+/// <param name="MaxFrames">Maximum number of stitched frames before the capture auto-stops.</param>
+/// <param name="MaxOutputHeight">Maximum stitched height in pixels before the capture auto-stops.</param>
+/// <param name="MaxMemoryBytes">
+/// Peak memory budget: the output buffer plus the copy made for the final image, plus the
+/// retained and incoming frames.
+/// </param>
+public sealed record PanoramaCaptureLimits(
+    int MaxFrames,
+    int MaxOutputHeight,
+    long MaxMemoryBytes)
+{
+    /// <summary>
+    /// Largest texture dimension Win2D / XAML can render; stitched images taller than this cannot
+    /// be opened in the screenshot editor.
+    /// </summary>
+    public const int EditorMaxOutputHeight = 16_384;
+
+    public static PanoramaCaptureLimits Default { get; } = new(
+        MaxFrames: 600,
+        MaxOutputHeight: 50_000,
+        MaxMemoryBytes: 1_200_000_000);
+
+    /// <summary>
+    /// Limits for a capture whose result will be opened in the screenshot editor, which caps the
+    /// output height at <see cref="EditorMaxOutputHeight"/>.
+    /// </summary>
+    public static PanoramaCaptureLimits ForEditor { get; } = Default with
+    {
+        MaxOutputHeight = EditorMaxOutputHeight,
+    };
+}

--- a/windows/src/TinyClips.Core/Capture/PanoramaFrame.cs
+++ b/windows/src/TinyClips.Core/Capture/PanoramaFrame.cs
@@ -1,0 +1,74 @@
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// One tightly-packed BGRA8 frame of a scrolling capture plus a precomputed per-row mean luma
+/// signature used for fast, repeatable vertical alignment.
+/// </summary>
+public sealed class PanoramaFrame
+{
+    /// <summary>Columns are sampled at this density when building row signatures and pixel scores.</summary>
+    internal const int SignatureColumns = 160;
+
+    public PanoramaFrame(CapturedFrame frame)
+        : this(frame.BgraPixels, frame.Width, frame.Height)
+    {
+    }
+
+    public PanoramaFrame(byte[] bgraPixels, int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Frame dimensions must be positive.");
+        }
+
+        if (bgraPixels.LongLength < (long)width * height * 4)
+        {
+            throw new ArgumentException("Pixel buffer is smaller than width * height * 4.", nameof(bgraPixels));
+        }
+
+        BgraPixels = bgraPixels;
+        Width = width;
+        Height = height;
+        RowLuma = MakeRowLuma(bgraPixels, width, height);
+    }
+
+    public byte[] BgraPixels { get; }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    /// <summary>Mean luma per row (0-255 scale), sampled across up to 160 columns.</summary>
+    public float[] RowLuma { get; }
+
+    public long ByteCount => (long)Width * Height * 4;
+
+    public CapturedFrame ToCapturedFrame() => new(BgraPixels, Width, Height);
+
+    /// <summary>Rec.601 luma of the BGRA pixel starting at <paramref name="index"/>.</summary>
+    internal static double Luma(byte[] bgra, int index)
+        => (0.114 * bgra[index]) + (0.587 * bgra[index + 1]) + (0.299 * bgra[index + 2]);
+
+    private static float[] MakeRowLuma(byte[] pixels, int width, int height)
+    {
+        var columnStep = Math.Max(1, width / SignatureColumns);
+        var result = new float[height];
+        for (var y = 0; y < height; y++)
+        {
+            long total = 0;
+            var samples = 0;
+            var rowStart = y * width;
+            for (var x = 0; x < width; x += columnStep)
+            {
+                var index = (rowStart + x) * 4;
+                // Integer approximation of Rec.601 luma (x256) keeps this hot loop cheap.
+                total += (29 * pixels[index]) + (150 * pixels[index + 1]) + (77 * pixels[index + 2]);
+                samples++;
+            }
+
+            result[y] = samples > 0 ? total / (float)(samples * 256) : 0f;
+        }
+
+        return result;
+    }
+}

--- a/windows/src/TinyClips.Core/Capture/ScrollingCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/ScrollingCaptureService.cs
@@ -7,21 +7,15 @@ namespace TinyClips.Core.Capture;
 /// WGC-backed <see cref="IScrollingCaptureService"/>. Frames arrive on the WGC thread only when
 /// the screen changes; they are throttled to ~12 fps and handed to a single consumer task that
 /// owns the <see cref="PanoramaAccumulator"/>, so stitching never blocks frame delivery.
+/// All per-capture state lives in a <see cref="Session"/> so a stop or cancel can never be
+/// confused with a later capture.
 /// </summary>
 public sealed class ScrollingCaptureService : IScrollingCaptureService, IDisposable
 {
     private static readonly TimeSpan MinFrameInterval = TimeSpan.FromSeconds(1.0 / 12);
 
     private readonly object _gate = new();
-
-    private ContinuousCaptureSession? _session;
-    private PanoramaAccumulator? _accumulator;
-    private Channel<CapturedFrame>? _channel;
-    private Task? _consumer;
-    private long _lastEnqueuedTimestamp;
-    private volatile bool _finished = true;
-    private bool _reportedLimit;
-    private bool _reportedFailure;
+    private Session? _current;
 
     public bool IsActive
     {
@@ -29,7 +23,7 @@ public sealed class ScrollingCaptureService : IScrollingCaptureService, IDisposa
         {
             lock (_gate)
             {
-                return _session is not null;
+                return _current is not null;
             }
         }
     }
@@ -44,46 +38,16 @@ public sealed class ScrollingCaptureService : IScrollingCaptureService, IDisposa
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        ContinuousCaptureSession session;
         lock (_gate)
         {
-            if (_session is not null)
+            if (_current is not null)
             {
                 throw new InvalidOperationException("A scrolling capture is already active.");
             }
 
-            _accumulator = new PanoramaAccumulator(limits);
-            _channel = Channel.CreateBounded<CapturedFrame>(new BoundedChannelOptions(4)
-            {
-                FullMode = BoundedChannelFullMode.DropOldest,
-                SingleReader = true,
-                SingleWriter = false,
-            });
-            _finished = false;
-            _reportedLimit = false;
-            _reportedFailure = false;
-            _lastEnqueuedTimestamp = 0;
-
-            session = new ContinuousCaptureSession(target, region, targetFps: 12, includeCursor: false);
-            session.FrameArrived += OnFrameArrived;
-            try
-            {
-                session.Start();
-            }
-            catch
-            {
-                session.FrameArrived -= OnFrameArrived;
-                session.Dispose();
-                _channel = null;
-                _accumulator = null;
-                _finished = true;
-                throw;
-            }
-
-            _session = session;
-            var reader = _channel.Reader;
-            var accumulator = _accumulator;
-            _consumer = Task.Run(() => ConsumeAsync(reader, accumulator), CancellationToken.None);
+            var session = new Session(this, target, region, limits);
+            session.Start();
+            _current = session;
         }
 
         CaptureFlowTrace.Mark("scrolling: capture started");
@@ -92,158 +56,248 @@ public sealed class ScrollingCaptureService : IScrollingCaptureService, IDisposa
 
     public async Task<CapturedFrame> StopAsync()
     {
-        PanoramaAccumulator accumulator;
-        Task? consumer;
+        Session session;
         lock (_gate)
         {
-            if (_session is null || _accumulator is null)
-            {
-                throw new PanoramaCaptureException(PanoramaCaptureError.Cancelled);
-            }
-
-            accumulator = _accumulator;
-            consumer = _consumer;
-            TearDownSessionLocked();
+            session = _current ?? throw new PanoramaCaptureException(PanoramaCaptureError.Cancelled);
+            _current = null;
         }
 
-        if (consumer is not null)
-        {
-            await consumer.ConfigureAwait(false);
-        }
-
-        var result = accumulator.Finish();
+        // Stop WGC, then let the consumer drain every frame that already arrived before finishing.
+        var result = await session.StopAndStitchAsync().ConfigureAwait(false);
         CaptureFlowTrace.Mark($"scrolling: stitched {result.FrameCount} frames -> {result.Image.Width}x{result.OutputHeight}");
         return result.Image;
     }
 
     public void Cancel()
     {
+        Session? session;
         lock (_gate)
         {
-            if (_session is null)
-            {
-                return;
-            }
-
-            TearDownSessionLocked();
+            session = _current;
+            _current = null;
         }
 
+        if (session is null)
+        {
+            return;
+        }
+
+        session.Cancel();
         CaptureFlowTrace.Mark("scrolling: cancelled");
     }
 
     public void Dispose() => Cancel();
 
-    /// <summary>Stops WGC, completes the frame channel and clears all per-session state. Caller holds <see cref="_gate"/>.</summary>
-    private void TearDownSessionLocked()
+    private void RaiseProgress(Session session, int count)
     {
-        _finished = true;
-        if (_session is { } session)
+        if (IsCurrent(session))
         {
-            session.FrameArrived -= OnFrameArrived;
+            Progress?.Invoke(count);
+        }
+    }
+
+    private void RaiseLimit(Session session, PanoramaCaptureLimitReason reason)
+    {
+        if (IsCurrent(session))
+        {
+            LimitReached?.Invoke(reason);
+        }
+    }
+
+    private void RaiseFailed(Session session, Exception error)
+    {
+        if (IsCurrent(session))
+        {
+            Failed?.Invoke(error);
+        }
+    }
+
+    private bool IsCurrent(Session session)
+    {
+        lock (_gate)
+        {
+            return ReferenceEquals(_current, session);
+        }
+    }
+
+    /// <summary>One scrolling capture: WGC session, frame channel, consumer task and accumulator.</summary>
+    private sealed class Session
+    {
+        private readonly ScrollingCaptureService _owner;
+        private readonly ContinuousCaptureSession _capture;
+        private readonly PanoramaAccumulator _accumulator;
+        private readonly Channel<CapturedFrame> _channel;
+        private readonly CancellationTokenSource _cancellation = new();
+        private Task _consumer = Task.CompletedTask;
+        private long _lastEnqueuedTimestamp;
+        private int _stopped;
+        private bool _reportedLimit;
+        private bool _reportedFailure;
+
+        public Session(ScrollingCaptureService owner, CaptureTarget target, PixelRect? region, PanoramaCaptureLimits limits)
+        {
+            _owner = owner;
+            _accumulator = new PanoramaAccumulator(limits);
+            _channel = Channel.CreateBounded<CapturedFrame>(new BoundedChannelOptions(4)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+            _capture = new ContinuousCaptureSession(target, region, targetFps: 12, includeCursor: false);
+        }
+
+        public void Start()
+        {
+            _capture.FrameArrived += OnFrameArrived;
             try
             {
-                session.Stop();
-                session.Dispose();
+                _capture.Start();
+            }
+            catch
+            {
+                _capture.FrameArrived -= OnFrameArrived;
+                _capture.Dispose();
+                _cancellation.Dispose();
+                throw;
+            }
+
+            _consumer = Task.Run(ConsumeAsync, CancellationToken.None);
+        }
+
+        /// <summary>Stops WGC, drains every queued frame into the accumulator, and materializes the panorama.</summary>
+        public async Task<PanoramaResult> StopAndStitchAsync()
+        {
+            StopCapture();
+            await _consumer.ConfigureAwait(false);
+            try
+            {
+                return _accumulator.Finish();
+            }
+            finally
+            {
+                _cancellation.Dispose();
+            }
+        }
+
+        /// <summary>Stops WGC and abandons queued frames. The consumer exits on its own; no events are raised afterwards.</summary>
+        public void Cancel()
+        {
+            _cancellation.Cancel();
+            StopCapture();
+            _consumer.ContinueWith(_ => _cancellation.Dispose(), TaskScheduler.Default);
+        }
+
+        private void StopCapture()
+        {
+            if (Interlocked.Exchange(ref _stopped, 1) != 0)
+            {
+                return;
+            }
+
+            _capture.FrameArrived -= OnFrameArrived;
+            try
+            {
+                _capture.Stop();
+                _capture.Dispose();
             }
             catch
             {
                 // Best-effort teardown.
             }
+
+            _channel.Writer.TryComplete();
         }
 
-        _session = null;
-        _channel?.Writer.TryComplete();
-        _channel = null;
-        _accumulator = null;
-        _consumer = null;
-    }
-
-    private void OnFrameArrived(CapturedFrame frame)
-    {
-        if (_finished)
+        private void OnFrameArrived(CapturedFrame frame)
         {
-            return;
-        }
-
-        // WGC can deliver at the display refresh rate; ~12 fps is plenty for stitching.
-        var now = Stopwatch.GetTimestamp();
-        var last = Interlocked.Read(ref _lastEnqueuedTimestamp);
-        if (last != 0 && Stopwatch.GetElapsedTime(last, now) < MinFrameInterval)
-        {
-            return;
-        }
-
-        if (Interlocked.CompareExchange(ref _lastEnqueuedTimestamp, now, last) != last)
-        {
-            return;
-        }
-
-        _channel?.Writer.TryWrite(frame);
-    }
-
-    private async Task ConsumeAsync(ChannelReader<CapturedFrame> reader, PanoramaAccumulator accumulator)
-    {
-        await foreach (var captured in reader.ReadAllAsync().ConfigureAwait(false))
-        {
-            if (_finished || accumulator.ReachedLimit)
+            if (Volatile.Read(ref _stopped) != 0)
             {
-                continue;
+                return;
             }
 
-            try
+            // WGC can deliver at the display refresh rate; ~12 fps is plenty for stitching.
+            var now = Stopwatch.GetTimestamp();
+            var last = Interlocked.Read(ref _lastEnqueuedTimestamp);
+            if (last != 0 && Stopwatch.GetElapsedTime(last, now) < MinFrameInterval)
             {
-                Process(accumulator, captured);
+                return;
             }
-            catch (Exception ex)
+
+            if (Interlocked.CompareExchange(ref _lastEnqueuedTimestamp, now, last) != last)
             {
-                ReportFailure(ex);
+                return;
+            }
+
+            _channel.Writer.TryWrite(frame);
+        }
+
+        private async Task ConsumeAsync()
+        {
+            var token = _cancellation.Token;
+            await foreach (var captured in _channel.Reader.ReadAllAsync().ConfigureAwait(false))
+            {
+                if (token.IsCancellationRequested || _accumulator.ReachedLimit)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Process(captured);
+                }
+                catch (Exception ex)
+                {
+                    ReportFailure(ex);
+                }
             }
         }
-    }
 
-    private void Process(PanoramaAccumulator accumulator, CapturedFrame captured)
-    {
-        var frame = new PanoramaFrame(captured);
-        if (accumulator.PreviousFrame is { } previous && !PanoramaAccumulator.AreMeaningfullyDifferent(previous, frame))
+        private void Process(CapturedFrame captured)
         {
-            // The region repainted (caret blink, spinner) without scrolling. Never give up here:
-            // the user may simply be pausing, and Done/Cancel remain available at all times.
-            return;
+            var frame = new PanoramaFrame(captured);
+            if (_accumulator.PreviousFrame is { } previous && !PanoramaAccumulator.AreMeaningfullyDifferent(previous, frame))
+            {
+                // The region repainted (caret blink, spinner) without scrolling. Never give up
+                // here: the user may simply be pausing, and Done/Cancel remain available.
+                return;
+            }
+
+            var outcome = _accumulator.Append(frame);
+            switch (outcome.Status)
+            {
+                case PanoramaAppendStatus.Accepted:
+                    _owner.RaiseProgress(this, _accumulator.AcceptedFrameCount);
+                    break;
+
+                case PanoramaAppendStatus.LimitReached:
+                    _owner.RaiseProgress(this, _accumulator.AcceptedFrameCount);
+                    ReportLimit(outcome.LimitReason ?? PanoramaCaptureLimitReason.Memory);
+                    break;
+            }
         }
 
-        var outcome = accumulator.Append(frame);
-        switch (outcome.Status)
+        private void ReportFailure(Exception error)
         {
-            case PanoramaAppendStatus.Accepted:
-                Progress?.Invoke(accumulator.AcceptedFrameCount);
-                break;
+            if (_reportedFailure)
+            {
+                return;
+            }
 
-            case PanoramaAppendStatus.LimitReached:
-                Progress?.Invoke(accumulator.AcceptedFrameCount);
-                ReportLimit(outcome.LimitReason ?? PanoramaCaptureLimitReason.Memory);
-                break;
-        }
-    }
-
-    private void ReportFailure(Exception error)
-    {
-        if (_reportedFailure)
-        {
-            return;
+            _reportedFailure = true;
+            _owner.RaiseFailed(this, error);
         }
 
-        _reportedFailure = true;
-        Failed?.Invoke(error);
-    }
-
-    private void ReportLimit(PanoramaCaptureLimitReason reason)
-    {
-        if (_reportedLimit)
+        private void ReportLimit(PanoramaCaptureLimitReason reason)
         {
-            return;
-        }
+            if (_reportedLimit)
+            {
+                return;
+            }
 
-        _reportedLimit = true;
-        LimitReached?.Invoke(reason);
+            _reportedLimit = true;
+            _owner.RaiseLimit(this, reason);
+        }
     }
 }

--- a/windows/src/TinyClips.Core/Capture/ScrollingCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/ScrollingCaptureService.cs
@@ -1,0 +1,249 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace TinyClips.Core.Capture;
+
+/// <summary>
+/// WGC-backed <see cref="IScrollingCaptureService"/>. Frames arrive on the WGC thread only when
+/// the screen changes; they are throttled to ~12 fps and handed to a single consumer task that
+/// owns the <see cref="PanoramaAccumulator"/>, so stitching never blocks frame delivery.
+/// </summary>
+public sealed class ScrollingCaptureService : IScrollingCaptureService, IDisposable
+{
+    private static readonly TimeSpan MinFrameInterval = TimeSpan.FromSeconds(1.0 / 12);
+
+    private readonly object _gate = new();
+
+    private ContinuousCaptureSession? _session;
+    private PanoramaAccumulator? _accumulator;
+    private Channel<CapturedFrame>? _channel;
+    private Task? _consumer;
+    private long _lastEnqueuedTimestamp;
+    private volatile bool _finished = true;
+    private bool _reportedLimit;
+    private bool _reportedFailure;
+
+    public bool IsActive
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _session is not null;
+            }
+        }
+    }
+
+    public event Action<int>? Progress;
+
+    public event Action<PanoramaCaptureLimitReason>? LimitReached;
+
+    public event Action<Exception>? Failed;
+
+    public Task StartAsync(CaptureTarget target, PixelRect? region, PanoramaCaptureLimits limits, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ContinuousCaptureSession session;
+        lock (_gate)
+        {
+            if (_session is not null)
+            {
+                throw new InvalidOperationException("A scrolling capture is already active.");
+            }
+
+            _accumulator = new PanoramaAccumulator(limits);
+            _channel = Channel.CreateBounded<CapturedFrame>(new BoundedChannelOptions(4)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+            _finished = false;
+            _reportedLimit = false;
+            _reportedFailure = false;
+            _lastEnqueuedTimestamp = 0;
+
+            session = new ContinuousCaptureSession(target, region, targetFps: 12, includeCursor: false);
+            session.FrameArrived += OnFrameArrived;
+            try
+            {
+                session.Start();
+            }
+            catch
+            {
+                session.FrameArrived -= OnFrameArrived;
+                session.Dispose();
+                _channel = null;
+                _accumulator = null;
+                _finished = true;
+                throw;
+            }
+
+            _session = session;
+            var reader = _channel.Reader;
+            var accumulator = _accumulator;
+            _consumer = Task.Run(() => ConsumeAsync(reader, accumulator), CancellationToken.None);
+        }
+
+        CaptureFlowTrace.Mark("scrolling: capture started");
+        return Task.CompletedTask;
+    }
+
+    public async Task<CapturedFrame> StopAsync()
+    {
+        PanoramaAccumulator accumulator;
+        Task? consumer;
+        lock (_gate)
+        {
+            if (_session is null || _accumulator is null)
+            {
+                throw new PanoramaCaptureException(PanoramaCaptureError.Cancelled);
+            }
+
+            accumulator = _accumulator;
+            consumer = _consumer;
+            TearDownSessionLocked();
+        }
+
+        if (consumer is not null)
+        {
+            await consumer.ConfigureAwait(false);
+        }
+
+        var result = accumulator.Finish();
+        CaptureFlowTrace.Mark($"scrolling: stitched {result.FrameCount} frames -> {result.Image.Width}x{result.OutputHeight}");
+        return result.Image;
+    }
+
+    public void Cancel()
+    {
+        lock (_gate)
+        {
+            if (_session is null)
+            {
+                return;
+            }
+
+            TearDownSessionLocked();
+        }
+
+        CaptureFlowTrace.Mark("scrolling: cancelled");
+    }
+
+    public void Dispose() => Cancel();
+
+    /// <summary>Stops WGC, completes the frame channel and clears all per-session state. Caller holds <see cref="_gate"/>.</summary>
+    private void TearDownSessionLocked()
+    {
+        _finished = true;
+        if (_session is { } session)
+        {
+            session.FrameArrived -= OnFrameArrived;
+            try
+            {
+                session.Stop();
+                session.Dispose();
+            }
+            catch
+            {
+                // Best-effort teardown.
+            }
+        }
+
+        _session = null;
+        _channel?.Writer.TryComplete();
+        _channel = null;
+        _accumulator = null;
+        _consumer = null;
+    }
+
+    private void OnFrameArrived(CapturedFrame frame)
+    {
+        if (_finished)
+        {
+            return;
+        }
+
+        // WGC can deliver at the display refresh rate; ~12 fps is plenty for stitching.
+        var now = Stopwatch.GetTimestamp();
+        var last = Interlocked.Read(ref _lastEnqueuedTimestamp);
+        if (last != 0 && Stopwatch.GetElapsedTime(last, now) < MinFrameInterval)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _lastEnqueuedTimestamp, now, last) != last)
+        {
+            return;
+        }
+
+        _channel?.Writer.TryWrite(frame);
+    }
+
+    private async Task ConsumeAsync(ChannelReader<CapturedFrame> reader, PanoramaAccumulator accumulator)
+    {
+        await foreach (var captured in reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            if (_finished || accumulator.ReachedLimit)
+            {
+                continue;
+            }
+
+            try
+            {
+                Process(accumulator, captured);
+            }
+            catch (Exception ex)
+            {
+                ReportFailure(ex);
+            }
+        }
+    }
+
+    private void Process(PanoramaAccumulator accumulator, CapturedFrame captured)
+    {
+        var frame = new PanoramaFrame(captured);
+        if (accumulator.PreviousFrame is { } previous && !PanoramaAccumulator.AreMeaningfullyDifferent(previous, frame))
+        {
+            // The region repainted (caret blink, spinner) without scrolling. Never give up here:
+            // the user may simply be pausing, and Done/Cancel remain available at all times.
+            return;
+        }
+
+        var outcome = accumulator.Append(frame);
+        switch (outcome.Status)
+        {
+            case PanoramaAppendStatus.Accepted:
+                Progress?.Invoke(accumulator.AcceptedFrameCount);
+                break;
+
+            case PanoramaAppendStatus.LimitReached:
+                Progress?.Invoke(accumulator.AcceptedFrameCount);
+                ReportLimit(outcome.LimitReason ?? PanoramaCaptureLimitReason.Memory);
+                break;
+        }
+    }
+
+    private void ReportFailure(Exception error)
+    {
+        if (_reportedFailure)
+        {
+            return;
+        }
+
+        _reportedFailure = true;
+        Failed?.Invoke(error);
+    }
+
+    private void ReportLimit(PanoramaCaptureLimitReason reason)
+    {
+        if (_reportedLimit)
+        {
+            return;
+        }
+
+        _reportedLimit = true;
+        LimitReached?.Invoke(reason);
+    }
+}

--- a/windows/src/TinyClips.Core/Services/ServiceCollectionExtensions.cs
+++ b/windows/src/TinyClips.Core/Services/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOcrService, OcrService>();
         services.AddSingleton<IVideoRecordingService, VideoRecordingService>();
         services.AddSingleton<IGifRecordingService, GifRecordingService>();
+        services.AddSingleton<IScrollingCaptureService, ScrollingCaptureService>();
         services.AddSingleton<IDisplaySleepAssertion, NoOpDisplaySleepAssertion>();
         return services;
     }

--- a/windows/tests/TinyClips.Core.Tests/PanoramaStitcherTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/PanoramaStitcherTests.cs
@@ -46,14 +46,16 @@ public sealed class PanoramaStitcherTests
     [Fact]
     public void RejectsFramesWithoutCredibleAlignment()
     {
-        var first = PanoramaFrameAt(globalStartRow: 0);
+        var accumulator = new PanoramaAccumulator(TestLimits());
+        accumulator.Append(PanoramaFrameAt(globalStartRow: 0));
         var unrelatedPixels = new byte[40 * 100 * 4];
         Array.Fill(unrelatedPixels, (byte)255);
-        var unrelated = new PanoramaFrame(unrelatedPixels, 40, 100);
 
-        var ex = Assert.Throws<PanoramaCaptureException>(
-            () => new PanoramaStitcher(TestLimits()).Stitch(new[] { first, unrelated }));
-        Assert.Equal(PanoramaCaptureError.AlignmentFailed, ex.Error);
+        var outcome = accumulator.Append(new PanoramaFrame(unrelatedPixels, 40, 100));
+
+        Assert.Equal(PanoramaAppendStatus.Skipped, outcome.Status);
+        Assert.Equal(1, accumulator.AcceptedFrameCount);
+        Assert.Null(PanoramaAccumulator.EstimateVerticalShift(accumulator.PreviousFrame!, new PanoramaFrame(unrelatedPixels, 40, 100)));
     }
 
     [Fact]
@@ -70,15 +72,66 @@ public sealed class PanoramaStitcherTests
     }
 
     [Fact]
+    public void SuppressesTallFooterOnSlowScroll()
+    {
+        // A 5 px sticky footer with a 4 px scroll step: the footer is taller than the step and
+        // must still be held back rather than partially appended on every frame.
+        var frames = new[]
+        {
+            PanoramaFrameAt(globalStartRow: 0, fixedFooterHeight: 5),
+            PanoramaFrameAt(globalStartRow: 4, fixedFooterHeight: 5),
+            PanoramaFrameAt(globalStartRow: 8, fixedFooterHeight: 5),
+        };
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(frames);
+
+        // 95 content rows per frame + 2 x 4 scrolled rows + one footer copy.
+        Assert.Equal(108, result.OutputHeight);
+        for (var y = 0; y < 103; y += 3)
+        {
+            Assert.Equal(ExpectedValue(y, x: 0), RedValue(result.Image, x: 0, y: y));
+        }
+
+        for (var y = 103; y < 108; y++)
+        {
+            Assert.Equal((byte)32, RedValue(result.Image, x: 0, y: y));
+        }
+    }
+
+    [Fact]
     public void EnforcesPeakMemoryBudget()
     {
+        // 40x100 frames are 16 000 bytes. Frame 1 needs 16 000 (buffer) + 16 000 (copy) + 32 000
+        // (two frames) = 64 000; stitching frame 2 needs 70 400, so a 70 000 budget keeps frame 1 only.
         var first = PanoramaFrameAt(globalStartRow: 0);
         var second = PanoramaFrameAt(globalStartRow: 20);
         var limits = TestLimits() with { MaxMemoryBytes = 70_000 };
 
-        var ex = Assert.Throws<PanoramaCaptureException>(
-            () => new PanoramaStitcher(limits).Stitch(new[] { first, second }));
-        Assert.Equal(PanoramaCaptureError.MemoryLimit, ex.Error);
+        var result = new PanoramaStitcher(limits).Stitch(new[] { first, second });
+
+        Assert.True(result.ReachedLimit);
+        Assert.Equal(1, result.FrameCount);
+        Assert.Equal(100, result.OutputHeight);
+    }
+
+    [Fact]
+    public void MemoryBudgetAccountsForBufferOverAllocation()
+    {
+        // Stitching frame 3 grows the buffer from 19 200 to 33 600 bytes (1.5x the 22 400 logical
+        // size). The naive "2x logical + 2 frames" estimate is 76 800 and would pass an 80 000
+        // budget, but the real peak (33 600 + 22 400 + 32 000 = 88 000) must be what is enforced.
+        var frames = new[]
+        {
+            PanoramaFrameAt(globalStartRow: 0),
+            PanoramaFrameAt(globalStartRow: 20),
+            PanoramaFrameAt(globalStartRow: 40),
+        };
+        var limits = TestLimits() with { MaxMemoryBytes = 80_000 };
+
+        var result = new PanoramaStitcher(limits).Stitch(frames);
+
+        Assert.True(result.ReachedLimit);
+        Assert.Equal(2, result.FrameCount);
     }
 
     [Fact]
@@ -90,7 +143,8 @@ public sealed class PanoramaStitcherTests
             PanoramaFrameAt(globalStartRow: 20),
             PanoramaFrameAt(globalStartRow: 40),
         };
-        var limits = TestLimits() with { MaxMemoryBytes = 75_000 };
+        // Frame 2 peaks at 70 400 bytes, frame 3 at 88 000 (see MemoryBudgetAccountsForBufferOverAllocation).
+        var limits = TestLimits() with { MaxMemoryBytes = 82_000 };
 
         var result = new PanoramaStitcher(limits).Stitch(frames);
 
@@ -141,7 +195,8 @@ public sealed class PanoramaStitcherTests
         const int outputHeight = height + (shiftPerFrame * 150);
         const long outputBytes = (long)width * outputHeight * 4;
 
-        Assert.True((outputBytes * 2) + (frameBytes * 2) <= PanoramaCaptureLimits.Default.MaxMemoryBytes);
+        // Buffer capacity can reach 1.5x the logical size; plus the final copy and two frames.
+        Assert.True((outputBytes * 2.5) + (frameBytes * 2) <= PanoramaCaptureLimits.Default.MaxMemoryBytes);
         Assert.True(outputHeight <= PanoramaCaptureLimits.Default.MaxOutputHeight);
     }
 
@@ -248,13 +303,34 @@ public sealed class PanoramaStitcherTests
     }
 
     [Fact]
-    public void Finish_WithSingleFrame_ReportsNoMovement()
+    public void Finish_WithSingleFrame_ReturnsThatFrame()
+    {
+        // Stopping must always produce an image from whatever was captured, even before any scroll.
+        var accumulator = new PanoramaAccumulator(TestLimits());
+        var only = PanoramaFrameAt(globalStartRow: 0);
+        accumulator.Append(only);
+
+        var result = accumulator.Finish();
+
+        Assert.Equal(1, result.FrameCount);
+        Assert.Equal(100, result.OutputHeight);
+        Assert.Same(only.BgraPixels, result.Image.BgraPixels);
+        Assert.False(result.ReachedLimit);
+    }
+
+    [Fact]
+    public void Finish_WithOnlyUnalignableFrames_ReturnsFirstFrame()
     {
         var accumulator = new PanoramaAccumulator(TestLimits());
         accumulator.Append(PanoramaFrameAt(globalStartRow: 0));
+        var unrelatedPixels = new byte[40 * 100 * 4];
+        Array.Fill(unrelatedPixels, (byte)255);
+        accumulator.Append(new PanoramaFrame(unrelatedPixels, 40, 100));
 
-        var ex = Assert.Throws<PanoramaCaptureException>(() => accumulator.Finish());
-        Assert.Equal(PanoramaCaptureError.NoMovement, ex.Error);
+        var result = accumulator.Finish();
+
+        Assert.Equal(1, result.FrameCount);
+        Assert.Equal(ExpectedValue(50, x: 0), RedValue(result.Image, x: 0, y: 50));
     }
 
     [Fact]

--- a/windows/tests/TinyClips.Core.Tests/PanoramaStitcherTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/PanoramaStitcherTests.cs
@@ -1,0 +1,342 @@
+using TinyClips.Core.Capture;
+
+namespace TinyClips.Core.Tests;
+
+public sealed class PanoramaStitcherTests
+{
+    private static PanoramaCaptureLimits TestLimits() => new(
+        MaxFrames: 10,
+        MaxOutputHeight: 1_000,
+        MaxMemoryBytes: 2_000_000);
+
+    [Fact]
+    public void StitchesKnownVerticalShift()
+    {
+        var first = PanoramaFrameAt(globalStartRow: 0);
+        var second = PanoramaFrameAt(globalStartRow: 20);
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(new[] { first, second });
+
+        Assert.Equal(2, result.FrameCount);
+        Assert.Equal(120, result.OutputHeight);
+        Assert.Equal(40, result.Image.Width);
+        Assert.Equal(120, result.Image.Height);
+        Assert.False(result.ReachedLimit);
+    }
+
+    [Fact]
+    public void StitchedRowsMatchSourceContent()
+    {
+        var frames = new[]
+        {
+            PanoramaFrameAt(globalStartRow: 0),
+            PanoramaFrameAt(globalStartRow: 20),
+            PanoramaFrameAt(globalStartRow: 40),
+        };
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(frames);
+
+        Assert.Equal(140, result.OutputHeight);
+        for (var y = 0; y < result.OutputHeight; y += 7)
+        {
+            Assert.Equal(ExpectedValue(y, x: 3), RedValue(result.Image, x: 3, y: y));
+        }
+    }
+
+    [Fact]
+    public void RejectsFramesWithoutCredibleAlignment()
+    {
+        var first = PanoramaFrameAt(globalStartRow: 0);
+        var unrelatedPixels = new byte[40 * 100 * 4];
+        Array.Fill(unrelatedPixels, (byte)255);
+        var unrelated = new PanoramaFrame(unrelatedPixels, 40, 100);
+
+        var ex = Assert.Throws<PanoramaCaptureException>(
+            () => new PanoramaStitcher(TestLimits()).Stitch(new[] { first, unrelated }));
+        Assert.Equal(PanoramaCaptureError.AlignmentFailed, ex.Error);
+    }
+
+    [Fact]
+    public void SuppressesStationaryFooterCopies()
+    {
+        var first = PanoramaFrameAt(globalStartRow: 0, fixedFooterHeight: 5);
+        var second = PanoramaFrameAt(globalStartRow: 20, fixedFooterHeight: 5);
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(new[] { first, second });
+
+        Assert.Equal(120, result.OutputHeight);
+        Assert.Equal((byte)((95 * 7) % 251), RedValue(result.Image, x: 0, y: 95));
+        Assert.Equal((byte)32, RedValue(result.Image, x: 0, y: 119));
+    }
+
+    [Fact]
+    public void EnforcesPeakMemoryBudget()
+    {
+        var first = PanoramaFrameAt(globalStartRow: 0);
+        var second = PanoramaFrameAt(globalStartRow: 20);
+        var limits = TestLimits() with { MaxMemoryBytes = 70_000 };
+
+        var ex = Assert.Throws<PanoramaCaptureException>(
+            () => new PanoramaStitcher(limits).Stitch(new[] { first, second }));
+        Assert.Equal(PanoramaCaptureError.MemoryLimit, ex.Error);
+    }
+
+    [Fact]
+    public void KeepsPartialResultWhenMemoryLimitIsReached()
+    {
+        var frames = new[]
+        {
+            PanoramaFrameAt(globalStartRow: 0),
+            PanoramaFrameAt(globalStartRow: 20),
+            PanoramaFrameAt(globalStartRow: 40),
+        };
+        var limits = TestLimits() with { MaxMemoryBytes = 75_000 };
+
+        var result = new PanoramaStitcher(limits).Stitch(frames);
+
+        Assert.True(result.ReachedLimit);
+        Assert.Equal(2, result.FrameCount);
+        Assert.Equal(120, result.OutputHeight);
+    }
+
+    [Fact]
+    public void KeepsPartialResultWhenOutputHeightIsReached()
+    {
+        var frames = new[]
+        {
+            PanoramaFrameAt(globalStartRow: 0),
+            PanoramaFrameAt(globalStartRow: 20),
+            PanoramaFrameAt(globalStartRow: 40),
+        };
+        var limits = TestLimits() with { MaxOutputHeight = 130 };
+
+        var result = new PanoramaStitcher(limits).Stitch(frames);
+
+        Assert.True(result.ReachedLimit);
+        Assert.Equal(120, result.OutputHeight);
+    }
+
+    [Fact]
+    public void StopsAtFrameLimit()
+    {
+        var frames = Enumerable.Range(0, 5).Select(i => PanoramaFrameAt(globalStartRow: i * 10)).ToArray();
+        var limits = TestLimits() with { MaxFrames = 3 };
+
+        var result = new PanoramaStitcher(limits).Stitch(frames);
+
+        Assert.True(result.ReachedLimit);
+        Assert.Equal(3, result.FrameCount);
+        Assert.Equal(120, result.OutputHeight);
+    }
+
+    [Fact]
+    public void DefaultMemoryUseDoesNotGrowWithFrameCount()
+    {
+        // Peak memory tracks the stitched output plus the retained and incoming frames, so a
+        // long capture of a modest region must stay well inside the default budget.
+        const int width = 2_400;
+        const int height = 1_800;
+        const long frameBytes = (long)width * height * 4;
+        const int shiftPerFrame = 200;
+        const int outputHeight = height + (shiftPerFrame * 150);
+        const long outputBytes = (long)width * outputHeight * 4;
+
+        Assert.True((outputBytes * 2) + (frameBytes * 2) <= PanoramaCaptureLimits.Default.MaxMemoryBytes);
+        Assert.True(outputHeight <= PanoramaCaptureLimits.Default.MaxOutputHeight);
+    }
+
+    [Fact]
+    public void EditorLimitsCapOutputHeightToTextureMaximum()
+    {
+        Assert.Equal(PanoramaCaptureLimits.EditorMaxOutputHeight, PanoramaCaptureLimits.ForEditor.MaxOutputHeight);
+        Assert.Equal(PanoramaCaptureLimits.Default.MaxMemoryBytes, PanoramaCaptureLimits.ForEditor.MaxMemoryBytes);
+        Assert.True(PanoramaCaptureLimits.ForEditor.MaxOutputHeight < PanoramaCaptureLimits.Default.MaxOutputHeight);
+    }
+
+    [Fact]
+    public void PrefersSmallestShiftOnRepeatingContent()
+    {
+        // A page of repeating rows aliases at shift + N * period; picking a later alias
+        // duplicates rows that are already committed.
+        var first = RepeatingPanoramaFrame(globalStartRow: 0, period: 30);
+        var second = RepeatingPanoramaFrame(globalStartRow: 20, period: 30);
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(new[] { first, second });
+
+        Assert.Equal(2, result.FrameCount);
+        Assert.Equal(120, result.OutputHeight);
+    }
+
+    [Fact]
+    public void AlignsSmallScrollSteps()
+    {
+        // Slow scrolling advances only a few pixels per frame, which must not be rounded up.
+        var first = PanoramaFrameAt(globalStartRow: 0);
+        var second = PanoramaFrameAt(globalStartRow: 4);
+
+        var result = new PanoramaStitcher(TestLimits()).Stitch(new[] { first, second });
+
+        Assert.Equal(104, result.OutputHeight);
+    }
+
+    [Theory]
+    [InlineData(6)]
+    [InlineData(37)]
+    [InlineData(120)]
+    [InlineData(480)]
+    public void AlignsPeriodicContentAcrossShiftSizes(int trueShift)
+    {
+        const int width = 320;
+        const int height = 900;
+        const int period = 100;
+
+        static PanoramaFrame MakeFrame(int globalStartRow)
+        {
+            var pixels = new byte[width * height * 4];
+            for (var y = 0; y < height; y++)
+            {
+                var row = globalStartRow + y;
+                var band = (row % period) < period / 2 ? 40 : 210;
+                for (var x = 0; x < width; x++)
+                {
+                    var index = ((y * width) + x) * 4;
+                    var value = (byte)Math.Clamp(band + ((row % 7) * 3) + ((x % 11) * 2), 0, 255);
+                    pixels[index] = value;
+                    pixels[index + 1] = value;
+                    pixels[index + 2] = value;
+                    pixels[index + 3] = 255;
+                }
+            }
+
+            return new PanoramaFrame(pixels, width, height);
+        }
+
+        var alignment = PanoramaAccumulator.EstimateVerticalShift(MakeFrame(0), MakeFrame(trueShift));
+
+        Assert.NotNull(alignment);
+        Assert.Equal(trueShift, alignment!.Value.Shift);
+    }
+
+    [Fact]
+    public void AreMeaningfullyDifferent_DetectsIdenticalAndScrolledFrames()
+    {
+        var first = PanoramaFrameAt(globalStartRow: 0);
+        var same = PanoramaFrameAt(globalStartRow: 0);
+        var scrolled = PanoramaFrameAt(globalStartRow: 20);
+
+        Assert.False(PanoramaAccumulator.AreMeaningfullyDifferent(first, same));
+        Assert.True(PanoramaAccumulator.AreMeaningfullyDifferent(first, scrolled));
+    }
+
+    [Fact]
+    public void RowLuma_UsesBgraChannelOrder()
+    {
+        // Row 0 is pure blue, row 1 pure red: red carries far more luma than blue.
+        var pixels = new byte[4 * 2 * 4];
+        for (var x = 0; x < 4; x++)
+        {
+            pixels[(x * 4) + 0] = 255;          // B on row 0
+            pixels[(x * 4) + 3] = 255;
+            pixels[((4 + x) * 4) + 2] = 255;    // R on row 1
+            pixels[((4 + x) * 4) + 3] = 255;
+        }
+
+        var frame = new PanoramaFrame(pixels, 4, 2);
+
+        Assert.InRange(frame.RowLuma[0], 28f, 30f);
+        Assert.InRange(frame.RowLuma[1], 76f, 78f);
+    }
+
+    [Fact]
+    public void Finish_WithSingleFrame_ReportsNoMovement()
+    {
+        var accumulator = new PanoramaAccumulator(TestLimits());
+        accumulator.Append(PanoramaFrameAt(globalStartRow: 0));
+
+        var ex = Assert.Throws<PanoramaCaptureException>(() => accumulator.Finish());
+        Assert.Equal(PanoramaCaptureError.NoMovement, ex.Error);
+    }
+
+    [Fact]
+    public void Finish_WithoutFrames_ReportsNoFrames()
+    {
+        var accumulator = new PanoramaAccumulator(TestLimits());
+
+        var ex = Assert.Throws<PanoramaCaptureException>(() => accumulator.Finish());
+        Assert.Equal(PanoramaCaptureError.NoFrames, ex.Error);
+    }
+
+    [Fact]
+    public void Append_SkipsFramesWithDifferentDimensions()
+    {
+        var accumulator = new PanoramaAccumulator(TestLimits());
+        accumulator.Append(PanoramaFrameAt(globalStartRow: 0));
+
+        var outcome = accumulator.Append(new PanoramaFrame(new byte[20 * 50 * 4], 20, 50));
+
+        Assert.Equal(PanoramaAppendStatus.Skipped, outcome.Status);
+        Assert.Equal(1, accumulator.AcceptedFrameCount);
+    }
+
+    [Fact]
+    public void PendingOutputHeight_TracksCommittedRows()
+    {
+        var accumulator = new PanoramaAccumulator(TestLimits());
+        Assert.Equal(0, accumulator.PendingOutputHeight);
+
+        accumulator.Append(PanoramaFrameAt(globalStartRow: 0));
+        Assert.Equal(100, accumulator.PendingOutputHeight);
+
+        accumulator.Append(PanoramaFrameAt(globalStartRow: 20));
+        Assert.Equal(120, accumulator.PendingOutputHeight);
+    }
+
+    private static byte ExpectedValue(int globalRow, int x) => (byte)(((globalRow * 7) + (x * 13)) % 251);
+
+    private static PanoramaFrame PanoramaFrameAt(int globalStartRow, int fixedFooterHeight = 0)
+    {
+        const int width = 40;
+        const int height = 100;
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var index = ((y * width) + x) * 4;
+                var isFooter = fixedFooterHeight > 0 && y >= height - fixedFooterHeight;
+                var value = isFooter ? (byte)32 : ExpectedValue(globalStartRow + y, x);
+                pixels[index] = value;
+                pixels[index + 1] = value;
+                pixels[index + 2] = value;
+                pixels[index + 3] = 255;
+            }
+        }
+
+        return new PanoramaFrame(pixels, width, height);
+    }
+
+    private static PanoramaFrame RepeatingPanoramaFrame(int globalStartRow, int period)
+    {
+        const int width = 40;
+        const int height = 100;
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            var row = (globalStartRow + y) % period;
+            for (var x = 0; x < width; x++)
+            {
+                var index = ((y * width) + x) * 4;
+                var value = (byte)(((row * 8) + (x * 3)) % 251);
+                pixels[index] = value;
+                pixels[index + 1] = value;
+                pixels[index + 2] = value;
+                pixels[index + 3] = 255;
+            }
+        }
+
+        return new PanoramaFrame(pixels, width, height);
+    }
+
+    private static byte RedValue(CapturedFrame image, int x, int y)
+        => image.BgraPixels[(((y * image.Width) + x) * 4) + 2];
+}


### PR DESCRIPTION
Closes #272

## Summary
Ports the macOS scrolling/panorama capture to Windows. The Screenshot picker gains a **Scroll** action (`P`): select a region, scroll the page normally, press **Done** (Enter) on the floating panel to stitch every frame into one tall image that flows through the existing save / clipboard / editor path; **Cancel** (Esc) discards.

## Core (`TinyClips.Core/Capture`)
- `PanoramaFrame`, `PanoramaAccumulator`, `PanoramaStitcher` — faithful port of the mac row-luma SAD alignment (pixel-verified, smallest-credible-shift for periodic content, stationary footer band held back and written once).
- `PanoramaCaptureLimits` — 600 frames, ~1.2 GB peak memory, **adaptive max height**: 16 384 px when the editor will open the result (Win2D/XAML texture cap), 50 000 px for direct save. Limits auto-stop and save what was captured.
- `ScrollingCaptureService` — WGC arrival-driven loop via a new `ContinuousCaptureSession.FrameArrived` event (~12 fps throttle), single-consumer channel so stitching never blocks WGC delivery.
- 22 unit tests ported from `CaptureMathTests.swift` + BGRA/limit coverage.

## App
- `CapturePickerMode.Scrolling`, Scroll button (screenshot mode only) and `P` key.
- `ScrollingCaptureWindow` — acrylic floating panel with pulsing dot + frame count, status line, Done/Cancel, Enter/Esc, draggable, excluded from capture, automation names/help text.
- `App.xaml.cs` orchestration; screenshot present tail extracted to `PresentScreenshotFrameAsync` and shared.
- Guide, README, changelog; plan in `plans/windows-scrolling-capture.md`.

## Design decisions
- No no-movement auto-fail: a live test showed a blinking caret in the region trips it while the user lines up Done. Capture stays open until Done/Cancel or a limit.
- No new global hotkey (mac parity).

## Validation
- `dotnet build` x64 Debug + `-p:TinyClipsStoreBuild=true`: clean (no new warnings)
- `dotnet test` Core: 142/142 pass
- Live UIA-driven test: Notepad 400-line file, 32 frames → 900×2640 seamless image (lines 002→121 continuous, no dupes), opened in editor and saved; `P` key, Esc cancel, picker reopen all verified.
