### PR TITLE
Windows: harden A/V sync (drift correction, pause fixes, audio offset, sync report)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,16 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Audio offset setting** — Settings → Video → Audio → *Audio offset* (−500 … +500 ms, default
+  0) shifts all recorded audio relative to the video. Positive delays audio, negative plays it
+  earlier — the fix for Bluetooth headsets and some USB microphones whose real latency WASAPI
+  does not report. Applied at capture time on the shared recording timeline; a reset button
+  returns to 0.
+- **End-of-recording sync report** — every video recording now writes a `Sync report:` block to
+  `webcam-diagnostics.log`: encoder path, elapsed/paused time, last video PTS, frames emitted and
+  dropped to encoder back-pressure, audio PTS and the audio−video end delta, starved chunks,
+  driver discontinuities, and per-source correction/pad/trim/underrun totals. Lets A/V sync be
+  verified from the log without a listen test (see `docs/audio-video-sync.md`).
 - **Scrolling capture** — The Screenshot picker gains a **Scroll** action (`P`). Select a region,
   scroll the page normally, and press **Done** (Enter) on the floating panel to stitch every frame
   into one tall image that flows into the usual save / editor / clipboard path; **Cancel** (Esc)
@@ -148,6 +158,35 @@ own `CHANGELOG.md` at the repository root.
   `TrayPopupWindow` now unsubscribes its `Activated` handler on closure.
 
 ### Fixed
+- **Pausing a recording for more than 2 seconds no longer silences the rest of the clip** — while
+  paused the audio muxer had no captured frames to hand over, hit its 2 s wait cap and returned a
+  `null` sample, which `MediaStreamSource` treats as end-of-stream for the audio track. The muxer
+  now waits through pauses without a cap, only ends the audio stream at a real stop, and fills a
+  genuinely starved request (no audio device activity for 2 s) with silence instead of ending
+  the track.
+- **Pause/resume no longer shifts audio earlier than video** — pausing used to discard audio that
+  had been captured but not yet muxed, and resuming appended the next packet contiguously, so every
+  pause moved the remainder of the audio track earlier by the discarded amount. Captured audio is
+  now retained through the pause and the resumed packet is placed on the paused-adjusted timeline.
+  The screen pump also keeps its last frame through a pause so video resumes immediately on a
+  static desktop.
+- **Audio can no longer drift or jump out of sync over a recording** — audio was appended
+  contiguously forever after the first packet, so a WASAPI buffer overrun (dropped packet), a
+  microphone whose clock runs fast or slow against the system clock, or two sources at slightly
+  different rates would silently slide the audio track relative to the video for the rest of the
+  recording. `TimelineAlignedWaveProvider` now tracks each source's expected position on the shared
+  timeline and, only when the deviation exceeds a 30 ms tolerance (or the driver flags
+  `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY`), inserts silence or trims once to snap back. Ordinary
+  per-packet jitter stays far below the tolerance, so the earlier crackle fix is preserved. Zero
+  padding the muxer consumes during an underrun now also counts toward the source's timeline
+  position so the following packet cannot land late behind it.
+- **Audio track now ends where the video does** — stopping a recording ended the audio stream
+  immediately, discarding up to a few hundred milliseconds of already-captured audio. The recorder
+  now stops the devices, drains the remaining captured audio into the muxer (bounded to 500 ms),
+  and only then ends the stream.
+- **Resampled microphones (e.g. 44.1 kHz) no longer crackle at the read edge** — the muxer's
+  back-pressure gate now keeps a 20 ms margin for sources that go through the resampler, so the
+  resampler's lookahead never reads past captured data.
 - **Hardened tray-first startup** — Launch no longer eagerly creates the off-screen UI Automation
   announcement window; it is created lazily on the first Narrator announcement and degrades to a
   log line if window creation fails. Hotkey registration, onboarding, and file activation are

--- a/windows/README.md
+++ b/windows/README.md
@@ -101,7 +101,8 @@ For coordinate/DPI behaviour across mixed-DPI monitors, see
 [`docs/dpi-and-coordinates.md`](docs/dpi-and-coordinates.md).
 
 For how the screen, webcam, microphone, and system audio are kept in sync (shared timeline,
-WASAPI capture, and audio back-pressure), see [`docs/audio-video-sync.md`](docs/audio-video-sync.md).
+WASAPI capture, drift/discontinuity correction, audio back-pressure, the *Audio offset* setting, and
+the end-of-recording sync report), see [`docs/audio-video-sync.md`](docs/audio-video-sync.md).
 
 ## CI
 

--- a/windows/docs/audio-video-sync.md
+++ b/windows/docs/audio-video-sync.md
@@ -61,6 +61,51 @@ were hard-won; each exists to fix a specific defect:
    lines up with video captured at the same wall-clock instant. (Some drivers report `0` here; the
    dominant sync mechanism is the back-pressure below.)
 
+5. **Apply the user's audio offset.** Settings → Video → Audio → *Audio offset* (±500 ms) is added
+   to every packet's target position. Positive delays audio; negative plays it earlier. This is the
+   escape hatch for Bluetooth headsets and some USB microphones whose real latency WASAPI does not
+   report (they stamp packets on arrival, so their audio lands late).
+
+## Drift and discontinuity correction
+
+Rule 1 (append contiguously) on its own lets a source silently slide against the video clock:
+
+- a WASAPI buffer overrun drops a packet, and everything after it moves earlier;
+- a microphone whose crystal runs 50–100 ppm fast or slow drifts hundreds of milliseconds per hour;
+- two sources at slightly different real rates make the faster one pile up in its buffer until
+  `DiscardOnBufferOverflow` throws away a chunk;
+- a pause/resume cycle removes packets from the middle of the stream.
+
+So `TimelineAlignedWaveProvider` still computes every packet's **expected position**
+(`timeline.Normalize(ts) − latency + userOffset`, in source frames) and compares it with the frames
+written so far. If the deviation is within **`DriftTolerance` (30 ms)** the packet is appended
+contiguously — that covers all ordinary jitter, so the crackle fix holds. Only when the deviation
+exceeds the tolerance, or the driver flagged the packet with `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY`
+(surfaced by `TimestampedWasapiCapture`), is the stream corrected **once**: silence is inserted for a
+gap, or frames are trimmed from the front of the packet (and following packets, if needed) for an
+overlap. Each correction is logged as `sync correction: padded/trimmed … ms`.
+
+The first packet after the origin is simply a forced, exact correction — the same code path anchors
+the source to the origin.
+
+**Underruns count as written.** If the muxer ever reads past captured audio, the zero padding it
+receives (`ReadFully`) occupies real positions on the output timeline, so `Read` advances the written
+cursor to cover it. The next packet then shows as an overlap and is trimmed, instead of landing late
+behind silence the muxer already consumed.
+
+### Pause and resume
+
+- `RecordingTimeline.Pause/Resume` exclude the paused interval from `Normalize`, so video PTS and
+  audio expected positions both continue seamlessly from the pause point.
+- `TimelineAlignedWaveProvider.Pause()` stops accepting packets but **keeps** already-captured audio:
+  it belongs to pre-pause video time and the muxer still has to drain it. (It used to be cleared,
+  which shifted every later sample earlier by the discarded amount.)
+- `Resume()` needs no special re-alignment: the first post-resume packet is compared against the
+  paused-adjusted timeline like any other and corrected only if it is out of tolerance.
+- `ContinuousCaptureSession.PauseEmitting` keeps capturing into its cached frame so the pump can
+  emit the current screen the instant recording resumes, even on a static desktop.
+- The muxer's audio request waits **without a cap** while paused (see back-pressure below).
+
 ## Clean capture — `TimestampedWasapiCapture`
 
 A custom WASAPI capture (rather than NAudio's `WasapiCapture`) so packets carry their QPC capture
@@ -92,7 +137,20 @@ all sources (`AudioCaptureService.AvailableFrames`, the minimum buffered duratio
 
 - Audio can never get ahead of real capture progress → **no racing / no delay**.
 - We never read an empty buffer → **no silence-splicing crackle**.
-- A 2 s wait cap prevents a stalled capture from hanging the transcode pull.
+- Sources that go through the resampler (e.g. 44.1 kHz microphones) keep a 20 ms margin so the
+  resampler's lookahead never reads past captured data.
+- **While paused there is no wait cap.** No audio arrives by design; ending the wait would hand the
+  muxer a sample it must not have.
+- When *not* paused, a 2 s cap prevents a dead device from hanging the transcode. A starved request
+  is filled with **silence** (logged as `Audio muxer starved`) — it is never answered with `null`,
+  because `MediaStreamSource` treats a `null` sample as **end of the audio stream**. (That was the
+  original "pause for more than 2 s and the rest of the clip is silent" bug.)
+
+### Ending the audio track
+
+`StopAsync` stops the WASAPI devices, then switches the muxer into a **drain** mode that serves the
+remaining captured frames (bounded to 500 ms, `MaxDrainFrames`) and only then answers `null`. This
+is what makes the audio track end where the video ends instead of a few hundred milliseconds early.
 
 > **Do not** gate audio reads to `timeline.Elapsed` (the recording wall clock). An earlier version
 > did, and it still read whenever the buffer was momentarily thin (WASAPI capture latency), splicing
@@ -113,11 +171,53 @@ Per-recording tracing is written to `webcam-diagnostics.log` (packaged app:
 debugging sync/audio:
 
 - `Audio capture loop started … latencyMs=…` — WASAPI stream latency and buffer/poll settings.
-- `TimelineAlignedWaveProvider aligned: sourceOffsetMs=… latencyMs=… trimFrames/padFrames=…` — how
-  the first packet landed on the origin.
+- `TimelineAlignedWaveProvider[source] aligned: padded/trimmed … ms (sourceOffsetMs=… latencyMs=… userOffsetMs=…)`
+  — how the first packet landed on the origin.
+- `TimelineAlignedWaveProvider[source] sync correction: …` — a drift/discontinuity correction fired.
+  Zero of these in a normal recording; one or two over a long recording with a drifting device is
+  expected and each is ≤ the accumulated drift.
+- `Audio packet discontinuity (…)` / `Audio packet timestamp jump (…)` — the driver lost data (or
+  its timestamps jumped) before this packet. The provider corrects it; this is the evidence.
+- `Audio muxer starved` — no captured audio for 2 s while not paused; silence was substituted.
 - `First screen frame emitted: ptsMs=…` — where the video stream starts.
 - `Audio muxer progress: requests=… nonSilentChunks=… framesRead=…` — verify `framesRead` tracks
   real elapsed time (≈ `SampleRate × seconds`); if it runs ahead, back-pressure isn't holding.
+
+### Sync report
+
+Every recording ends with a `Sync report:` block:
+
+```
+Sync report: encoder='software H.264 Baseline (fallback)' elapsed=12.345s pauses=1 pausedTotal=3.012s.
+Sync report: video lastPts=12.331s framesEmitted=370 framesDroppedByEncoderBackpressure=0.
+Sync report: audio pts=12.340s chunks=617 nonSilent=540 starvedChunks=0 drainedFrames=432 userOffsetMs=0 driverDiscontinuities=0.
+Sync report: audio-video end delta=9.0ms (audio longer; |delta| < 30 ms is healthy).
+Sync report: system/loopback: written=12.340s corrections=0 padded=0.0ms trimmed=0.0ms underrun=0.0ms preOriginDropped=3 lastDeviation=0.4ms maxDeviation=1.1ms
+Sync report: microphone: written=12.340s corrections=0 padded=0.0ms trimmed=0.0ms underrun=0.0ms preOriginDropped=2 lastDeviation=-0.8ms maxDeviation=2.3ms
+```
+
+Healthy values: `|delta|` well under 30 ms, `corrections=0` (or a handful on very long recordings),
+`starvedChunks=0`, `underrun=0`, `maxDeviation` a few ms. A large `framesDropped…` count only means
+the encoder could not keep up (lower effective frame rate) — video PTS is wall-clock, so it does not
+affect sync.
+
+## Hardware listen-test checklist
+
+Unit tests cover the timeline math; these need a real machine (record, then open the clip and the
+`Sync report` block):
+
+1. **Clap test** — record the screen with microphone, clap on camera (webcam overlay on) or against
+   a visible on-screen metronome; the transient must land on the visual within a frame.
+2. **Pause** — record 10 s, pause ≥ 5 s, resume, record 10 s more. Audio must be present after the
+   pause and still aligned; `pauses=1`, `corrections` 0 or 1.
+3. **Long recording** — 15+ minutes with mic + system audio; `delta` stays < 30 ms, and any
+   `sync correction` lines are small (tens of ms).
+4. **Mic + system together** — play a video with speech while talking; both tracks stay aligned to
+   the picture, neither creeps ahead of the other.
+5. **Bluetooth / USB mic** — if audio lands late, set a negative *Audio offset* (start at −150 ms)
+   and confirm the report shows `userOffsetMs` and the clap test passes.
+6. **Stop edge** — speak right up to pressing Stop; the last word must be in the file (`drainedFrames`
+   > 0).
 
 ## See also
 

--- a/windows/docs/audio-video-sync.md
+++ b/windows/docs/audio-video-sync.md
@@ -191,12 +191,14 @@ Every recording ends with a `Sync report:` block:
 Sync report: encoder='software H.264 Baseline (fallback)' elapsed=12.345s pauses=1 pausedTotal=3.012s.
 Sync report: video lastPts=12.331s framesEmitted=370 framesDroppedByEncoderBackpressure=0.
 Sync report: audio pts=12.340s chunks=617 nonSilent=540 starvedChunks=0 drainedFrames=432 userOffsetMs=0 driverDiscontinuities=0.
-Sync report: audio-video end delta=9.0ms (audio longer; |delta| < 30 ms is healthy).
+Sync report: audio-video end delta=-0.3ms offset-compensated (raw=-0.3ms vs videoEnd=12.364s; audio shorter; |delta| < 30 ms is healthy).
 Sync report: system/loopback: written=12.340s corrections=0 padded=0.0ms trimmed=0.0ms underrun=0.0ms preOriginDropped=3 lastDeviation=0.4ms maxDeviation=1.1ms
 Sync report: microphone: written=12.340s corrections=0 padded=0.0ms trimmed=0.0ms underrun=0.0ms preOriginDropped=2 lastDeviation=-0.8ms maxDeviation=2.3ms
 ```
 
-Healthy values: `|delta|` well under 30 ms, `corrections=0` (or a handful on very long recordings),
+Healthy values: `|delta|` well under 30 ms (the delta compares the audio end cursor with the *end* of
+the last video sample and subtracts the configured audio offset, so a deliberate offset does not look
+like an error), `corrections=0` (or a handful on very long recordings),
 `starvedChunks=0`, `underrun=0`, `maxDeviation` a few ms. A large `framesDropped…` count only means
 the encoder could not keep up (lower effective frame rate) — video PTS is wall-clock, so it does not
 affect sync.

--- a/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
@@ -98,6 +98,33 @@
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
+
+                <controls:SettingsCard
+                    Description="Fine-tune audio timing if recorded sound lands early or late. Positive delays audio; negative plays it earlier (try negative for Bluetooth headsets). 0 is right for most setups."
+                    Header="Audio offset"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xEC4A;}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <NumberBox
+                            Width="140"
+                            AutomationProperties.AutomationId="AudioOffsetNumberBox"
+                            AutomationProperties.Name="Audio offset in milliseconds"
+                            LargeChange="50"
+                            Maximum="500"
+                            Minimum="-500"
+                            SmallChange="10"
+                            SpinButtonPlacementMode="Inline"
+                            ToolTipService.ToolTip="Milliseconds, -500 to +500"
+                            Value="{x:Bind ViewModel.AudioOffsetMilliseconds, Mode=TwoWay}" />
+                        <Button
+                            AutomationProperties.AutomationId="AudioOffsetResetButton"
+                            AutomationProperties.Name="Reset audio offset to zero"
+                            Command="{x:Bind ViewModel.ResetAudioOffsetCommand}"
+                            IsEnabled="{x:Bind ViewModel.AudioOffsetIsNonZero, Mode=OneWay}"
+                            ToolTipService.ToolTip="Reset to 0 ms">
+                            <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                        </Button>
+                    </StackPanel>
+                </controls:SettingsCard>
             </StackPanel>
 
             <InfoBar

--- a/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Dispatching;
 using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
@@ -388,6 +389,16 @@ public sealed partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _microphoneLimiterEnabled = true;
 
+    /// <summary>Manual A/V offset in ms; positive delays audio, negative plays it earlier.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(AudioOffsetIsNonZero))]
+    private double _audioOffsetMilliseconds;
+
+    public bool AudioOffsetIsNonZero => Math.Abs(AudioOffsetMilliseconds) >= 0.5;
+
+    [RelayCommand]
+    private void ResetAudioOffset() => AudioOffsetMilliseconds = 0;
+
     /// <summary>Microphone devices for the picker (first entry is the system default).</summary>
     public System.Collections.ObjectModel.ObservableCollection<AudioInputDevice> Microphones { get; } = new();
 
@@ -754,6 +765,7 @@ public sealed partial class SettingsViewModel : ObservableObject
             RecordAudio = _settings.RecordAudio;
             RecordMicrophone = _settings.RecordMicrophone;
             MicrophoneLimiterEnabled = _settings.MicrophoneLimiterEnabled;
+            AudioOffsetMilliseconds = _settings.AudioOffsetMilliseconds;
 
             _savedMicrophoneId = _settings.SelectedMicrophoneId ?? string.Empty;
             WebcamEnabled = _settings.WebcamEnabled;
@@ -1138,6 +1150,18 @@ public sealed partial class SettingsViewModel : ObservableObject
     partial void OnRecordMicrophoneChanged(bool value) => Persist(() => _settings.RecordMicrophone = value);
 
     partial void OnMicrophoneLimiterEnabledChanged(bool value) => Persist(() => _settings.MicrophoneLimiterEnabled = value);
+
+    partial void OnAudioOffsetMillisecondsChanged(double value)
+    {
+        // NumberBox reports NaN when its text is cleared; treat that as "no offset".
+        if (double.IsNaN(value))
+        {
+            AudioOffsetMilliseconds = 0;
+            return;
+        }
+
+        Persist(() => _settings.AudioOffsetMilliseconds = (int)Math.Round(value));
+    }
 
     partial void OnSelectedMicrophoneChanged(AudioInputDevice? value) =>
         Persist(() => _settings.SelectedMicrophoneId = value?.Id ?? string.Empty);

--- a/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
@@ -21,8 +21,15 @@ public sealed class AudioCaptureService : IDisposable
     private readonly bool _captureMic;
     private readonly string? _micDeviceId;
     private readonly bool _limitMicrophone;
+    private readonly TimeSpan _userOffset;
     private readonly object _gate = new();
     private readonly List<TimelineAlignedWaveProvider> _buffers = new();
+
+    // Resampled sources (e.g. 44.1 kHz microphones) feed a WDL resampler that pulls a little more
+    // source audio than the 48 kHz frames it produces. Keep this much extra buffered before
+    // declaring frames "available" so the resampler never reads past captured data (which would
+    // splice in zeros and crackle).
+    private static readonly TimeSpan ResamplerReadMargin = TimeSpan.FromMilliseconds(20);
 
     private TimestampedWasapiCapture? _loopback;
     private TimestampedWasapiCapture? _mic;
@@ -38,12 +45,16 @@ public sealed class AudioCaptureService : IDisposable
     /// the microphone source before mixing so hot input rounds off instead of hard-clipping.
     /// System/loopback audio is never limited.
     /// </param>
-    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId, bool limitMicrophone)
+    /// <param name="userOffset">
+    /// Manual A/V correction applied to every source. Positive delays audio relative to video.
+    /// </param>
+    public AudioCaptureService(bool captureSystem, bool captureMic, string? micDeviceId, bool limitMicrophone, TimeSpan userOffset = default)
     {
         _captureSystem = captureSystem;
         _captureMic = captureMic;
         _micDeviceId = micDeviceId;
         _limitMicrophone = limitMicrophone;
+        _userOffset = userOffset;
     }
 
     /// <summary>True once at least one requested source started successfully.</summary>
@@ -111,15 +122,18 @@ public sealed class AudioCaptureService : IDisposable
         {
             var capture = CreateCapture(isLoopback);
 
-            var buffer = new TimelineAlignedWaveProvider(capture.WaveFormat);
+            var buffer = new TimelineAlignedWaveProvider(capture.WaveFormat, sourceName)
+            {
+                UserOffset = _userOffset,
+            };
 
-            capture.DataAvailable += (data, count, sourceTimestamp) =>
+            capture.DataAvailable += (data, count, sourceTimestamp, discontinuity) =>
             {
                 lock (_gate)
                 {
                     if (!_disposed && !_paused)
                     {
-                        buffer.AddSamples(data, count, sourceTimestamp);
+                        buffer.AddSamples(data, count, sourceTimestamp, discontinuity);
                     }
                 }
             };
@@ -218,7 +232,7 @@ public sealed class AudioCaptureService : IDisposable
     /// active sources (the minimum, since the mixer advances every source in lockstep). Used to
     /// pace the muxer to real capture progress so audio is never padded ahead of real time
     /// (which would race the audio track ~1s ahead) nor read from an empty buffer (which splices
-    /// in silence and crackles).
+    /// in silence and crackles). Audio captured before a pause remains available while paused.
     /// </summary>
     public int AvailableFrames
     {
@@ -226,7 +240,7 @@ public sealed class AudioCaptureService : IDisposable
         {
             lock (_gate)
             {
-                if (_disposed || _paused || _buffers.Count == 0)
+                if (_disposed || _buffers.Count == 0)
                 {
                     return 0;
                 }
@@ -235,13 +249,18 @@ public sealed class AudioCaptureService : IDisposable
                 foreach (var buffer in _buffers)
                 {
                     var buffered = buffer.BufferedDuration;
+                    if (buffer.WaveFormat.SampleRate != SampleRate)
+                    {
+                        buffered -= ResamplerReadMargin;
+                    }
+
                     if (buffered < min)
                     {
                         min = buffered;
                     }
                 }
 
-                if (min == TimeSpan.MaxValue)
+                if (min == TimeSpan.MaxValue || min <= TimeSpan.Zero)
                 {
                     return 0;
                 }
@@ -251,15 +270,30 @@ public sealed class AudioCaptureService : IDisposable
         }
     }
 
+    /// <summary>Snapshot of per-source sync bookkeeping for diagnostics.</summary>
+    internal IReadOnlyList<TimelineAlignedWaveProvider.SyncStats> GetSyncStats()
+    {
+        lock (_gate)
+        {
+            return _buffers.Select(b => b.GetStats()).ToList();
+        }
+    }
+
+    /// <summary>Packets the WASAPI drivers flagged as following lost data, across both sources.</summary>
+    public long DriverDiscontinuityCount =>
+        (_loopback?.DiscontinuityCount ?? 0) + (_mic?.DiscontinuityCount ?? 0);
+
     /// <summary>
     /// Reads up to <paramref name="frameCount"/> frames (samples per channel) of mixed audio
-    /// as interleaved 16-bit stereo PCM. Returns a silence-padded full buffer while active.
+    /// as interleaved 16-bit stereo PCM. Returns a silence-padded full buffer while active, so
+    /// the only <c>null</c> result is after disposal. (Pausing does not block reads: audio that
+    /// was captured before the pause still has to reach the muxer.)
     /// </summary>
     public byte[]? ReadChunk(int frameCount)
     {
         lock (_gate)
         {
-            if (_disposed || _paused || _output is null)
+            if (_disposed || _output is null || frameCount <= 0)
             {
                 return null;
             }
@@ -296,7 +330,7 @@ public sealed class AudioCaptureService : IDisposable
 
             foreach (var buffer in _buffers)
             {
-                buffer.BeginTimeline(timeline.Origin);
+                buffer.BeginTimeline(timeline);
             }
         }
     }

--- a/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
+++ b/windows/src/TinyClips.Core/Capture/ContinuousCaptureSession.cs
@@ -66,6 +66,14 @@ internal sealed class ContinuousCaptureSession : IDisposable
     /// <summary>Output height in pixels (region height, or full monitor height), rounded down to even.</summary>
     public int OutputHeight { get; private set; }
 
+    /// <summary>Presentation timestamp of the most recently emitted frame (MinValue if none).</summary>
+    public TimeSpan LastEmittedPts => _lastEmittedPts;
+
+    /// <summary>Frames handed to <see cref="FrameReady"/> since <see cref="BeginEmitting"/>.</summary>
+    public long EmittedFrameCount => Interlocked.Read(ref _emittedFrameCount);
+
+    private long _emittedFrameCount;
+
     public ContinuousCaptureSession(CaptureTarget target, PixelRect? region, int targetFps, bool includeCursor)
     {
         _target = target;
@@ -134,21 +142,22 @@ internal sealed class ContinuousCaptureSession : IDisposable
             _timeline = timeline ?? RecordingTimeline.StartNow();
             _loggedFirstEmit = false;
             _emittingPaused = false;
+            _lastEmittedPts = TimeSpan.MinValue;
+            Interlocked.Exchange(ref _emittedFrameCount, 0);
 
             // Steady-rate pump: re-emits the latest captured frame even when WGC is idle.
             _pump = new Timer(OnPump, null, TimeSpan.Zero, _frameInterval);
         }
     }
 
+    /// <summary>
+    /// Stops emitting frames. WGC keeps capturing into the cached latest frame so that, on
+    /// resume, the pump can emit the current screen immediately instead of waiting for the next
+    /// content change (which on a static desktop might never come).
+    /// </summary>
     public void PauseEmitting()
     {
-        lock (_sync)
-        {
-            _emittingPaused = true;
-            _latestPixels = null;
-            _latestWidth = 0;
-            _latestHeight = 0;
-        }
+        _emittingPaused = true;
     }
 
     public void ResumeEmitting()
@@ -158,7 +167,7 @@ internal sealed class ContinuousCaptureSession : IDisposable
 
     private void OnFrameArrived(Direct3D11CaptureFramePool pool, object? args)
     {
-        if (!_running || _emittingPaused)
+        if (!_running)
         {
             return;
         }
@@ -219,7 +228,7 @@ internal sealed class ContinuousCaptureSession : IDisposable
 
     private void OnPump(object? state)
     {
-        if (!_running)
+        if (!_running || _emittingPaused)
         {
             return;
         }
@@ -269,6 +278,8 @@ internal sealed class ContinuousCaptureSession : IDisposable
             _loggedFirstEmit = true;
             WebcamDiagnostics.Log($"First screen frame emitted: ptsMs={pts.TotalMilliseconds:F1}.");
         }
+
+        Interlocked.Increment(ref _emittedFrameCount);
 
         // Raise outside the lock so heavy per-frame compositing doesn't stall WGC delivery.
         FrameReady?.Invoke(new CapturedFrame(copy, width, height), pts);

--- a/windows/src/TinyClips.Core/Capture/RecordingTimeline.cs
+++ b/windows/src/TinyClips.Core/Capture/RecordingTimeline.cs
@@ -11,6 +11,7 @@ internal sealed class RecordingTimeline
     private readonly object _gate = new();
     private TimeSpan _pausedDuration;
     private TimeSpan? _pauseStartedAt;
+    private int _pauseCount;
 
     private RecordingTimeline(TimeSpan origin)
     {
@@ -36,11 +37,45 @@ internal sealed class RecordingTimeline
         }
     }
 
+    /// <summary>Number of completed or in-progress pauses.</summary>
+    public int PauseCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _pauseCount;
+            }
+        }
+    }
+
+    /// <summary>Total time excluded from the timeline so far (including an in-progress pause).</summary>
+    public TimeSpan PausedDuration
+    {
+        get
+        {
+            lock (_gate)
+            {
+                var paused = _pausedDuration;
+                if (_pauseStartedAt is { } pausedAt)
+                {
+                    paused += GetSystemRelativeTime() - pausedAt;
+                }
+
+                return paused;
+            }
+        }
+    }
+
     public void Pause()
     {
         lock (_gate)
         {
-            _pauseStartedAt ??= GetSystemRelativeTime();
+            if (_pauseStartedAt is null)
+            {
+                _pauseStartedAt = GetSystemRelativeTime();
+                _pauseCount++;
+            }
         }
     }
 

--- a/windows/src/TinyClips.Core/Capture/TimelineAlignedWaveProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/TimelineAlignedWaveProvider.cs
@@ -3,25 +3,54 @@ using NAudio.Wave;
 namespace TinyClips.Core.Capture;
 
 /// <summary>
-/// Places timestamped source packets on a shared recording timeline. The first packet after
-/// <see cref="BeginTimeline"/> is aligned to the shared origin (leading silence is inserted, or
-/// pre-origin frames are trimmed) so independent sources that start at slightly different times
-/// stay in sync. Every subsequent packet is appended contiguously: re-deriving each packet's
-/// position from its (jittery, frame-rounded) timestamp would insert or drop a sample or two on
-/// every ~10 ms packet, producing constant audible crackle.
+/// Places timestamped source packets on a shared recording timeline.
+/// <para>
+/// The first packet after <see cref="BeginTimeline(RecordingTimeline)"/> is aligned to the shared
+/// origin (leading silence is inserted, or pre-origin frames are trimmed) so independent sources
+/// that start at slightly different times stay in sync. Subsequent packets are appended
+/// contiguously: re-deriving each packet's position from its (jittery, frame-rounded) timestamp
+/// would insert or drop a sample or two on every ~10 ms packet, producing constant audible crackle.
+/// </para>
+/// <para>
+/// Contiguous append alone, however, lets the stream silently diverge from the video clock whenever
+/// WASAPI drops a packet (buffer overrun), the device clock drifts against QPC over a long
+/// recording, or a pause/resume cycle removes packets. So every packet's expected position is still
+/// compared against the frames written so far, and when the deviation exceeds
+/// <see cref="DriftTolerance"/> (or the driver flags a discontinuity) the stream is corrected once:
+/// silence is inserted for a gap, or frames are trimmed from the packet front for an overlap. The
+/// tolerance is far above per-packet jitter, so ordinary packets are never touched.
+/// </para>
 /// </summary>
 internal sealed class TimelineAlignedWaveProvider : IWaveProvider
 {
+    /// <summary>
+    /// Deviation a source may accumulate before it is snapped back to the timeline. Well below
+    /// lip-sync detectability (~45 ms) yet far above WASAPI/timer jitter (sub-millisecond).
+    /// </summary>
+    public static readonly TimeSpan DriftTolerance = TimeSpan.FromMilliseconds(30);
+
     private readonly BufferedWaveProvider _buffer;
-    private TimeSpan _origin;
+    private readonly object _statsGate = new();
+    private readonly string _sourceName;
+    private RecordingTimeline? _timeline;
     private TimeSpan _latency;
+    private TimeSpan _userOffset;
     private bool _timelineStarted;
     private bool _aligned;
     private bool _paused;
+    private long _framesWritten;
+    private long _correctionCount;
+    private long _paddedFrames;
+    private long _trimmedFrames;
+    private long _underrunFrames;
+    private long _droppedPreOriginPackets;
+    private TimeSpan _lastDeviation;
+    private TimeSpan _maxAbsDeviation;
 
-    public TimelineAlignedWaveProvider(WaveFormat waveFormat)
+    public TimelineAlignedWaveProvider(WaveFormat waveFormat, string? sourceName = null)
     {
         WaveFormat = waveFormat;
+        _sourceName = sourceName ?? "audio";
         _buffer = new BufferedWaveProvider(waveFormat)
         {
             ReadFully = true,
@@ -36,8 +65,8 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
     public TimeSpan BufferedDuration => _timelineStarted && _aligned ? _buffer.BufferedDuration : TimeSpan.Zero;
 
     /// <summary>
-    /// The source's capture latency. Audio is advanced by this amount during alignment so the
-    /// recorded sound lines up with video captured at the same wall-clock instant.
+    /// The source's capture latency. Audio is advanced by this amount so the recorded sound lines up
+    /// with video captured at the same wall-clock instant.
     /// </summary>
     public TimeSpan Latency
     {
@@ -45,30 +74,91 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
         set => _latency = value;
     }
 
-    public void BeginTimeline(TimeSpan origin)
+    /// <summary>
+    /// User-configured correction. Positive values delay audio relative to video; negative values
+    /// play it earlier (for devices such as Bluetooth headsets whose real latency WASAPI does not
+    /// report).
+    /// </summary>
+    public TimeSpan UserOffset
     {
-        _origin = origin;
+        get => _userOffset;
+        set => _userOffset = value;
+    }
+
+    /// <summary>Total frames placed on the timeline so far, including inserted silence.</summary>
+    public long FramesWritten => Interlocked.Read(ref _framesWritten);
+
+    public SyncStats GetStats()
+    {
+        lock (_statsGate)
+        {
+            return new SyncStats(
+                _sourceName,
+                WaveFormat.SampleRate,
+                Interlocked.Read(ref _framesWritten),
+                _correctionCount,
+                _paddedFrames,
+                _trimmedFrames,
+                _underrunFrames,
+                _droppedPreOriginPackets,
+                _lastDeviation,
+                _maxAbsDeviation);
+        }
+    }
+
+    public void BeginTimeline(TimeSpan origin) => BeginTimeline(RecordingTimeline.FromOrigin(origin));
+
+    public void BeginTimeline(RecordingTimeline timeline)
+    {
+        _timeline = timeline;
         _buffer.ClearBuffer();
         _timelineStarted = true;
         _aligned = false;
         _paused = false;
+        Interlocked.Exchange(ref _framesWritten, 0);
+        lock (_statsGate)
+        {
+            _correctionCount = 0;
+            _paddedFrames = 0;
+            _trimmedFrames = 0;
+            _underrunFrames = 0;
+            _droppedPreOriginPackets = 0;
+            _lastDeviation = TimeSpan.Zero;
+            _maxAbsDeviation = TimeSpan.Zero;
+        }
     }
 
+    /// <summary>
+    /// Stops accepting new packets. Audio already captured is retained: it belongs to pre-pause
+    /// video time and the muxer still needs to drain it, otherwise every pause would shift the
+    /// rest of the track earlier by the discarded amount.
+    /// </summary>
     public void Pause()
     {
         _paused = true;
-        _buffer.ClearBuffer();
     }
 
+    /// <summary>
+    /// Resumes accepting packets. No explicit re-alignment is needed: the next packet's expected
+    /// position (derived from the paused-adjusted timeline) is compared against frames written,
+    /// and any gap or overlap beyond the tolerance is corrected like any other discontinuity.
+    /// </summary>
     public void Resume()
     {
-        _buffer.ClearBuffer();
         _paused = false;
     }
 
-    public void AddSamples(byte[] samples, int count, TimeSpan sourceTimestamp)
+    public void AddSamples(byte[] samples, int count, TimeSpan sourceTimestamp) =>
+        AddSamples(samples, count, sourceTimestamp, discontinuity: false);
+
+    /// <param name="discontinuity">
+    /// True when the driver flagged this packet as following a gap (WASAPI
+    /// <c>AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY</c>). Forces a correction regardless of tolerance.
+    /// </param>
+    public void AddSamples(byte[] samples, int count, TimeSpan sourceTimestamp, bool discontinuity)
     {
-        if (!_timelineStarted || _paused || count <= 0)
+        var timeline = _timeline;
+        if (!_timelineStarted || timeline is null || _paused || count <= 0)
         {
             return;
         }
@@ -80,57 +170,144 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
             return;
         }
 
+        // Where this packet's first frame belongs on the output stream. The timeline subtracts the
+        // shared origin and any paused time; the latency advance compensates for WASAPI stamping
+        // the buffer read rather than the true acoustic capture instant; the user offset is an
+        // explicit manual correction.
+        var targetOffset = timeline.Normalize(sourceTimestamp) - _latency + _userOffset;
+        var targetFrame = ToFrames(targetOffset);
+        var deviationFrames = targetFrame - Interlocked.Read(ref _framesWritten);
         var byteOffset = 0;
+        var firstPacket = false;
 
         if (!_aligned)
         {
-            // Position the stream relative to the shared origin, compensating for the source's
-            // input latency so captured sound lands at the wall-clock moment it actually occurred
-            // (WASAPI timestamps the buffer read, which trails the real acoustic capture time).
-            var sourceOffset = sourceTimestamp - _origin - _latency;
-            var desiredStartFrame = (long)Math.Round(sourceOffset.Ticks * WaveFormat.SampleRate / (double)TimeSpan.TicksPerSecond);
-
-            if (desiredStartFrame + packetFrames <= 0)
+            if (deviationFrames + packetFrames <= 0)
             {
                 // The entire packet is before the (latency-compensated) origin. Drop it and keep
                 // waiting: later packets carry later timestamps, so one of them will straddle the
                 // origin. This discards ALL pre-origin pre-roll, not just the first packet's worth.
+                lock (_statsGate)
+                {
+                    _droppedPreOriginPackets++;
+                }
+
                 return;
             }
 
+            // The first packet is always positioned exactly (no tolerance): this is what anchors
+            // the source to the shared origin.
             _aligned = true;
+            firstPacket = true;
+        }
 
-            if (desiredStartFrame < 0)
+        var deviation = ToTime(deviationFrames);
+        var toleranceFrames = ToFrames(DriftTolerance);
+        var forced = firstPacket || discontinuity;
+
+        lock (_statsGate)
+        {
+            if (!firstPacket)
             {
-                // This packet straddles the origin: drop its pre-origin frames, keep the rest.
-                var trimFrames = Math.Min(packetFrames, -desiredStartFrame);
+                _lastDeviation = deviation;
+                if (deviation.Duration() > _maxAbsDeviation)
+                {
+                    _maxAbsDeviation = deviation.Duration();
+                }
+            }
+        }
+
+        if (deviationFrames != 0 && (forced || Math.Abs(deviationFrames) > toleranceFrames))
+        {
+            var reason = firstPacket ? "aligned" : discontinuity ? "sync correction (driver discontinuity)" : "sync correction";
+            if (deviationFrames > 0)
+            {
+                // Gap: the source starts (or fell) behind its expected position — late start,
+                // dropped packet, pause, slow device clock. Insert exactly that much silence.
+                AddSilence(deviationFrames);
+                Interlocked.Add(ref _framesWritten, deviationFrames);
+                lock (_statsGate)
+                {
+                    if (!firstPacket)
+                    {
+                        _correctionCount++;
+                        _paddedFrames += deviationFrames;
+                    }
+                }
+
+                WebcamDiagnostics.Log($"TimelineAlignedWaveProvider[{_sourceName}] {reason}: padded {deviation.TotalMilliseconds:F1} ms{Describe(sourceTimestamp, timeline)}.");
+            }
+            else
+            {
+                // Overlap: the source ran ahead — pre-origin frames in the straddling first packet,
+                // fast device clock, or a resumed packet that began before the resume point. Trim
+                // the excess from the front of this packet; if the packet is shorter than the
+                // overlap, the next packet trims the remainder.
+                var trimFrames = Math.Min(packetFrames, -deviationFrames);
                 byteOffset = checked((int)(trimFrames * blockAlign));
-                WebcamDiagnostics.Log($"TimelineAlignedWaveProvider aligned: sourceOffsetMs={(sourceTimestamp - _origin).TotalMilliseconds:F1} latencyMs={_latency.TotalMilliseconds:F1} trimFrames={trimFrames}.");
+                lock (_statsGate)
+                {
+                    if (!firstPacket)
+                    {
+                        _correctionCount++;
+                        _trimmedFrames += trimFrames;
+                    }
+                }
+
+                WebcamDiagnostics.Log($"TimelineAlignedWaveProvider[{_sourceName}] {reason}: trimmed {ToTime(trimFrames).TotalMilliseconds:F1} ms of {(-deviation).TotalMilliseconds:F1} ms overlap{Describe(sourceTimestamp, timeline)}.");
                 if (byteOffset >= count)
                 {
                     return;
                 }
             }
-            else
-            {
-                // The source begins after the origin: pad the gap so it lands at the right offset.
-                if (desiredStartFrame > 0)
-                {
-                    AddSilence(desiredStartFrame);
-                }
-
-                WebcamDiagnostics.Log($"TimelineAlignedWaveProvider aligned: sourceOffsetMs={(sourceTimestamp - _origin).TotalMilliseconds:F1} latencyMs={_latency.TotalMilliseconds:F1} padFrames={desiredStartFrame}.");
-            }
+        }
+        else if (firstPacket)
+        {
+            WebcamDiagnostics.Log($"TimelineAlignedWaveProvider[{_sourceName}] aligned exactly{Describe(sourceTimestamp, timeline)}.");
         }
 
         var alignedCount = ((count - byteOffset) / blockAlign) * blockAlign;
         if (alignedCount > 0)
         {
             _buffer.AddSamples(samples, byteOffset, alignedCount);
+            Interlocked.Add(ref _framesWritten, alignedCount / blockAlign);
         }
     }
 
-    public int Read(byte[] buffer, int offset, int count) => _buffer.Read(buffer, offset, count);
+    /// <summary>
+    /// Reads mixed output. When the buffer runs dry the underlying provider pads zeros
+    /// (<c>ReadFully</c>); those padded frames occupy real positions on the output timeline, so the
+    /// written cursor advances to cover them. The next packet then sees an overlap and is trimmed,
+    /// instead of landing late behind silence the muxer has already consumed.
+    /// </summary>
+    public int Read(byte[] buffer, int offset, int count)
+    {
+        var bufferedBefore = _buffer.BufferedBytes;
+        var read = _buffer.Read(buffer, offset, count);
+        if (read > bufferedBefore)
+        {
+            var underrunFrames = (read - bufferedBefore) / WaveFormat.BlockAlign;
+            if (underrunFrames > 0 && _timelineStarted)
+            {
+                Interlocked.Add(ref _framesWritten, underrunFrames);
+                lock (_statsGate)
+                {
+                    _underrunFrames += underrunFrames;
+                }
+            }
+        }
+
+        return read;
+    }
+
+    private string Describe(TimeSpan sourceTimestamp, RecordingTimeline timeline) =>
+        $" (sourceOffsetMs={(sourceTimestamp - timeline.Origin).TotalMilliseconds:F1} latencyMs={_latency.TotalMilliseconds:F1} userOffsetMs={_userOffset.TotalMilliseconds:F1})";
+
+    private long ToFrames(TimeSpan time) =>
+        (long)Math.Round(time.Ticks * WaveFormat.SampleRate / (double)TimeSpan.TicksPerSecond);
+
+    private TimeSpan ToTime(long frames) =>
+        TimeSpan.FromTicks((long)Math.Round(frames * (double)TimeSpan.TicksPerSecond / WaveFormat.SampleRate));
 
     private void AddSilence(long frameCount)
     {
@@ -145,5 +322,27 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
             _buffer.AddSamples(silence, 0, frames * blockAlign);
             frameCount -= frames;
         }
+    }
+
+    /// <summary>Per-source sync bookkeeping for the end-of-recording diagnostics report.</summary>
+    public sealed record SyncStats(
+        string SourceName,
+        int SampleRate,
+        long FramesWritten,
+        long CorrectionCount,
+        long PaddedFrames,
+        long TrimmedFrames,
+        long UnderrunFrames,
+        long DroppedPreOriginPackets,
+        TimeSpan LastDeviation,
+        TimeSpan MaxAbsDeviation)
+    {
+        public TimeSpan Written => TimeSpan.FromSeconds(FramesWritten / (double)SampleRate);
+        public TimeSpan Padded => TimeSpan.FromSeconds(PaddedFrames / (double)SampleRate);
+        public TimeSpan Trimmed => TimeSpan.FromSeconds(TrimmedFrames / (double)SampleRate);
+        public TimeSpan Underrun => TimeSpan.FromSeconds(UnderrunFrames / (double)SampleRate);
+
+        public override string ToString() =>
+            $"{SourceName}: written={Written.TotalSeconds:F3}s corrections={CorrectionCount} padded={Padded.TotalMilliseconds:F1}ms trimmed={Trimmed.TotalMilliseconds:F1}ms underrun={Underrun.TotalMilliseconds:F1}ms preOriginDropped={DroppedPreOriginPackets} lastDeviation={LastDeviation.TotalMilliseconds:F1}ms maxDeviation={MaxAbsDeviation.TotalMilliseconds:F1}ms";
     }
 }

--- a/windows/src/TinyClips.Core/Capture/TimestampedWasapiCapture.cs
+++ b/windows/src/TinyClips.Core/Capture/TimestampedWasapiCapture.cs
@@ -55,7 +55,19 @@ internal sealed class TimestampedWasapiCapture : IDisposable
     /// </summary>
     public TimeSpan CaptureLatency { get; private set; }
 
-    public event Action<byte[], int, TimeSpan>? DataAvailable;
+    /// <summary>
+    /// Raised per WASAPI packet with (data, byteCount, qpcTimestamp, discontinuity). The
+    /// discontinuity flag mirrors <c>AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY</c>: the driver lost
+    /// data before this packet, so consumers must re-derive the packet's position rather than
+    /// append it contiguously.
+    /// </summary>
+    public event Action<byte[], int, TimeSpan, bool>? DataAvailable;
+
+    /// <summary>Count of packets the driver flagged as following a data gap.</summary>
+    public long DiscontinuityCount => Interlocked.Read(ref _discontinuityCount);
+
+    private long _discontinuityCount;
+    private TimeSpan _expectedNextTimestamp = TimeSpan.MinValue;
 
     public void Start()
     {
@@ -199,7 +211,30 @@ internal sealed class TimestampedWasapiCapture : IDisposable
                     ? TimeSpan.FromTicks(qpcPosition)
                     : Stopwatch.GetElapsedTime(0, Stopwatch.GetTimestamp()) -
                         TimeSpan.FromSeconds(framesAvailable / (double)WaveFormat.SampleRate);
-                DataAvailable?.Invoke(data, byteCount, sourceTimestamp);
+
+                var discontinuity = (flags & AudioClientBufferFlags.DataDiscontinuity) != 0;
+                var packetDuration = TimeSpan.FromSeconds(framesAvailable / (double)WaveFormat.SampleRate);
+                if (discontinuity)
+                {
+                    Interlocked.Increment(ref _discontinuityCount);
+                    var gap = _expectedNextTimestamp == TimeSpan.MinValue
+                        ? TimeSpan.Zero
+                        : sourceTimestamp - _expectedNextTimestamp;
+                    WebcamDiagnostics.Log($"Audio packet discontinuity ({(_isLoopback ? "loopback" : "microphone")}): packet#{packetCount} gapMs={gap.TotalMilliseconds:F1}.");
+                }
+                else if (_expectedNextTimestamp != TimeSpan.MinValue)
+                {
+                    // Purely diagnostic: a large timestamp jump without the driver flag still points
+                    // at lost data. The timeline provider corrects it; this just leaves evidence.
+                    var jump = sourceTimestamp - _expectedNextTimestamp;
+                    if (jump.Duration() > TimelineAlignedWaveProvider.DriftTolerance)
+                    {
+                        WebcamDiagnostics.Log($"Audio packet timestamp jump ({(_isLoopback ? "loopback" : "microphone")}): packet#{packetCount} jumpMs={jump.TotalMilliseconds:F1} (no driver flag).");
+                    }
+                }
+
+                _expectedNextTimestamp = sourceTimestamp + packetDuration;
+                DataAvailable?.Invoke(data, byteCount, sourceTimestamp, discontinuity);
             }
             finally
             {

--- a/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
@@ -63,9 +63,18 @@ public sealed class VideoRecordingService : IVideoRecordingService
     private long _audioFramesRead;
     private long _audioSamplesRequested;
     private long _audioNonSilentChunks;
+    private long _audioStarvedChunks;
+    private long _videoFramesDropped;
+    private long _drainFramesServed;
     private bool _loggedFirstAudioChunk;
     private volatile bool _audioEnding;
+    private volatile bool _audioDraining;
     private RecordingTimeline? _recordingTimeline;
+    private string _encoderPath = "unknown";
+
+    // Remaining captured audio handed to the muxer after Stop before the track is ended. Bounds the
+    // tail so a source that somehow keeps producing cannot hold the transcode open.
+    private const int MaxDrainFrames = AudioCaptureService.SampleRate / 2;
 
     public VideoRecordingService(
         IMonitorService monitors,
@@ -238,9 +247,13 @@ public sealed class VideoRecordingService : IVideoRecordingService
         var randomAccessStream = _fileStream.AsRandomAccessStream();
 
         _audioEnding = false;
+        _audioDraining = false;
         _audioFramesRead = 0;
         _audioSamplesRequested = 0;
         _audioNonSilentChunks = 0;
+        _audioStarvedChunks = 0;
+        _drainFramesServed = 0;
+        Interlocked.Exchange(ref _videoFramesDropped, 0);
         _loggedFirstAudioChunk = false;
         StartAudioCapture();
         CaptureFlowTrace.Mark("video: audio capture started");
@@ -291,6 +304,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
             throw new InvalidOperationException($"Cannot encode video: {prepare.FailureReason}.");
         }
 
+        _encoderPath = usedFallbackProfile ? "software H.264 Baseline (fallback)" : "H.264 High (hardware-accelerated)";
         CaptureFlowTrace.Mark("video: transcoder prepared");
         _prepared = new PreparedPipeline(captureTarget, region, prepare);
     }
@@ -369,7 +383,12 @@ public sealed class VideoRecordingService : IVideoRecordingService
             Interlocked.Increment(ref _webcamOverlayNullFrames);
         }
 
-        _channel?.Writer.TryWrite(new TimestampedFrame(CreateBottomUpVideoBuffer(frame), pts));
+        if (_channel?.Writer.TryWrite(new TimestampedFrame(CreateBottomUpVideoBuffer(frame), pts)) == false)
+        {
+            // Encoder back-pressure: the frame is dropped but PTS stays wall-clock, so the video
+            // simply has a lower effective frame rate here and never slides against audio.
+            Interlocked.Increment(ref _videoFramesDropped);
+        }
     }
 
     private void StartMouseClickOverlay(CaptureTarget target, PixelRect? region)
@@ -793,22 +812,36 @@ public sealed class VideoRecordingService : IVideoRecordingService
             // the transcoder drains audio far faster than real time and the whole audio track
             // races ~1s ahead of the video. Gating on captured-frame availability (not the wall
             // clock) keeps audio locked to real capture progress AND never reads an empty buffer,
-            // so there is no silence-splicing crackle. A generous cap prevents a stalled capture
-            // from hanging the transcode pull.
+            // so there is no silence-splicing crackle.
+            //
+            // While paused there is no cap on the wait: no new audio arrives by design, and ending
+            // the wait would hand the muxer a sample it must not have (or, worse, end the track).
+            // When not paused, a generous cap prevents a stalled device from hanging the transcode;
+            // the starved chunk is then filled with silence rather than ending the stream.
             var audio = _audio;
             var waited = 0;
+            var starved = false;
             const int maxWaitMs = 2000;
             const int pollMs = 4;
-            while (audio is not null &&
-                   !_audioEnding &&
-                   audio.AvailableFrames < frameCount &&
-                   waited < maxWaitMs)
+            while (audio is not null && !_audioEnding && !_audioDraining && audio.AvailableFrames < frameCount)
             {
+                if (IsPaused)
+                {
+                    await Task.Delay(pollMs).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (waited >= maxWaitMs)
+                {
+                    starved = true;
+                    break;
+                }
+
                 await Task.Delay(pollMs).ConfigureAwait(false);
                 waited += pollMs;
             }
 
-            FillAudioRequest(args, frameCount);
+            FillAudioRequest(args, frameCount, starved);
         }
         catch
         {
@@ -820,7 +853,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
         }
     }
 
-    private void FillAudioRequest(MediaStreamSourceSampleRequestedEventArgs args, int frameCount)
+    private void FillAudioRequest(MediaStreamSourceSampleRequestedEventArgs args, int frameCount, bool starved)
     {
         var audio = _audio;
         if (audio is null || _audioEnding)
@@ -830,11 +863,44 @@ public sealed class VideoRecordingService : IVideoRecordingService
             return;
         }
 
+        if (_audioDraining)
+        {
+            // Devices are stopped; serve whatever was captured before Stop so the audio track
+            // reaches the same point as the video, then end the stream.
+            var remaining = Math.Min(audio.AvailableFrames, (int)Math.Max(0, MaxDrainFrames - _drainFramesServed));
+            if (remaining <= 0)
+            {
+                _audioEnding = true;
+                args.Request.Sample = null;
+                return;
+            }
+
+            frameCount = Math.Min(frameCount, remaining);
+            _drainFramesServed += frameCount;
+        }
+
         var data = audio.ReadChunk(frameCount);
         if (data is null || data.Length == 0)
         {
-            args.Request.Sample = null;
-            return;
+            if (_audioDraining)
+            {
+                _audioEnding = true;
+                args.Request.Sample = null;
+                return;
+            }
+
+            // The mixer should always return a full (silence-padded) chunk; if it somehow did not,
+            // substitute silence rather than ending the track mid-recording.
+            data = new byte[frameCount * AudioCaptureService.Channels * (AudioCaptureService.BitsPerSample / 8)];
+        }
+
+        if (starved)
+        {
+            _audioStarvedChunks++;
+            if (_audioStarvedChunks == 1 || _audioStarvedChunks % 50 == 0)
+            {
+                WebcamDiagnostics.Log($"Audio muxer starved: no captured audio for 2 s; filled chunk with silence (starvedChunks={_audioStarvedChunks}).");
+            }
         }
 
         var producedFrames = data.Length / (AudioCaptureService.Channels * (AudioCaptureService.BitsPerSample / 8));
@@ -883,7 +949,8 @@ public sealed class VideoRecordingService : IVideoRecordingService
         var wantSystem = _settings.RecordAudio;
         var wantMic = _settings.RecordMicrophone;
         var limitMic = _settings.MicrophoneLimiterEnabled;
-        WebcamDiagnostics.Log($"StartAudioCapture: RecordAudio={wantSystem} RecordMicrophone={wantMic} MicrophoneLimiter={limitMic} micDeviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedMicrophoneId) ? "(default)" : _settings.SelectedMicrophoneId)}'");
+        var userOffset = TimeSpan.FromMilliseconds(_settings.AudioOffsetMilliseconds);
+        WebcamDiagnostics.Log($"StartAudioCapture: RecordAudio={wantSystem} RecordMicrophone={wantMic} MicrophoneLimiter={limitMic} audioOffsetMs={userOffset.TotalMilliseconds:F0} micDeviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedMicrophoneId) ? "(default)" : _settings.SelectedMicrophoneId)}'");
         if (!wantSystem && !wantMic)
         {
             WebcamDiagnostics.Log("StartAudioCapture: no audio sources requested; recording will have no audio track.");
@@ -892,7 +959,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
 
         try
         {
-            var audio = new AudioCaptureService(wantSystem, wantMic, _settings.SelectedMicrophoneId, limitMic);
+            var audio = new AudioCaptureService(wantSystem, wantMic, _settings.SelectedMicrophoneId, limitMic, userOffset);
             if (audio.TryStart())
             {
                 _audio = audio;
@@ -919,6 +986,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
     private void DisposeAudio()
     {
         _audioEnding = true;
+        _audioDraining = false;
         _audio?.Dispose();
         _audio = null;
         _hasAudio = false;
@@ -1045,12 +1113,12 @@ public sealed class VideoRecordingService : IVideoRecordingService
             }
             await StopWebcamOverlayAsync().ConfigureAwait(false);
 
-            // Signal audio end-of-stream and stop the device before draining the encoder,
-            // otherwise the continuous silence source would prevent EOS.
-            _audioEnding = true;
+            // Stop the audio devices first, then let the muxer drain the audio already captured
+            // (so the track ends where the video does) before it ends the stream. Only then stop
+            // new video frames and let the encoder drain what's buffered.
             _audio?.Stop();
+            _audioDraining = true;
 
-            // Stop new frames, then let the encoder drain what's buffered.
             _capture?.Stop();
             _channel?.Writer.TryComplete();
 
@@ -1065,6 +1133,8 @@ public sealed class VideoRecordingService : IVideoRecordingService
                     // Surface nothing here; the file may still be partially valid.
                 }
             }
+
+            LogSyncReport();
 
             _capture?.Dispose();
             _capture = null;
@@ -1104,6 +1174,46 @@ public sealed class VideoRecordingService : IVideoRecordingService
             WebcamDiagnostics.EndRecording();
             Interlocked.Exchange(ref _stopping, 0);
             _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// One-shot end-of-recording summary so A/V sync can be verified from the diagnostics log
+    /// without a listen test. Healthy: |delta| well under 30 ms, zero corrections, no starvation.
+    /// </summary>
+    private void LogSyncReport()
+    {
+        try
+        {
+            var timeline = _recordingTimeline;
+            var videoPts = _capture?.LastEmittedPts ?? TimeSpan.MinValue;
+            var videoEmitted = _capture?.EmittedFrameCount ?? 0;
+            var videoDropped = Interlocked.Read(ref _videoFramesDropped);
+            var elapsed = timeline?.Elapsed ?? TimeSpan.Zero;
+            var pauses = timeline?.PauseCount ?? 0;
+            var paused = timeline?.PausedDuration ?? TimeSpan.Zero;
+
+            WebcamDiagnostics.Log($"Sync report: encoder='{_encoderPath}' elapsed={elapsed.TotalSeconds:F3}s pauses={pauses} pausedTotal={paused.TotalSeconds:F3}s.");
+            WebcamDiagnostics.Log($"Sync report: video lastPts={(videoPts == TimeSpan.MinValue ? "none" : $"{videoPts.TotalSeconds:F3}s")} framesEmitted={videoEmitted} framesDroppedByEncoderBackpressure={videoDropped}.");
+
+            if (!_hasAudio || _audio is null)
+            {
+                WebcamDiagnostics.Log("Sync report: no audio track.");
+                return;
+            }
+
+            var audioPts = TimeSpan.FromSeconds(_audioFramesRead / (double)AudioCaptureService.SampleRate);
+            var delta = videoPts == TimeSpan.MinValue ? TimeSpan.Zero : audioPts - videoPts;
+            WebcamDiagnostics.Log($"Sync report: audio pts={audioPts.TotalSeconds:F3}s chunks={_audioSamplesRequested} nonSilent={_audioNonSilentChunks} starvedChunks={_audioStarvedChunks} drainedFrames={_drainFramesServed} userOffsetMs={_settings.AudioOffsetMilliseconds} driverDiscontinuities={_audio.DriverDiscontinuityCount}.");
+            WebcamDiagnostics.Log($"Sync report: audio-video end delta={delta.TotalMilliseconds:F1}ms (audio {(delta >= TimeSpan.Zero ? "longer" : "shorter")}; |delta| < 30 ms is healthy).");
+            foreach (var stats in _audio.GetSyncStats())
+            {
+                WebcamDiagnostics.Log($"Sync report: {stats}");
+            }
+        }
+        catch (Exception ex)
+        {
+            WebcamDiagnostics.Log($"Sync report failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
+++ b/windows/src/TinyClips.Core/Capture/VideoRecordingService.cs
@@ -71,6 +71,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
     private volatile bool _audioDraining;
     private RecordingTimeline? _recordingTimeline;
     private string _encoderPath = "unknown";
+    private TimeSpan _activeUserOffset;
 
     // Remaining captured audio handed to the muxer after Stop before the track is ended. Bounds the
     // tail so a source that somehow keeps producing cannot hold the transcode open.
@@ -216,12 +217,16 @@ public sealed class VideoRecordingService : IVideoRecordingService
         var fps = Math.Clamp(_settings.VideoFrameRate, 1, 60);
         _frameDuration = TimeSpan.FromSeconds(1.0 / fps);
 
-        _channel = Channel.CreateBounded<TimestampedFrame>(new BoundedChannelOptions(fps * 4)
-        {
-            FullMode = BoundedChannelFullMode.DropWrite,
-            SingleReader = true,
-            SingleWriter = true,
-        });
+        // DropWrite makes TryWrite report success even when the item is discarded, so drops are
+        // counted through the item-dropped callback rather than the TryWrite result.
+        _channel = Channel.CreateBounded<TimestampedFrame>(
+            new BoundedChannelOptions(fps * 4)
+            {
+                FullMode = BoundedChannelFullMode.DropWrite,
+                SingleReader = true,
+                SingleWriter = true,
+            },
+            _ => Interlocked.Increment(ref _videoFramesDropped));
 
         _capture = new ContinuousCaptureSession(captureTarget, region, fps, includeCursor: true);
         _capture.FrameReady += OnFrameReady;
@@ -297,6 +302,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
                 includeAudio,
                 cancellationToken,
                 null).ConfigureAwait(false);
+            usedFallbackProfile = true;
         }
 
         if (!prepare.CanTranscode)
@@ -383,12 +389,10 @@ public sealed class VideoRecordingService : IVideoRecordingService
             Interlocked.Increment(ref _webcamOverlayNullFrames);
         }
 
-        if (_channel?.Writer.TryWrite(new TimestampedFrame(CreateBottomUpVideoBuffer(frame), pts)) == false)
-        {
-            // Encoder back-pressure: the frame is dropped but PTS stays wall-clock, so the video
-            // simply has a lower effective frame rate here and never slides against audio.
-            Interlocked.Increment(ref _videoFramesDropped);
-        }
+        // Encoder back-pressure: the frame is dropped (counted by the channel's item-dropped
+        // callback) but PTS stays wall-clock, so the video simply has a lower effective frame rate
+        // here and never slides against audio.
+        _channel?.Writer.TryWrite(new TimestampedFrame(CreateBottomUpVideoBuffer(frame), pts));
     }
 
     private void StartMouseClickOverlay(CaptureTarget target, PixelRect? region)
@@ -950,6 +954,7 @@ public sealed class VideoRecordingService : IVideoRecordingService
         var wantMic = _settings.RecordMicrophone;
         var limitMic = _settings.MicrophoneLimiterEnabled;
         var userOffset = TimeSpan.FromMilliseconds(_settings.AudioOffsetMilliseconds);
+        _activeUserOffset = userOffset;
         WebcamDiagnostics.Log($"StartAudioCapture: RecordAudio={wantSystem} RecordMicrophone={wantMic} MicrophoneLimiter={limitMic} audioOffsetMs={userOffset.TotalMilliseconds:F0} micDeviceId='{(string.IsNullOrWhiteSpace(_settings.SelectedMicrophoneId) ? "(default)" : _settings.SelectedMicrophoneId)}'");
         if (!wantSystem && !wantMic)
         {
@@ -1203,9 +1208,15 @@ public sealed class VideoRecordingService : IVideoRecordingService
             }
 
             var audioPts = TimeSpan.FromSeconds(_audioFramesRead / (double)AudioCaptureService.SampleRate);
-            var delta = videoPts == TimeSpan.MinValue ? TimeSpan.Zero : audioPts - videoPts;
-            WebcamDiagnostics.Log($"Sync report: audio pts={audioPts.TotalSeconds:F3}s chunks={_audioSamplesRequested} nonSilent={_audioNonSilentChunks} starvedChunks={_audioStarvedChunks} drainedFrames={_drainFramesServed} userOffsetMs={_settings.AudioOffsetMilliseconds} driverDiscontinuities={_audio.DriverDiscontinuityCount}.");
-            WebcamDiagnostics.Log($"Sync report: audio-video end delta={delta.TotalMilliseconds:F1}ms (audio {(delta >= TimeSpan.Zero ? "longer" : "shorter")}; |delta| < 30 ms is healthy).");
+
+            // The audio cursor is an end position, so compare it with the END of the last video
+            // sample (its PTS plus one frame), not its start. A non-zero user offset deliberately
+            // shifts the audio endpoint by that amount, so grade the offset-compensated delta.
+            var videoEnd = videoPts == TimeSpan.MinValue ? TimeSpan.MinValue : videoPts + _frameDuration;
+            var rawDelta = videoEnd == TimeSpan.MinValue ? TimeSpan.Zero : audioPts - videoEnd;
+            var delta = rawDelta - _activeUserOffset;
+            WebcamDiagnostics.Log($"Sync report: audio pts={audioPts.TotalSeconds:F3}s chunks={_audioSamplesRequested} nonSilent={_audioNonSilentChunks} starvedChunks={_audioStarvedChunks} drainedFrames={_drainFramesServed} userOffsetMs={_activeUserOffset.TotalMilliseconds:F0} driverDiscontinuities={_audio.DriverDiscontinuityCount}.");
+            WebcamDiagnostics.Log($"Sync report: audio-video end delta={delta.TotalMilliseconds:F1}ms offset-compensated (raw={rawDelta.TotalMilliseconds:F1}ms vs videoEnd={(videoEnd == TimeSpan.MinValue ? "none" : $"{videoEnd.TotalSeconds:F3}s")}; audio {(delta >= TimeSpan.Zero ? "longer" : "shorter")}; |delta| < 30 ms is healthy).");
             foreach (var stats in _audio.GetSyncStats())
             {
                 WebcamDiagnostics.Log($"Sync report: {stats}");

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -283,6 +283,14 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("microphoneLimiterEnabled", value);
     }
 
+    public const int MaxAudioOffsetMilliseconds = 500;
+
+    public int AudioOffsetMilliseconds
+    {
+        get => Math.Clamp(_settings.Get("audioOffsetMilliseconds", 0), -MaxAudioOffsetMilliseconds, MaxAudioOffsetMilliseconds);
+        set => _settings.Set("audioOffsetMilliseconds", Math.Clamp(value, -MaxAudioOffsetMilliseconds, MaxAudioOffsetMilliseconds));
+    }
+
     public bool WebcamEnabled
     {
         get => _settings.Get("webcamEnabled", false);
@@ -724,6 +732,7 @@ public sealed class CaptureSettings : ICaptureSettings
         RecordMicrophone = false;
         SelectedMicrophoneId = string.Empty;
         MicrophoneLimiterEnabled = true;
+        AudioOffsetMilliseconds = 0;
         WebcamEnabled = false;
         SelectedWebcamId = string.Empty;
         WebcamShape = WebcamShape.Circle;

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -41,6 +41,12 @@ public interface ICaptureSettings
     string SelectedMicrophoneId { get; set; }
     /// <summary>Apply a soft-knee limiter to microphone audio so hot input rounds off instead of clipping. Default true.</summary>
     bool MicrophoneLimiterEnabled { get; set; }
+    /// <summary>
+    /// Manual A/V correction in milliseconds applied to all recorded audio. Positive delays audio
+    /// relative to video; negative plays it earlier (e.g. for Bluetooth headsets whose latency
+    /// WASAPI does not report). Clamped to ±<see cref="CaptureSettings.MaxAudioOffsetMilliseconds"/>. Default 0.
+    /// </summary>
+    int AudioOffsetMilliseconds { get; set; }
     bool WebcamEnabled { get; set; }
     string SelectedWebcamId { get; set; }
     WebcamShape WebcamShape { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -32,6 +32,7 @@ public sealed class CaptureSettingsTests
         Assert.Equal("TinyClips {date} at {time}", settings.FileNameTemplate);
         Assert.True(settings.ShowTrimmer);
         Assert.True(settings.MicrophoneLimiterEnabled);
+        Assert.Equal(0, settings.AudioOffsetMilliseconds);
         Assert.False(settings.WebcamEnabled);
         Assert.Equal(string.Empty, settings.SelectedWebcamId);
         Assert.Equal(WebcamShape.Circle, settings.WebcamShape);
@@ -114,6 +115,49 @@ public sealed class CaptureSettingsTests
         settings.ResetToDefaults();
 
         Assert.True(settings.MicrophoneLimiterEnabled);
+    }
+
+    [Fact]
+    public void AudioOffsetMilliseconds_RoundTripsAndResetsToZero()
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        settings.AudioOffsetMilliseconds = -150;
+
+        Assert.Equal(-150, settings.AudioOffsetMilliseconds);
+        Assert.Equal(-150, settingsService.Get("audioOffsetMilliseconds", 0));
+
+        settings.ResetToDefaults();
+
+        Assert.Equal(0, settings.AudioOffsetMilliseconds);
+    }
+
+    [Theory]
+    [InlineData(600, 500)]
+    [InlineData(500, 500)]
+    [InlineData(-500, -500)]
+    [InlineData(-9999, -500)]
+    public void AudioOffsetMilliseconds_ClampsToSupportedRange(int requested, int expected)
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        settings.AudioOffsetMilliseconds = requested;
+
+        Assert.Equal(expected, settings.AudioOffsetMilliseconds);
+        Assert.Equal(expected, settingsService.Get("audioOffsetMilliseconds", 0));
+    }
+
+    [Fact]
+    public void AudioOffsetMilliseconds_ClampsOutOfRangeStoredValueOnRead()
+    {
+        // A value written by an older/newer build or edited by hand must never leak outside the range.
+        var settingsService = new TestSettingsService();
+        settingsService.Set("audioOffsetMilliseconds", 2000);
+        var settings = new CaptureSettings(settingsService);
+
+        Assert.Equal(CaptureSettings.MaxAudioOffsetMilliseconds, settings.AudioOffsetMilliseconds);
     }
 
     [Fact]

--- a/windows/tests/TinyClips.Core.Tests/RecordingTimelineTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/RecordingTimelineTests.cs
@@ -127,7 +127,7 @@ public sealed class RecordingTimelineTests
     }
 
     [Fact]
-    public void Pause_DropsSamplesUntilResume()
+    public void Pause_DropsSamplesUntilResume_ThenPlacesResumedPacketOnTimeline()
     {
         var format = new WaveFormat(1000, 16, 1);
         var origin = TimeSpan.FromSeconds(10);
@@ -137,33 +137,244 @@ public sealed class RecordingTimelineTests
 
         Assert.Equal(new short[] { 1, 2 }, ReadSamples(provider, 2));
 
+        // Packets during the pause are dropped.
         provider.Pause();
-        provider.AddSamples(ToBytes(1, 2), 4, origin);
+        provider.AddSamples(ToBytes(7, 8), 4, origin + TimeSpan.FromMilliseconds(2));
         provider.Resume();
+
+        // The timeline here has no paused interval (FromOrigin), so a packet stamped 1 s after the
+        // origin belongs at frame 1000; the provider must pad the 998-frame gap rather than append
+        // it right after frame 2 (which would have pulled all later audio ~1 s early).
         provider.AddSamples(ToBytes(3, 4), 4, origin + TimeSpan.FromSeconds(1));
 
-        Assert.Equal(new short[] { 3, 4 }, ReadSamples(provider, 2));
+        var stats = provider.GetStats();
+        Assert.Equal(1, stats.CorrectionCount);
+        Assert.Equal(998, stats.PaddedFrames);
+        var all = ReadSamples(provider, 1000);
+        Assert.All(all.Take(998), s => Assert.Equal(0, s));
+        Assert.Equal(new short[] { 3, 4 }, all.Skip(998).ToArray());
     }
 
     [Fact]
-    public void Resume_AppendsContiguouslyWithoutRealigningFirstPacket()
+    public void Pause_RetainsCapturedAudioForTheMuxer()
+    {
+        // Audio captured before a pause belongs to pre-pause video time; clearing it would shift
+        // everything after the pause earlier by the discarded amount.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+        provider.AddSamples(ToBytes(1, 2, 3, 4), 8, origin);
+
+        provider.Pause();
+
+        Assert.Equal(TimeSpan.FromMilliseconds(4), provider.BufferedDuration);
+        Assert.Equal(new short[] { 1, 2, 3, 4 }, ReadSamples(provider, 4));
+    }
+
+    [Fact]
+    public void Resume_WithPausedTimeline_AppendsContiguouslyWhenWithinTolerance()
+    {
+        // With a real paused interval on the timeline, a packet captured right after resume
+        // normalizes to just after the pause point, i.e. right where the pre-pause audio ended, so
+        // no correction is needed.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = SystemRelativeNow();
+        var timeline = RecordingTimeline.FromOrigin(origin);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(timeline);
+        provider.AddSamples(ToBytes(1, 2, 3, 4, 5), 10, origin);
+
+        Assert.Equal(new short[] { 1, 2, 3, 4, 5 }, ReadSamples(provider, 5));
+
+        provider.Pause();
+        timeline.Pause();
+        Thread.Sleep(60);
+        timeline.Resume();
+        provider.Resume();
+
+        // Stamped at "now": normalizes to (now - origin - paused) ≈ 5 ms, which is where frame 5 sits.
+        provider.AddSamples(ToBytes(6, 7), 4, SystemRelativeNow());
+
+        var stats = provider.GetStats();
+        Assert.Equal(0, stats.CorrectionCount);
+        Assert.True(stats.LastDeviation.Duration() < TimelineAlignedWaveProvider.DriftTolerance);
+        Assert.Equal(new short[] { 6, 7 }, ReadSamples(provider, 2));
+    }
+
+    [Fact]
+    public void AddSamples_IgnoresJitterBelowTolerance()
+    {
+        // Per-packet timestamp jitter (a few frames either way) never triggers a correction, so
+        // the crackle from per-packet micro-edits cannot return.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+
+        var expected = new List<short>();
+        var jitter = new[] { 0, 2, -3, 5, -4, 1, -1, 3, -2, 0 };
+        for (var i = 0; i < jitter.Length; i++)
+        {
+            var samples = Enumerable.Range(i * 10, 10).Select(v => (short)v).ToArray();
+            expected.AddRange(samples);
+            var ts = origin + TimeSpan.FromMilliseconds(i * 10 + jitter[i]);
+            provider.AddSamples(ToBytes(samples), samples.Length * 2, ts);
+        }
+
+        var stats = provider.GetStats();
+        Assert.Equal(0, stats.CorrectionCount);
+        Assert.Equal(0, stats.PaddedFrames);
+        Assert.Equal(0, stats.TrimmedFrames);
+        Assert.Equal(expected.ToArray(), ReadSamples(provider, expected.Count));
+    }
+
+    [Fact]
+    public void AddSamples_PadsGapBeyondTolerance()
+    {
+        // A dropped packet (buffer overrun) leaves a gap in timestamps; exactly that much silence
+        // is inserted so later audio stays on the video clock.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+        provider.AddSamples(ToBytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 20, origin);
+
+        // Next packet should have been at 10 ms; it arrives stamped at 60 ms (50 frames lost).
+        provider.AddSamples(ToBytes(11, 12), 4, origin + TimeSpan.FromMilliseconds(60));
+
+        var stats = provider.GetStats();
+        Assert.Equal(1, stats.CorrectionCount);
+        Assert.Equal(50, stats.PaddedFrames);
+        var all = ReadSamples(provider, 62);
+        Assert.Equal(10, all[9]);
+        Assert.All(all.Skip(10).Take(50), s => Assert.Equal(0, s));
+        Assert.Equal(new short[] { 11, 12 }, all.Skip(60).ToArray());
+    }
+
+    [Fact]
+    public void AddSamples_TrimsOverlapBeyondTolerance_AcrossPackets()
+    {
+        // A source running ahead of the timeline (fast device clock) is trimmed back; when the
+        // overlap exceeds one packet, the remainder is trimmed from the following packets.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+        var first = Enumerable.Range(1, 100).Select(v => (short)v).ToArray();
+        provider.AddSamples(ToBytes(first), 200, origin);
+
+        // Written = 100 frames, but the device claims this packet belongs at 60 ms → 40 frames ahead:
+        // the whole 10-frame packet is trimmed.
+        provider.AddSamples(ToBytes(201, 202, 203, 204, 205, 206, 207, 208, 209, 210), 20, origin + TimeSpan.FromMilliseconds(60));
+        // Written still 100; next packet stamped 65 ms → 35 ahead, trimmed too. Then 80 ms → 20 ahead (within tolerance: kept).
+        provider.AddSamples(ToBytes(301, 302, 303, 304, 305, 306, 307, 308, 309, 310), 20, origin + TimeSpan.FromMilliseconds(65));
+        provider.AddSamples(ToBytes(401, 402), 4, origin + TimeSpan.FromMilliseconds(80));
+
+        var stats = provider.GetStats();
+        Assert.Equal(2, stats.CorrectionCount);
+        Assert.Equal(20, stats.TrimmedFrames);
+        var all = ReadSamples(provider, 102);
+        Assert.Equal(100, all[99]);
+        Assert.Equal(new short[] { 401, 402 }, all.Skip(100).ToArray());
+    }
+
+    [Fact]
+    public void AddSamples_SlowDrift_IsCorrectedOnceToleranceIsCrossed()
+    {
+        // Device clock ~10% fast: each packet stamped 10 ms apart actually carries 11 frames, so the
+        // written cursor gains one frame per packet on the timeline. Nothing happens until the
+        // deviation passes 30 frames (packet 31); that packet is then trimmed entirely (11 frames),
+        // pulling the deviation back inside tolerance, and appending resumes.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+
+        for (var i = 0; i < 40; i++)
+        {
+            var samples = Enumerable.Repeat((short)(i + 1), 11).ToArray();
+            var ts = origin + TimeSpan.FromMilliseconds(i * 10);
+            provider.AddSamples(ToBytes(samples), samples.Length * 2, ts);
+
+            var statsSoFar = provider.GetStats();
+            if (i < 31)
+            {
+                Assert.Equal(0, statsSoFar.CorrectionCount);
+            }
+        }
+
+        var stats = provider.GetStats();
+        Assert.Equal(1, stats.CorrectionCount);
+        Assert.Equal(11, stats.TrimmedFrames);
+        Assert.True(stats.LastDeviation.Duration() <= TimelineAlignedWaveProvider.DriftTolerance);
+    }
+
+    [Fact]
+    public void AddSamples_DiscontinuityFlagForcesCorrectionBelowTolerance()
     {
         var format = new WaveFormat(1000, 16, 1);
         var origin = TimeSpan.FromSeconds(10);
-        var provider = new TimelineAlignedWaveProvider(format)
-        {
-            Latency = TimeSpan.FromMilliseconds(3),
-        };
+        var provider = new TimelineAlignedWaveProvider(format);
         provider.BeginTimeline(origin);
-        provider.AddSamples(ToBytes(1, 2, 3, 4, 5), 10, origin);
+        provider.AddSamples(ToBytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 20, origin);
 
-        Assert.Equal(new short[] { 4, 5 }, ReadSamples(provider, 2));
+        // 5-frame gap is inside tolerance, but the driver says data was lost: pad it exactly.
+        provider.AddSamples(ToBytes(11, 12), 4, origin + TimeSpan.FromMilliseconds(15), discontinuity: true);
 
-        provider.Pause();
-        provider.Resume();
-        provider.AddSamples(ToBytes(6, 7), 4, origin + TimeSpan.FromSeconds(1));
+        var stats = provider.GetStats();
+        Assert.Equal(1, stats.CorrectionCount);
+        Assert.Equal(5, stats.PaddedFrames);
+        var all = ReadSamples(provider, 17);
+        Assert.All(all.Skip(10).Take(5), s => Assert.Equal(0, s));
+        Assert.Equal(new short[] { 11, 12 }, all.Skip(15).ToArray());
+    }
 
-        Assert.Equal(new short[] { 6, 7 }, ReadSamples(provider, 2));
+    [Fact]
+    public void UserOffset_ShiftsWhereAudioLands()
+    {
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+
+        // Positive offset delays audio: a packet at the origin lands 4 frames later.
+        var delayed = new TimelineAlignedWaveProvider(format) { UserOffset = TimeSpan.FromMilliseconds(4) };
+        delayed.BeginTimeline(origin);
+        delayed.AddSamples(ToBytes(1, 2), 4, origin);
+        Assert.Equal(new short[] { 0, 0, 0, 0, 1, 2 }, ReadSamples(delayed, 6));
+
+        // Negative offset advances audio: the first 3 frames are treated as pre-origin and trimmed.
+        var advanced = new TimelineAlignedWaveProvider(format) { UserOffset = TimeSpan.FromMilliseconds(-3) };
+        advanced.BeginTimeline(origin);
+        advanced.AddSamples(ToBytes(1, 2, 3, 4, 5), 10, origin);
+        Assert.Equal(new short[] { 4, 5 }, ReadSamples(advanced, 2));
+    }
+
+    [Fact]
+    public void Read_Underrun_AdvancesTimelineSoNextPacketIsTrimmed()
+    {
+        // If the muxer reads past captured audio, the zero padding it received occupies timeline
+        // positions. The next packet must not be appended behind that padding (it would play late);
+        // it is trimmed so its content still lands at its real time.
+        var format = new WaveFormat(1000, 16, 1);
+        var origin = TimeSpan.FromSeconds(10);
+        var provider = new TimelineAlignedWaveProvider(format);
+        provider.BeginTimeline(origin);
+        provider.AddSamples(ToBytes(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 20, origin);
+
+        // Muxer reads 60 frames although only 10 are buffered → 50 frames of underrun padding.
+        var read = ReadSamples(provider, 60);
+        Assert.Equal(10, read[9]);
+        Assert.Equal(0, read[59]);
+        Assert.Equal(60, provider.FramesWritten);
+        Assert.Equal(50, provider.GetStats().UnderrunFrames);
+
+        // Next packet is stamped at 10 ms (frame 10), but frames 10..59 were already emitted as
+        // silence, so its first 50 frames are trimmed and the rest lands at frame 60.
+        var packet = Enumerable.Range(11, 55).Select(v => (short)v).ToArray();
+        provider.AddSamples(ToBytes(packet), packet.Length * 2, origin + TimeSpan.FromMilliseconds(10));
+
+        Assert.Equal(50, provider.GetStats().TrimmedFrames);
+        Assert.Equal(new short[] { 61, 62, 63, 64, 65 }, ReadSamples(provider, 5));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Deep-dive hardening of audio/video sync for Windows video recording. The shared-timeline + back-pressure design from earlier PRs was right, but a code audit found several ways audio could still diverge from video. This PR closes them, adds a user-facing audio offset, and makes sync verifiable from the diagnostics log.

## Defects fixed

| Defect | Effect before |
|---|---|
| Pause > 2 s → muxer received a `null` audio sample (MSS end-of-stream) | Rest of the clip silent |
| `Pause()` cleared unread audio; `Resume()` appended contiguously | Each pause shifted audio earlier |
| No `DataDiscontinuity` handling, no drift correction after first packet | Dropped packet / mic clock drift / mic-vs-loopback rate mismatch → permanent desync on long recordings |
| `_audioEnding` set before transcoder drained | Audio track ended a few hundred ms before video |
| Resampler lookahead could read past captured data for 44.1 kHz mics | Crackle |

## Changes

**`TinyClips.Core/Capture`**
- `TimelineAlignedWaveProvider` — tracks each packet's expected position (`Normalize(ts) − latency + userOffset`) vs frames written. Appends contiguously within a **30 ms tolerance** (preserves the earlier crackle fix); beyond it, or on a driver discontinuity flag, pads/trims **once**. First packet = forced exact alignment (same path). `Pause` retains captured audio; `Resume` needs no special-case. Muxer underrun padding advances the written cursor so the next packet is trimmed rather than landing late. Exposes `SyncStats`.
- `TimestampedWasapiCapture` — surfaces `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY` and logs timestamp jumps.
- `AudioCaptureService` — passes the `RecordingTimeline` + user offset through; `AvailableFrames`/`ReadChunk` no longer blocked by pause; 20 ms read margin for resampled sources.
- `VideoRecordingService` — audio request waits uncapped while paused, fills a starved request with silence (never `null` mid-recording), **drains the audio tail** (≤ 500 ms) at stop, counts encoder back-pressure drops, logs an end-of-recording **`Sync report`** (video/audio PTS delta, corrections, starvation, discontinuities, pauses, encoder path).
- `ContinuousCaptureSession` — keeps capturing into the cached frame during pause so video resumes instantly on a static desktop; exposes `LastEmittedPts`/`EmittedFrameCount`.
- `RecordingTimeline` — `PauseCount`, `PausedDuration`.

**Settings / UI**
- New **Audio offset** (−500…+500 ms, default 0) in Settings → Video → Audio, with reset button. Positive delays audio, negative advances it (for Bluetooth/USB mics whose latency WASAPI doesn't report). Keyboard accessible, automation names set.

**Trimmer** — verified `MediaComposition` + `MediaTrimmingPreference.Precise` preserves stream timing; no change needed.

**Docs** — `windows/docs/audio-video-sync.md` (new sections: drift/discontinuity correction, pause/resume, ending the track, sync report, hardware listen-test checklist), `windows/README.md`, `windows/CHANGELOG.md`.

## Validation

- `dotnet test windows/tests/TinyClips.Core.Tests` — **153 passed** (10 new/updated tests: sub-tolerance jitter ignored, gap padded, overlap trimmed across packets, slow drift corrected once, discontinuity flag forces correction, pause retains audio / resumed packet placed on timeline, user offset ±, underrun advances cursor).
- `dotnet build windows/src/TinyClips.App -c Debug -p:Platform=x64` — succeeded, no new warnings.
- Hardware listen tests (clap, 5 s pause, 15 min mic + system, Bluetooth mic with offset, stop edge) are listed in the doc and still to be run on real hardware.
