### PR TITLE
Windows: teleprompter text-size and panel-height presets (parity, #295)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -8,7 +8,7 @@ own `CHANGELOG.md` at the repository root.
 ### Added
 - **Teleprompter text size and panel height presets** — Settings → Teleprompter gains **Text
   size** and **Panel height** pickers (Small / Medium / Large), matching the macOS 1.6.0 presets
-  (20/24/30 pt text; 120/140/220 pt panel). Both persist, drive the live recording overlay
+  (20/24/30 DIP text; 120/140/220 DIP panel). Both persist, drive the live recording overlay
   immediately — including while a recording is in progress — and are reflected in the Settings
   scroll preview. Keyboard/Narrator accessible. Closes #295.
 - **Audio offset setting** — Settings → Video → Audio → *Audio offset* (−500 … +500 ms, default

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,11 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Added
+- **Teleprompter text size and panel height presets** — Settings → Teleprompter gains **Text
+  size** and **Panel height** pickers (Small / Medium / Large), matching the macOS 1.6.0 presets
+  (20/24/30 pt text; 120/140/220 pt panel). Both persist, drive the live recording overlay
+  immediately — including while a recording is in progress — and are reflected in the Settings
+  scroll preview. Keyboard/Narrator accessible. Closes #295.
 - **Audio offset setting** — Settings → Video → Audio → *Audio offset* (−500 … +500 ms, default
   0) shifts all recorded audio relative to the video. Positive delays audio, negative plays it
   earlier — the fix for Bluetooth headsets and some USB microphones whose real latency WASAPI

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -2803,6 +2803,7 @@ public partial class App : Application
         if (_settingsWindow is null)
         {
             _settingsWindow = new SettingsWindow();
+            _settingsWindow.ViewModel.TeleprompterDisplayChanged += () => _teleprompter?.ApplyDisplaySettings();
             _settingsWindow.Closed += (_, _) => _settingsWindow = null;
         }
 

--- a/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/TeleprompterSettingsSection.xaml
@@ -94,6 +94,38 @@
             </StackPanel>
         </Border>
 
+            <controls:SettingsCard
+                Description="Size of the transcript text in the overlay."
+                Header="Text size"
+                HeaderIcon="{ui:FontIcon Glyph=&#xE8D2;}">
+                <ComboBox
+                    MinWidth="160"
+                    AutomationProperties.AutomationId="TeleprompterFontSizeCombo"
+                    AutomationProperties.Name="Teleprompter text size"
+                    IsEnabled="{x:Bind ViewModel.TeleprompterEnabled, Mode=OneWay}"
+                    SelectedIndex="{x:Bind ViewModel.TeleprompterFontSizeIndex, Mode=TwoWay}">
+                    <ComboBoxItem Content="Small" />
+                    <ComboBoxItem Content="Medium" />
+                    <ComboBoxItem Content="Large" />
+                </ComboBox>
+            </controls:SettingsCard>
+
+            <controls:SettingsCard
+                Description="How tall the overlay panel is, which controls how many lines are visible at once."
+                Header="Panel height"
+                HeaderIcon="{ui:FontIcon Glyph=&#xE745;}">
+                <ComboBox
+                    MinWidth="160"
+                    AutomationProperties.AutomationId="TeleprompterPanelHeightCombo"
+                    AutomationProperties.Name="Teleprompter panel height"
+                    IsEnabled="{x:Bind ViewModel.TeleprompterEnabled, Mode=OneWay}"
+                    SelectedIndex="{x:Bind ViewModel.TeleprompterPanelHeightIndex, Mode=TwoWay}">
+                    <ComboBoxItem Content="Small" />
+                    <ComboBoxItem Content="Medium" />
+                    <ComboBoxItem Content="Large" />
+                </ComboBox>
+            </controls:SettingsCard>
+
             <Border Style="{StaticResource SettingCardStyle}">
                 <StackPanel Spacing="8">
                     <Grid ColumnSpacing="16">
@@ -109,9 +141,9 @@
                             Text="{x:Bind ViewModel.TeleprompterScrollSpeedDisplay, Mode=OneWay}" />
                     </Grid>
                     <Border
-                        Height="140"
+                        Height="{x:Bind ViewModel.TeleprompterPreviewPanelHeight, Mode=OneWay}"
                         Padding="16,12"
-                        AutomationProperties.HelpText="Shows how quickly the transcript will move during a recording."
+                        AutomationProperties.HelpText="Shows how quickly the transcript will move during a recording, at the selected text size and panel height."
                         AutomationProperties.Name="Teleprompter scroll speed preview"
                         Background="#99000000"
                         CornerRadius="{StaticResource OverlayCornerRadius}">
@@ -126,7 +158,7 @@
                             ZoomMode="Disabled">
                             <TextBlock
                                 x:Name="PreviewText"
-                                FontSize="24"
+                                FontSize="{x:Bind ViewModel.TeleprompterPreviewFontSize, Mode=OneWay}"
                                 Foreground="#FFFFFFFF"
                                 TextWrapping="Wrap" />
                         </ScrollViewer>

--- a/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
@@ -570,6 +570,30 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     public string TeleprompterScrollSpeedDisplay => $"{TeleprompterScrollSpeed:N0} DIPs/s";
 
+    /// <summary>0 = Small, 1 = Medium, 2 = Large (matches <see cref="TeleprompterDisplaySize"/>).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TeleprompterPreviewFontSize))]
+    private int _teleprompterFontSizeIndex = (int)TeleprompterDisplaySize.Medium;
+
+    /// <summary>0 = Small, 1 = Medium, 2 = Large (matches <see cref="TeleprompterDisplaySize"/>).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TeleprompterPreviewPanelHeight))]
+    private int _teleprompterPanelHeightIndex = (int)TeleprompterDisplaySize.Medium;
+
+    public double TeleprompterPreviewFontSize => ToTeleprompterDisplaySize(TeleprompterFontSizeIndex).FontSize();
+
+    public double TeleprompterPreviewPanelHeight => ToTeleprompterDisplaySize(TeleprompterPanelHeightIndex).PanelHeight();
+
+    /// <summary>Raised when the overlay text size or panel height preset changes, so a live overlay can re-apply it.</summary>
+    public event Action? TeleprompterDisplayChanged;
+
+    private static TeleprompterDisplaySize ToTeleprompterDisplaySize(int index) => index switch
+    {
+        0 => TeleprompterDisplaySize.Small,
+        2 => TeleprompterDisplaySize.Large,
+        _ => TeleprompterDisplaySize.Medium,
+    };
+
     // Analytics
     public System.Collections.ObjectModel.ObservableCollection<CaptureAnalyticsDayViewModel> AnalyticsDays { get; } = new();
 
@@ -820,6 +844,8 @@ public sealed partial class SettingsViewModel : ObservableObject
             TeleprompterEnabled = _settings.TeleprompterEnabled;
             TeleprompterTranscript = _settings.TeleprompterTranscript;
             TeleprompterScrollSpeed = Math.Clamp(_settings.TeleprompterScrollSpeed, 10.0, 200.0);
+            TeleprompterFontSizeIndex = (int)_settings.TeleprompterFontSize;
+            TeleprompterPanelHeightIndex = (int)_settings.TeleprompterPanelHeight;
         }
         finally
         {
@@ -1312,6 +1338,18 @@ public sealed partial class SettingsViewModel : ObservableObject
     }
 
     partial void OnTeleprompterScrollSpeedChanged(double value) => Persist(() => _settings.TeleprompterScrollSpeed = value);
+
+    partial void OnTeleprompterFontSizeIndexChanged(int value) => Persist(() =>
+    {
+        _settings.TeleprompterFontSize = ToTeleprompterDisplaySize(value);
+        TeleprompterDisplayChanged?.Invoke();
+    });
+
+    partial void OnTeleprompterPanelHeightIndexChanged(int value) => Persist(() =>
+    {
+        _settings.TeleprompterPanelHeight = ToTeleprompterDisplaySize(value);
+        TeleprompterDisplayChanged?.Invoke();
+    });
 
     partial void OnAnalyticsRangeIndexChanged(int value)
     {

--- a/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
+++ b/windows/src/TinyClips.App/ViewModels/SettingsViewModel.cs
@@ -1390,6 +1390,9 @@ public sealed partial class SettingsViewModel : ObservableObject
         _settings.ResetToDefaults();
         Load();
         ThemeChanged?.Invoke();
+        // Load() runs under the _loading guard, so the per-property persistence callbacks (and
+        // their live notifications) are suppressed; tell an active overlay explicitly.
+        TeleprompterDisplayChanged?.Invoke();
     }
 
     public void ResetAnalytics()

--- a/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
@@ -128,15 +128,25 @@ public sealed partial class TeleprompterWindow : Window
             AppWindow.Resize(new SizeInt32(AppWindow.Size.Width, height));
         }
 
-        // A shorter panel may leave the current offset past the new maximum; re-evaluate so
-        // scrolling stops or continues correctly from the clamped position.
-        var maxOffset = Math.Max(0, Scroller.ExtentHeight - Scroller.ViewportHeight);
-        if (Scroller.VerticalOffset > maxOffset)
+        // ExtentHeight/ViewportHeight still reflect the previous font and window size until layout
+        // has run, so defer the clamp/restart to a low-priority pass after the resize and
+        // re-measure have been processed. Otherwise a font-only change that turns fitting text
+        // into overflowing text would be evaluated against the stale extent and never start.
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
-            Scroller.ChangeView(null, maxOffset, null, disableAnimation: true);
-        }
+            if (_closed)
+            {
+                return;
+            }
 
-        StartScrollingIfPossible();
+            var maxOffset = Math.Max(0, Scroller.ExtentHeight - Scroller.ViewportHeight);
+            if (Scroller.VerticalOffset > maxOffset)
+            {
+                Scroller.ChangeView(null, maxOffset, null, disableAnimation: true);
+            }
+
+            StartScrollingIfPossible();
+        });
     }
 
     private void OnSizeChanged(object sender, WindowSizeChangedEventArgs args)

--- a/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/TeleprompterWindow.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using TinyClips.Core.Capture;
+using TinyClips.Core.Models;
 using TinyClips.Core.Services;
 using Windows.Graphics;
 using WinRT.Interop;
@@ -19,8 +20,10 @@ namespace TinyClips.App;
 public sealed partial class TeleprompterWindow : Window
 {
     private const int WidthDip = 600;
-    private const int HeightDip = 140;
     private const int TopOffsetDip = 24;
+
+    /// <summary>Current panel height preset, in DIPs (Settings → Teleprompter → Panel height).</summary>
+    private int HeightDip => (int)Math.Round(_settings.TeleprompterPanelHeight.PanelHeight());
 
     // The capture-exclusion style makes the window read back as fully transparent to XAML
     // hit-testing; a ~1% alpha background keeps the panel draggable without showing a fill.
@@ -50,6 +53,7 @@ public sealed partial class TeleprompterWindow : Window
         _settings = settings;
         _monitorService = monitorService;
         TranscriptText.Text = settings.TeleprompterTranscript;
+        TranscriptText.FontSize = settings.TeleprompterFontSize.FontSize();
         _scrollSpeedDipPerSecond = Math.Max(1.0, settings.TeleprompterScrollSpeed);
 
         RootGrid.Background = SizingSurfaceBrush;
@@ -100,6 +104,39 @@ public sealed partial class TeleprompterWindow : Window
         _closed = true;
         _scrollTimer.Stop();
         Close();
+    }
+
+    /// <summary>
+    /// Re-reads the text-size and panel-height presets from settings and applies them to the live
+    /// overlay, keeping the panel's top-left position and the current scroll offset so a change
+    /// made mid-recording is reflected without restarting.
+    /// </summary>
+    public void ApplyDisplaySettings()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        TranscriptText.FontSize = _settings.TeleprompterFontSize.FontSize();
+
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var scale = AppWindowPlacement.GetScaleForWindow(hwnd);
+        var height = AppWindowPlacement.DipToPixels(HeightDip, scale);
+        if (AppWindow.Size.Height != height)
+        {
+            AppWindow.Resize(new SizeInt32(AppWindow.Size.Width, height));
+        }
+
+        // A shorter panel may leave the current offset past the new maximum; re-evaluate so
+        // scrolling stops or continues correctly from the clamped position.
+        var maxOffset = Math.Max(0, Scroller.ExtentHeight - Scroller.ViewportHeight);
+        if (Scroller.VerticalOffset > maxOffset)
+        {
+            Scroller.ChangeView(null, maxOffset, null, disableAnimation: true);
+        }
+
+        StartScrollingIfPossible();
     }
 
     private void OnSizeChanged(object sender, WindowSizeChangedEventArgs args)

--- a/windows/src/TinyClips.Core/Models/TeleprompterDisplaySize.cs
+++ b/windows/src/TinyClips.Core/Models/TeleprompterDisplaySize.cs
@@ -1,0 +1,45 @@
+namespace TinyClips.Core.Models;
+
+/// <summary>
+/// Small / Medium / Large presets for the teleprompter overlay's text size and panel height.
+/// Values mirror the macOS <c>TeleprompterDisplaySize</c> so both apps read the same way.
+/// </summary>
+public enum TeleprompterDisplaySize
+{
+    Small = 0,
+    Medium = 1,
+    Large = 2,
+}
+
+public static class TeleprompterDisplaySizeExtensions
+{
+    /// <summary>Vertical padding inside the panel (top + bottom) that is not part of the text viewport.</summary>
+    public const double PanelVerticalPaddingDip = 24;
+
+    /// <summary>Overlay transcript font size, in DIPs.</summary>
+    public static double FontSize(this TeleprompterDisplaySize size) => size switch
+    {
+        TeleprompterDisplaySize.Small => 20,
+        TeleprompterDisplaySize.Large => 30,
+        _ => 24,
+    };
+
+    /// <summary>Total overlay panel height (including padding), in DIPs.</summary>
+    public static double PanelHeight(this TeleprompterDisplaySize size) => size switch
+    {
+        TeleprompterDisplaySize.Small => 120,
+        TeleprompterDisplaySize.Large => 220,
+        _ => 140,
+    };
+
+    /// <summary>Height of the scrolling text viewport (panel height minus padding), in DIPs.</summary>
+    public static double ViewportHeight(this TeleprompterDisplaySize size) =>
+        size.PanelHeight() - PanelVerticalPaddingDip;
+
+    public static string Label(this TeleprompterDisplaySize size) => size switch
+    {
+        TeleprompterDisplaySize.Small => "Small",
+        TeleprompterDisplaySize.Large => "Large",
+        _ => "Medium",
+    };
+}

--- a/windows/src/TinyClips.Core/Services/CaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/CaptureSettings.cs
@@ -558,6 +558,18 @@ public sealed class CaptureSettings : ICaptureSettings
         set => _settings.Set("teleprompterScrollSpeed", value);
     }
 
+    public TeleprompterDisplaySize TeleprompterFontSize
+    {
+        get => ParseTeleprompterDisplaySize(_settings.Get("teleprompterFontSize", "medium"));
+        set => _settings.Set("teleprompterFontSize", ToPersistedTeleprompterDisplaySize(value));
+    }
+
+    public TeleprompterDisplaySize TeleprompterPanelHeight
+    {
+        get => ParseTeleprompterDisplaySize(_settings.Get("teleprompterPanelHeight", "medium"));
+        set => _settings.Set("teleprompterPanelHeight", ToPersistedTeleprompterDisplaySize(value));
+    }
+
     public double TeleprompterPosX
     {
         get => _settings.Get("teleprompterPosX", -1.0);
@@ -769,6 +781,8 @@ public sealed class CaptureSettings : ICaptureSettings
         TeleprompterEnabled = false;
         TeleprompterTranscript = string.Empty;
         TeleprompterScrollSpeed = 50.0;
+        TeleprompterFontSize = TeleprompterDisplaySize.Medium;
+        TeleprompterPanelHeight = TeleprompterDisplaySize.Medium;
         TeleprompterPosX = -1.0;
         TeleprompterPosY = -1.0;
         TeleprompterMonitorDeviceName = string.Empty;
@@ -856,6 +870,21 @@ public sealed class CaptureSettings : ICaptureSettings
         WebcamSizePreset.Small => "small",
         WebcamSizePreset.Medium => "medium",
         WebcamSizePreset.Large => "large",
+        _ => "medium",
+    };
+
+    private static TeleprompterDisplaySize ParseTeleprompterDisplaySize(string value) =>
+        (value ?? string.Empty).ToLowerInvariant() switch
+        {
+            "small" => TeleprompterDisplaySize.Small,
+            "large" => TeleprompterDisplaySize.Large,
+            _ => TeleprompterDisplaySize.Medium,
+        };
+
+    private static string ToPersistedTeleprompterDisplaySize(TeleprompterDisplaySize value) => value switch
+    {
+        TeleprompterDisplaySize.Small => "small",
+        TeleprompterDisplaySize.Large => "large",
         _ => "medium",
     };
 

--- a/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
+++ b/windows/src/TinyClips.Core/Services/ICaptureSettings.cs
@@ -89,6 +89,10 @@ public interface ICaptureSettings
     bool TeleprompterEnabled { get; set; }
     string TeleprompterTranscript { get; set; }
     double TeleprompterScrollSpeed { get; set; }
+    /// <summary>Overlay transcript text size preset. Default Medium (24 DIP).</summary>
+    TeleprompterDisplaySize TeleprompterFontSize { get; set; }
+    /// <summary>Overlay panel height preset. Default Medium (140 DIP).</summary>
+    TeleprompterDisplaySize TeleprompterPanelHeight { get; set; }
     double TeleprompterPosX { get; set; }
     double TeleprompterPosY { get; set; }
     string TeleprompterMonitorDeviceName { get; set; }

--- a/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/CaptureSettingsTests.cs
@@ -161,6 +161,51 @@ public sealed class CaptureSettingsTests
     }
 
     [Fact]
+    public void TeleprompterDisplaySizes_DefaultToMediumAndRoundTrip()
+    {
+        var settingsService = new TestSettingsService();
+        var settings = new CaptureSettings(settingsService);
+
+        Assert.Equal(TeleprompterDisplaySize.Medium, settings.TeleprompterFontSize);
+        Assert.Equal(TeleprompterDisplaySize.Medium, settings.TeleprompterPanelHeight);
+
+        settings.TeleprompterFontSize = TeleprompterDisplaySize.Large;
+        settings.TeleprompterPanelHeight = TeleprompterDisplaySize.Small;
+
+        Assert.Equal(TeleprompterDisplaySize.Large, settings.TeleprompterFontSize);
+        Assert.Equal(TeleprompterDisplaySize.Small, settings.TeleprompterPanelHeight);
+        // Persisted as the same lowercase tokens the macOS app uses.
+        Assert.Equal("large", settingsService.Get("teleprompterFontSize", string.Empty));
+        Assert.Equal("small", settingsService.Get("teleprompterPanelHeight", string.Empty));
+
+        settings.ResetToDefaults();
+
+        Assert.Equal(TeleprompterDisplaySize.Medium, settings.TeleprompterFontSize);
+        Assert.Equal(TeleprompterDisplaySize.Medium, settings.TeleprompterPanelHeight);
+    }
+
+    [Fact]
+    public void TeleprompterDisplaySizes_UnknownPersistedValueFallsBackToMedium()
+    {
+        var settingsService = new TestSettingsService();
+        settingsService.Set("teleprompterFontSize", "gigantic");
+        var settings = new CaptureSettings(settingsService);
+
+        Assert.Equal(TeleprompterDisplaySize.Medium, settings.TeleprompterFontSize);
+    }
+
+    [Theory]
+    [InlineData(TeleprompterDisplaySize.Small, 20, 120)]
+    [InlineData(TeleprompterDisplaySize.Medium, 24, 140)]
+    [InlineData(TeleprompterDisplaySize.Large, 30, 220)]
+    public void TeleprompterDisplaySize_PresetsMatchMacParity(TeleprompterDisplaySize size, double fontSize, double panelHeight)
+    {
+        Assert.Equal(fontSize, size.FontSize());
+        Assert.Equal(panelHeight, size.PanelHeight());
+        Assert.Equal(panelHeight - TeleprompterDisplaySizeExtensions.PanelVerticalPaddingDip, size.ViewportHeight());
+    }
+
+    [Fact]
     public void RoundTrip_StoresExpectedValues()
     {
         var settings = CreateSettings();


### PR DESCRIPTION
Closes #295

## Summary

Brings the Windows teleprompter overlay to parity with macOS 1.6.0 by adding **Text size** and **Panel height** presets (Small / Medium / Large).

| Preset | Font size | Panel height |
|--------|-----------|--------------|
| Small  | 20        | 120          |
| Medium | 24 (default) | 140 (default) |
| Large  | 30        | 220          |

## Changes

- **Core**: `TeleprompterDisplaySize` enum with `FontSize()` / `PanelHeight()` / `ViewportHeight()` extensions; `TeleprompterFontSize` and `TeleprompterPanelHeight` on `ICaptureSettings` / `CaptureSettings`, persisted as `small|medium|large` (same keys/tokens as the mac app), default Medium, unknown values fall back to Medium.
- **Settings UI**: two `SettingsCard` combo pickers under Teleprompter (between Scroll speed and Preview) with automation IDs/names; disabled when the teleprompter is off. The scroll-speed preview now renders at the chosen font size and panel height.
- **Overlay**: `TeleprompterWindow` sizes itself from the panel-height preset and applies the font-size preset; new `ApplyDisplaySettings()` re-applies both on a live overlay (resizes in place, clamps scroll offset). `App` subscribes to the view model's `TeleprompterDisplayChanged` so changes made in Settings during a recording take effect immediately.
- **Tests**: defaults, round-trip + reset, persisted token format, unknown-value fallback, and preset value table.

## Validation

- `dotnet test windows/tests/TinyClips.Core.Tests` — 164 passed.
- `dotnet build windows/src/TinyClips.App -c Debug -p:Platform=x64` — succeeded.

## Acceptance criteria

- [x] Settings → Teleprompter shows a **Text size** control with Small / Medium / Large
- [x] Settings → Teleprompter shows a **Panel height** control with Small / Medium / Large
- [x] Changes persist across restarts
- [x] Live overlay reflects the chosen size/height without restarting recording
- [x] Keyboard-navigable and Narrator-accessible (standard `ComboBox` + `AutomationProperties.Name`)
- [x] Windows unit tests pass
