### PR TITLE
Windows: 3×3 image-alignment grid in the screenshot editor (parity, #296)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,15 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Changed
+- **Screenshot editor image alignment is now a 3×3 placement grid** — the Background section's
+  separate Horizontal / Vertical alignment combo boxes are replaced by a single labeled 3×3 grid
+  of toggle cells, so any export-frame placement (e.g. bottom-right) is one click and every
+  combination is visible at once. The selected cell is highlighted; arrow keys move between cells
+  and each cell has a Narrator name ("Top-left image alignment", …). The grid is disabled when the
+  frame is Original (no free space on either axis). Export alignment logic is unchanged. Mirrors
+  the macOS 1.6.0 editor. Closes #296.
+
 ### Added
 - **Audio offset setting** — Settings → Video → Audio → *Audio offset* (−500 … +500 ms, default
   0) shifts all recorded audio relative to the video. Positive delays audio, negative plays it

--- a/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml
+++ b/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml
@@ -273,10 +273,11 @@
                                         <Setter Property="HorizontalContentAlignment" Value="Center" />
                                         <Setter Property="VerticalContentAlignment" Value="Center" />
                                     </Style>
-                                    <Style x:Key="AlignmentDotStyle" TargetType="Ellipse">
-                                        <Setter Property="Width" Value="8" />
-                                        <Setter Property="Height" Value="8" />
-                                        <Setter Property="Fill" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                    <!--  A glyph (not a shape) so the dot inherits the cell's state foreground.  -->
+                                    <Style x:Key="AlignmentDotStyle" TargetType="TextBlock">
+                                        <Setter Property="Text" Value="&#x25CF;" />
+                                        <Setter Property="FontSize" Value="10" />
+                                        <Setter Property="IsTextSelectionEnabled" Value="False" />
                                     </Style>
                                 </Grid.Resources>
                                 <Grid.RowDefinitions>

--- a/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml
+++ b/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml
@@ -245,26 +245,62 @@
                             <ComboBoxItem Content="3:4" />
                             <ComboBoxItem Content="9:16" />
                         </ComboBox>
-                        <ComboBox
-                            x:Name="HorizontalAlignmentCombo"
-                            AutomationProperties.AutomationId="EditorHorizontalAlignmentCombo"
-                            AutomationProperties.Name="Horizontal image alignment"
-                            Header="Horizontal alignment"
-                            SelectionChanged="OnHorizontalAlignmentChanged">
-                            <ComboBoxItem Content="Left" />
-                            <ComboBoxItem Content="Center" />
-                            <ComboBoxItem Content="Right" />
-                        </ComboBox>
-                        <ComboBox
-                            x:Name="VerticalAlignmentCombo"
-                            AutomationProperties.AutomationId="EditorVerticalAlignmentCombo"
-                            AutomationProperties.Name="Vertical image alignment"
-                            Header="Vertical alignment"
-                            SelectionChanged="OnVerticalAlignmentChanged">
-                            <ComboBoxItem Content="Top" />
-                            <ComboBoxItem Content="Center" />
-                            <ComboBoxItem Content="Bottom" />
-                        </ComboBox>
+                        <StackPanel Spacing="6">
+                            <TextBlock
+                                x:Name="AlignmentHeader"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="Image alignment" />
+                            <!--
+                                3×3 placement grid: one tap sets both axes. Each cell is a ToggleButton
+                                whose checked state mirrors the controller's H+V alignment; arrow keys
+                                move between cells, Space/Enter selects.
+                            -->
+                            <Grid
+                                x:Name="AlignmentGrid"
+                                HorizontalAlignment="Left"
+                                AutomationProperties.Name="Image alignment"
+                                ColumnSpacing="4"
+                                RowSpacing="4"
+                                XYFocusKeyboardNavigation="Enabled">
+                                <Grid.Resources>
+                                    <Style x:Key="AlignmentCellStyle" TargetType="ToggleButton">
+                                        <Setter Property="Width" Value="40" />
+                                        <Setter Property="Height" Value="32" />
+                                        <Setter Property="Padding" Value="0" />
+                                        <Setter Property="MinWidth" Value="0" />
+                                        <Setter Property="MinHeight" Value="0" />
+                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                                    </Style>
+                                    <Style x:Key="AlignmentDotStyle" TargetType="Ellipse">
+                                        <Setter Property="Width" Value="8" />
+                                        <Setter Property="Height" Value="8" />
+                                        <Setter Property="Fill" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                    </Style>
+                                </Grid.Resources>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <ToggleButton Grid.Row="0" Grid.Column="0" Style="{StaticResource AlignmentCellStyle}" Tag="0,0" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignTopLeft" AutomationProperties.Name="Top-left image alignment" ToolTipService.ToolTip="Top left"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="0" Grid.Column="1" Style="{StaticResource AlignmentCellStyle}" Tag="1,0" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignTopCenter" AutomationProperties.Name="Top-center image alignment" ToolTipService.ToolTip="Top center"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="0" Grid.Column="2" Style="{StaticResource AlignmentCellStyle}" Tag="2,0" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignTopRight" AutomationProperties.Name="Top-right image alignment" ToolTipService.ToolTip="Top right"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="1" Grid.Column="0" Style="{StaticResource AlignmentCellStyle}" Tag="0,1" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignMiddleLeft" AutomationProperties.Name="Middle-left image alignment" ToolTipService.ToolTip="Middle left"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="1" Grid.Column="1" Style="{StaticResource AlignmentCellStyle}" Tag="1,1" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignCenter" AutomationProperties.Name="Center image alignment" ToolTipService.ToolTip="Center"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="1" Grid.Column="2" Style="{StaticResource AlignmentCellStyle}" Tag="2,1" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignMiddleRight" AutomationProperties.Name="Middle-right image alignment" ToolTipService.ToolTip="Middle right"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="2" Grid.Column="0" Style="{StaticResource AlignmentCellStyle}" Tag="0,2" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignBottomLeft" AutomationProperties.Name="Bottom-left image alignment" ToolTipService.ToolTip="Bottom left"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="2" Grid.Column="1" Style="{StaticResource AlignmentCellStyle}" Tag="1,2" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignBottomCenter" AutomationProperties.Name="Bottom-center image alignment" ToolTipService.ToolTip="Bottom center"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                                <ToggleButton Grid.Row="2" Grid.Column="2" Style="{StaticResource AlignmentCellStyle}" Tag="2,2" Click="OnAlignmentCellClicked" AutomationProperties.AutomationId="EditorAlignBottomRight" AutomationProperties.Name="Bottom-right image alignment" ToolTipService.ToolTip="Bottom right"><TextBlock Style="{StaticResource AlignmentDotStyle}" /></ToggleButton>
+                            </Grid>
+                        </StackPanel>
                         <Slider
                             x:Name="CornerSlider"
                             AutomationProperties.AutomationId="EditorCornerSlider"

--- a/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml.cs
+++ b/windows/src/TinyClips.App/Controls/ScreenshotEditor/EditorInspector.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -104,8 +106,7 @@ public sealed partial class EditorInspector : UserControl
         CornerSlider.Value = _controller.CanvasCornerRadius;
         ShadowSlider.Value = _controller.CanvasShadow;
         ExportFrameCombo.SelectedIndex = (int)_controller.FramePreset;
-        HorizontalAlignmentCombo.SelectedIndex = (int)_controller.HorizontalExportAlignment;
-        VerticalAlignmentCombo.SelectedIndex = (int)_controller.VerticalExportAlignment;
+        SyncAlignmentGrid();
         UpdateSliderHeaders();
         UpdateBackgroundStyleUi();
         UpdateExportFrameControls();
@@ -469,19 +470,55 @@ public sealed partial class EditorInspector : UserControl
         UpdateExportFrameControls();
     }
 
-    private void OnHorizontalAlignmentChanged(object sender, SelectionChangedEventArgs e)
+    private void OnAlignmentCellClicked(object sender, RoutedEventArgs e)
     {
+        if (sender is not ToggleButton cell || cell.Tag is not string tag || !TryParseAlignmentTag(tag, out var h, out var v))
+        {
+            return;
+        }
+
         if (!_bgInitializing)
         {
-            _controller.SetHorizontalExportAlignment((ExportHorizontalAlignment)HorizontalAlignmentCombo.SelectedIndex);
+            _controller.SetHorizontalExportAlignment(h);
+            _controller.SetVerticalExportAlignment(v);
         }
+
+        // The grid is a single-selection control: the clicked cell is always the one checked,
+        // even when the user clicks the already-selected cell (ToggleButton would uncheck it).
+        SyncAlignmentGrid();
     }
 
-    private void OnVerticalAlignmentChanged(object sender, SelectionChangedEventArgs e)
+    private static bool TryParseAlignmentTag(string tag, out ExportHorizontalAlignment h, out ExportVerticalAlignment v)
     {
-        if (!_bgInitializing)
+        h = ExportHorizontalAlignment.Center;
+        v = ExportVerticalAlignment.Center;
+        var parts = tag.Split(',');
+        if (parts.Length != 2 || !int.TryParse(parts[0], out var hi) || !int.TryParse(parts[1], out var vi))
         {
-            _controller.SetVerticalExportAlignment((ExportVerticalAlignment)VerticalAlignmentCombo.SelectedIndex);
+            return false;
+        }
+
+        h = (ExportHorizontalAlignment)Math.Clamp(hi, 0, 2);
+        v = (ExportVerticalAlignment)Math.Clamp(vi, 0, 2);
+        return true;
+    }
+
+    private IEnumerable<ToggleButton> AlignmentCells => AlignmentGrid.Children.OfType<ToggleButton>();
+
+    /// <summary>Checks exactly the cell matching the controller's current H+V alignment.</summary>
+    private void SyncAlignmentGrid()
+    {
+        var h = _controller.HorizontalExportAlignment;
+        var v = _controller.VerticalExportAlignment;
+        foreach (var cell in AlignmentCells)
+        {
+            var selected = cell.Tag is string tag &&
+                TryParseAlignmentTag(tag, out var cellH, out var cellV) &&
+                cellH == h && cellV == v;
+            if (cell.IsChecked != selected)
+            {
+                cell.IsChecked = selected;
+            }
         }
     }
 
@@ -516,7 +553,13 @@ public sealed partial class EditorInspector : UserControl
 
     private void UpdateExportFrameControls()
     {
-        HorizontalAlignmentCombo.IsEnabled = _controller.HasHorizontalExportFrameSpace;
-        VerticalAlignmentCombo.IsEnabled = _controller.HasVerticalExportFrameSpace;
+        // Placement only matters when the export frame leaves room on at least one axis
+        // (Original has none). A cell's other axis is harmless when that axis has no space.
+        var enabled = _controller.HasHorizontalExportFrameSpace || _controller.HasVerticalExportFrameSpace;
+        AlignmentHeader.Opacity = enabled ? 1.0 : 0.5;
+        foreach (var cell in AlignmentCells)
+        {
+            cell.IsEnabled = enabled;
+        }
     }
 }


### PR DESCRIPTION
Closes #296

## Summary

Replaces the Windows screenshot editor's two image-alignment `ComboBox` controls (Horizontal: Left/Center/Right, Vertical: Top/Center/Bottom) with a single **3×3 placement grid**, matching the macOS 1.6.0 editor. One click sets both axes; every combination is visible at once.

## Changes

**`EditorInspector.xaml`**
- Background section: new "Image alignment" caption + a `Grid` of nine `ToggleButton` cells (40×32, dot glyph content that inherits the cell's state foreground so it stays readable on the accent-filled selected cell).
- `XYFocusKeyboardNavigation="Enabled"` on the grid so arrow keys move between cells; Space/Enter selects.
- Each cell has an `AutomationId` (`EditorAlignTopLeft` … `EditorAlignBottomRight`), an `AutomationProperties.Name` ("Top-left image alignment", …) and a tooltip.

**`EditorInspector.xaml.cs`**
- `OnAlignmentCellClicked` parses the cell's `Tag` ("h,v") and calls the existing `SetHorizontalExportAlignment` / `SetVerticalExportAlignment` on `EditorController`.
- `SyncAlignmentGrid` keeps exactly one cell checked from the controller's current H+V state (also prevents un-checking the selected cell, so the grid behaves as single-select).
- `UpdateExportFrameControls` disables all cells (and dims the caption) when neither axis has free frame space (i.e. frame = Original).

`EditorController` / `EditorModels` export-alignment logic is untouched.

## Validation

- `dotnet build windows/src/TinyClips.App -c Debug -p:Platform=x64` — succeeded, no new warnings.
- No Core changes, so `TinyClips.Core.Tests` are unaffected (164 passing on main).

## Acceptance criteria

- [x] Inspector shows a 3×3 alignment grid instead of two combo boxes (enabled when a non-Original frame is selected)
- [x] Clicking any cell immediately updates the editor preview (same controller calls as before)
- [x] Selected cell is visually distinct (checked ToggleButton accent fill)
- [x] All 9 positions are keyboard-reachable (Tab + arrow keys) and have Narrator names
- [x] `ExportHorizontalAlignment` / `ExportVerticalAlignment` logic unchanged — UI only
