### PR TITLE
Update tray footer button label to "Recognize Text"

### DIFF
--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -387,7 +387,7 @@ public partial class App : Application
 
         footerActions.Children.Add(CreateFooterButton(
             GlyphTextRecognition,
-            $"Capture Text ({hotKeys.GetBinding(HotKeyAction.RecognizeText).DisplayString})",
+            $"Recognize Text ({hotKeys.GetBinding(HotKeyAction.RecognizeText).DisplayString})",
             "TrayCaptureTextButton",
             new AsyncRelayCommand(RecognizeTextAsync),
             Dismiss));
@@ -399,12 +399,7 @@ public partial class App : Application
             new AsyncRelayCommand(CheckForUpdatesFromTrayAsync),
             Dismiss));
 #endif
-        footerActions.Children.Add(CreateFooterButton(
-            GlyphSettings,
-            "Settings",
-            "TraySettingsButton",
-            new RelayCommand(OpenSettingsWindow),
-            Dismiss));
+
         footerActions.Children.Add(CreateFooterButton(
             GlyphDocument,
             "Guide",
@@ -417,7 +412,13 @@ public partial class App : Application
             "TrayFileBugButton",
             new RelayCommand(OpenQuickBugReportWindow),
             Dismiss));
-        footerActions.Children.Add(CreateFooterButton(
+		footerActions.Children.Add(CreateFooterButton(
+	        GlyphSettings,
+	        "Settings",
+	        "TraySettingsButton",
+	        new RelayCommand(OpenSettingsWindow),
+	        Dismiss));
+		footerActions.Children.Add(CreateFooterButton(
             GlyphExit,
             "Exit",
             "TrayExitButton",

--- a/windows/src/TinyClips.App/Controls/Settings/GeneralSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/GeneralSettingsSection.xaml
@@ -151,14 +151,6 @@
                 Text="Capture behavior" />
 
             <StackPanel Spacing="2">
-                <controls:SettingsCard
-                    Header="Copy screenshots to the clipboard"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xE8C8;}">
-                    <ToggleSwitch
-                        AutomationProperties.AutomationId="CopyScreenshotToggle"
-                        AutomationProperties.Name="Copy screenshots to the clipboard"
-                        IsOn="{x:Bind ViewModel.CopyScreenshotToClipboard, Mode=TwoWay}" />
-                </controls:SettingsCard>
 
                 <controls:SettingsCard
                     Description="Add a small Tiny Clips watermark to the corner of captures."

--- a/windows/src/TinyClips.App/Controls/Settings/GifSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/GifSettingsSection.xaml
@@ -68,6 +68,18 @@
                         IsOn="{x:Bind ViewModel.ShowGifCapturePicker, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
+
+                <controls:SettingsCard
+                    Description="Start another GIF recording with the same picker after saving."
+                    Header="Show capture picker after recording"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                    <ToggleSwitch
+                        AutomationProperties.AutomationId="ShowGifCapturePickerAfterCaptureToggle"
+                        AutomationProperties.Name="Show capture picker after GIF recording"
+                        IsEnabled="{x:Bind ViewModel.GifCapturePickerAfterCaptureEnabled, Mode=OneWay}"
+                        IsOn="{x:Bind ViewModel.ShowGifCapturePickerAfterCapture, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
                 <controls:SettingsCard
                     Header="Countdown before recording"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE823;}">
@@ -110,16 +122,6 @@
                         IsOn="{x:Bind ViewModel.CopyGifToClipboard, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
-                <controls:SettingsCard
-                    Description="Start another GIF recording with the same picker after saving."
-                    Header="Show capture picker after recording"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
-                    <ToggleSwitch
-                        AutomationProperties.AutomationId="ShowGifCapturePickerAfterCaptureToggle"
-                        AutomationProperties.Name="Show capture picker after GIF recording"
-                        IsEnabled="{x:Bind ViewModel.GifCapturePickerAfterCaptureEnabled, Mode=OneWay}"
-                        IsOn="{x:Bind ViewModel.ShowGifCapturePickerAfterCapture, Mode=TwoWay}" />
-                </controls:SettingsCard>
             </StackPanel>
         </StackPanel>
     </Border>

--- a/windows/src/TinyClips.App/Controls/Settings/ScreenshotSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/ScreenshotSettingsSection.xaml
@@ -134,6 +134,15 @@
                         AutomationProperties.Name="Re-capture screen after region selection"
                         IsOn="{x:Bind ViewModel.ScreenshotUsesLiveCapture, Mode=TwoWay}" />
                 </controls:SettingsCard>
+
+                <controls:SettingsCard
+                    Header="Copy screenshots to the clipboard"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE8C8;}">
+                    <ToggleSwitch
+                        AutomationProperties.AutomationId="CopyScreenshotToggle"
+                        AutomationProperties.Name="Copy screenshots to the clipboard"
+                        IsOn="{x:Bind ViewModel.CopyScreenshotToClipboard, Mode=TwoWay}" />
+                </controls:SettingsCard>
             </StackPanel>
         </StackPanel>
     </Border>

--- a/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
@@ -248,6 +248,18 @@
                         IsOn="{x:Bind ViewModel.ShowVideoCapturePicker, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
+
+                <controls:SettingsCard
+                    Description="Start another recording with the same picker after saving."
+                    Header="Show capture picker after recording"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                    <ToggleSwitch
+                        AutomationProperties.AutomationId="ShowVideoCapturePickerAfterCaptureToggle"
+                        AutomationProperties.Name="Show capture picker after recording"
+                        IsEnabled="{x:Bind ViewModel.VideoCapturePickerAfterCaptureEnabled, Mode=OneWay}"
+                        IsOn="{x:Bind ViewModel.ShowVideoCapturePickerAfterCapture, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
                 <controls:SettingsCard
                     Header="Countdown before recording"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE823;}">
@@ -304,16 +316,6 @@
                         IsOn="{x:Bind ViewModel.CopyVideoToClipboard, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
-                <controls:SettingsCard
-                    Description="Start another recording with the same picker after saving."
-                    Header="Show capture picker after recording"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
-                    <ToggleSwitch
-                        AutomationProperties.AutomationId="ShowVideoCapturePickerAfterCaptureToggle"
-                        AutomationProperties.Name="Show capture picker after recording"
-                        IsEnabled="{x:Bind ViewModel.VideoCapturePickerAfterCaptureEnabled, Mode=OneWay}"
-                        IsOn="{x:Bind ViewModel.ShowVideoCapturePickerAfterCapture, Mode=TwoWay}" />
-                </controls:SettingsCard>
             </StackPanel>
         </StackPanel>
     </Border>


### PR DESCRIPTION
Update tray footer button label to "Recognize Text"

Changed the tray footer button label in App.xaml.cs from "Capture Text" to "Recognize Text" to more accurately describe its function, which is to recognize text rather than capture it.

Update tray label and reorder capture picker setting

Changed tray button label to "Recognize Text" for clarity. Moved "Show capture picker after recording" setting above "Countdown before recording" in GIF and video settings sections for improved UI grouping; no logic changes.