### PR TITLE
Windows: fix 0xC000027B startup crash behind winget Validation-Executable-Error

### DIFF
--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -8,6 +8,8 @@ name: Windows Launch Smoke (winget harness repro)
 # winget moderators only sometimes paste into the PR.
 
 on:
+  push:
+    branches: [diag/winget-launch-smoke]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -40,9 +42,9 @@ jobs:
             runner: windows-11-arm
 
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      ASSET_VERSION: ${{ inputs.asset_version }}
-      WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      RELEASE_TAG: ${{ inputs.release_tag || 'v1.7.1-windows' }}
+      ASSET_VERSION: ${{ inputs.asset_version || '1.7.1' }}
+      WAIT_SECONDS: ${{ inputs.wait_seconds || '60' }}
       ARCH: ${{ matrix.arch }}
       GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -12,8 +12,6 @@ name: Windows Launch Smoke (winget harness repro)
 # fix can be verified before cutting a release.
 
 on:
-  push:
-    branches: [diag/winget-launch-smoke]
   workflow_dispatch:
     inputs:
       source:
@@ -52,7 +50,7 @@ jobs:
             runner: windows-11-arm
 
     env:
-      SOURCE: ${{ inputs.source || 'build' }}
+      SOURCE: ${{ inputs.source || 'release' }}
       RELEASE_TAG: ${{ inputs.release_tag || 'v1.7.1-windows' }}
       ASSET_VERSION: ${{ inputs.asset_version || '1.7.1' }}
       WAIT_SECONDS: ${{ inputs.wait_seconds || '60' }}

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -1,0 +1,168 @@
+name: Windows Launch Smoke (winget harness repro)
+
+# Reproduces the winget-pkgs "Installation Validation" step on real x64 and ARM64 runners:
+# install the framework-dependent release MSIX together with its declared dependencies, launch
+# TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the harness does), and report
+# whether the process survives. On a crash the job collects the app's crash.log plus the
+# ".NET Runtime" / "Application Error" event-log records, which carry the managed stack that the
+# winget moderators only sometimes paste into the PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag holding the MSIX assets (e.g. v1.7.1-windows)"
+        required: true
+        default: "v1.7.1-windows"
+      asset_version:
+        description: "Version embedded in the asset name (e.g. 1.7.1)"
+        required: true
+        default: "1.7.1"
+      wait_seconds:
+        description: "How long the app must stay alive to count as a pass"
+        required: false
+        default: "60"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Launch (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+          - arch: arm64
+            runner: windows-11-arm
+
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      ASSET_VERSION: ${{ inputs.asset_version }}
+      WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      ARCH: ${{ matrix.arch }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Describe runner
+        shell: pwsh
+        run: |
+          "OS: $([Environment]::OSVersion.VersionString)  Arch: $env:PROCESSOR_ARCHITECTURE"
+          "Display adapters: $((Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name) -join '; ')"
+          "Session: $((Get-Process -Id $PID).SessionId)  Interactive: $([Environment]::UserInteractive)"
+
+      - name: Download release MSIX
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force packages | Out-Null
+          gh release download $env:RELEASE_TAG --repo ${{ github.repository }} `
+            --pattern "TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" --dir packages --clobber
+          Get-ChildItem packages
+
+      - name: Install .NET Desktop Runtime 10 (machine-wide)
+        shell: pwsh
+        run: |
+          $url = "https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-$env:ARCH.exe"
+          Invoke-WebRequest $url -OutFile windowsdesktop-runtime.exe -MaximumRedirection 10
+          $p = Start-Process .\windowsdesktop-runtime.exe -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru
+          "Desktop runtime installer exit code: $($p.ExitCode)"
+          if ($p.ExitCode -notin 0, 1638, 3010) { throw "Desktop runtime install failed." }
+
+      - name: Install Windows App Runtime 1.8
+        shell: pwsh
+        run: |
+          $url = "https://aka.ms/windowsappsdk/1.8/latest/windowsappruntimeinstall-$env:ARCH.exe"
+          Invoke-WebRequest $url -OutFile WindowsAppRuntimeInstall.exe -MaximumRedirection 10
+          $p = Start-Process .\WindowsAppRuntimeInstall.exe -ArgumentList '--quiet' -Wait -PassThru
+          "Windows App Runtime installer exit code: $($p.ExitCode)"
+          if ($p.ExitCode -ne 0) { throw "Windows App Runtime install failed." }
+          Get-AppxPackage Microsoft.WindowsAppRuntime.1.8* | Select-Object Name, Version, Architecture
+
+      - name: Install TinyClips MSIX
+        shell: pwsh
+        run: |
+          $msix = Resolve-Path "packages\TinyClips-$env:ASSET_VERSION-$env:ARCH.msix"
+          Add-AppxPackage -Path $msix
+          $pkg = Get-AppxPackage Refractored.TinyClips
+          if (-not $pkg) { throw "Package did not install." }
+          "Installed $($pkg.PackageFullName) at $($pkg.InstallLocation)"
+          "PKG_INSTALL=$($pkg.InstallLocation)" | Out-File $env:GITHUB_ENV -Append
+          "PKG_PFN=$($pkg.PackageFamilyName)" | Out-File $env:GITHUB_ENV -Append
+
+      - name: Launch TinyClips.App.exe like the winget harness
+        id: launch
+        shell: pwsh
+        run: |
+          # The harness starts the exe by full path with an unrelated working directory.
+          $exe = Join-Path $env:PKG_INSTALL 'TinyClips.App.exe'
+          $start = Get-Date
+          $proc = Start-Process $exe -WorkingDirectory $env:TEMP -PassThru
+          $deadline = $start.AddSeconds([int]$env:WAIT_SECONDS)
+          while ((Get-Date) -lt $deadline) {
+            Start-Sleep -Seconds 2
+            $proc.Refresh()
+            if ($proc.HasExited) { break }
+          }
+          $proc.Refresh()
+          if ($proc.HasExited) {
+            $code = $proc.ExitCode
+            "::error::TinyClips.App.exe exited after $([int]((Get-Date) - $start).TotalSeconds)s with exit code $code (0x$('{0:X8}' -f $code))"
+            "crashed=true" | Out-File $env:GITHUB_OUTPUT -Append
+          } else {
+            "TinyClips.App.exe still running after $env:WAIT_SECONDS s (PID $($proc.Id)) -> PASS"
+            Get-Process -Id $proc.Id | Select-Object Id, ProcessName, WorkingSet64, StartTime
+            Stop-Process -Id $proc.Id -Force
+            "crashed=false" | Out-File $env:GITHUB_OUTPUT -Append
+          }
+          "launch_start=$($start.ToString('o'))" | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Collect diagnostics
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force diag | Out-Null
+          $start = [DateTime]::Parse('${{ steps.launch.outputs.launch_start }}')
+
+          foreach ($log in @(
+              "$env:LOCALAPPDATA\TinyClips\Logs\crash.log",
+              "$env:LOCALAPPDATA\Packages\$env:PKG_PFN\LocalCache\Local\TinyClips\Logs\crash.log")) {
+            if (Test-Path $log) {
+              "=== $log ==="
+              Get-Content $log
+              Copy-Item $log ("diag\" + ($log -replace '[:\\]', '_'))
+            } else { "No crash log at $log" }
+          }
+
+          "=== Application event log (.NET Runtime / Application Error / WER) since launch ==="
+          Get-WinEvent -FilterHashtable @{ LogName = 'Application'; StartTime = $start.AddSeconds(-5) } -ErrorAction SilentlyContinue |
+            Where-Object { $_.ProviderName -in '.NET Runtime', 'Application Error', 'Windows Error Reporting' -or $_.Message -match 'TinyClips' } |
+            ForEach-Object {
+              $text = "[{0}] {1} (Id {2})`n{3}`n" -f $_.TimeCreated, $_.ProviderName, $_.Id, $_.Message
+              $text
+              $text | Out-File diag\application-events.txt -Append
+            }
+
+          "=== WER report signatures ==="
+          Get-ChildItem "$env:LOCALAPPDATA\Microsoft\Windows\WER", "C:\ProgramData\Microsoft\Windows\WER" -Recurse -Filter Report.wer -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -ge $start.AddSeconds(-5) } |
+            ForEach-Object {
+              "== $($_.FullName)"
+              Get-Content $_.FullName | Select-String 'AppName|AppPath|ExceptionCode|Sig\[|DynamicSig\[' | ForEach-Object { "   $_" }
+              Copy-Item $_.FullName ("diag\" + $_.Directory.Name + ".wer")
+            }
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: launch-diagnostics-${{ matrix.arch }}
+          path: diag
+          if-no-files-found: ignore
+
+      - name: Fail if the app crashed
+        if: steps.launch.outputs.crashed == 'true'
+        shell: pwsh
+        run: exit 1

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -1,20 +1,30 @@
 name: Windows Launch Smoke (winget harness repro)
 
 # Reproduces the winget-pkgs "Installation Validation" step on real x64 and ARM64 runners:
-# install the framework-dependent release MSIX together with its declared dependencies, launch
+# install a framework-dependent MSIX together with its declared dependencies, launch
 # TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the harness does), and report
 # whether the process survives. On a crash the job collects the app's crash.log plus the
 # ".NET Runtime" / "Application Error" event-log records, which carry the managed stack that the
 # winget moderators only sometimes paste into the PR.
+#
+# source=release downloads the signed MSIX from a GitHub release; source=build packages the
+# checked-out branch with the release recipe and signs it with a throwaway self-signed cert so a
+# fix can be verified before cutting a release.
 
 on:
   push:
     branches: [diag/winget-launch-smoke]
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: "Release tag holding the MSIX assets (e.g. v1.7.1-windows)"
+      source:
+        description: "Where the MSIX comes from"
         required: true
+        type: choice
+        options: [release, build]
+        default: "release"
+      release_tag:
+        description: "Release tag holding the MSIX assets (source=release)"
+        required: false
         default: "v1.7.1-windows"
       asset_version:
         description: "Version embedded in the asset name (e.g. 1.7.1)"
@@ -42,27 +52,99 @@ jobs:
             runner: windows-11-arm
 
     env:
+      SOURCE: ${{ inputs.source || 'build' }}
       RELEASE_TAG: ${{ inputs.release_tag || 'v1.7.1-windows' }}
       ASSET_VERSION: ${{ inputs.asset_version || '1.7.1' }}
       WAIT_SECONDS: ${{ inputs.wait_seconds || '60' }}
       ARCH: ${{ matrix.arch }}
       GH_TOKEN: ${{ github.token }}
+      APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
 
     steps:
       - name: Describe runner
         shell: pwsh
         run: |
+          "Source: $env:SOURCE"
           "OS: $([Environment]::OSVersion.VersionString)  Arch: $env:PROCESSOR_ARCHITECTURE"
           "Display adapters: $((Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name) -join '; ')"
           "Session: $((Get-Process -Id $PID).SessionId)  Interactive: $([Environment]::UserInteractive)"
 
       - name: Download release MSIX
+        if: env.SOURCE == 'release'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force packages | Out-Null
           gh release download $env:RELEASE_TAG --repo ${{ github.repository }} `
             --pattern "TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" --dir packages --clobber
           Get-ChildItem packages
+
+      - name: Checkout code
+        if: env.SOURCE == 'build'
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        if: env.SOURCE == 'build'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build and package MSIX from this branch
+        if: env.SOURCE == 'build'
+        shell: pwsh
+        run: |
+          $platform = if ($env:ARCH -eq 'arm64') { 'ARM64' } else { 'x64' }
+          $packageDir = "packages/build"
+          New-Item -ItemType Directory -Force packages, $packageDir | Out-Null
+          $packageDirFull = (Resolve-Path $packageDir).Path + [IO.Path]::DirectorySeparatorChar
+
+          $manifestPath = "windows/src/TinyClips.App/Package.appxmanifest"
+          $content = Get-Content $manifestPath -Raw
+          $content = $content -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$env:ASSET_VERSION.0`${2}"
+          Set-Content -Path $manifestPath -Value $content -Encoding UTF8
+
+          dotnet build $env:APP_PROJECT `
+            -c Release `
+            -p:Platform=$platform `
+            -p:RuntimeIdentifier=win-$env:ARCH `
+            -p:SelfContained=false `
+            -p:WindowsAppSDKSelfContained=false `
+            -p:EnableMsixTooling=true `
+            -p:GenerateAppxPackageOnBuild=true `
+            -p:AppxPackageDir=$packageDirFull `
+            -p:AppxBundle=Never `
+            -p:UapAppxPackageBuildMode=SideloadOnly `
+            -p:AppxPackageSigningEnabled=false `
+            -v:minimal
+          if ($LASTEXITCODE -ne 0) { throw "MSIX build failed for $platform." }
+
+          $produced = Get-ChildItem $packageDir -Recurse -Filter *.msix |
+            Where-Object { $_.Name -notmatch 'symbols' } | Select-Object -First 1
+          if (-not $produced) { throw "No MSIX produced." }
+          Copy-Item $produced.FullName "packages/TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" -Force
+          Get-ChildItem packages -File
+
+      - name: Sign MSIX with a throwaway self-signed certificate
+        if: env.SOURCE == 'build'
+        shell: pwsh
+        run: |
+          $subject = ([xml](Get-Content windows/src/TinyClips.App/Package.appxmanifest)).Package.Identity.Publisher
+          "Publisher: $subject"
+          $cert = New-SelfSignedCertificate -Type Custom -Subject $subject `
+            -KeyUsage DigitalSignature -FriendlyName "TinyClips smoke" `
+            -CertStoreLocation Cert:\CurrentUser\My `
+            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+          $pfx = "packages\smoke.pfx"
+          $pwd = ConvertTo-SecureString -String "smoke" -Force -AsPlainText
+          Export-PfxCertificate -Cert $cert -FilePath $pfx -Password $pwd | Out-Null
+          Import-PfxCertificate -FilePath $pfx -CertStoreLocation Cert:\LocalMachine\TrustedPeople -Password $pwd | Out-Null
+
+          $kitsBin = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory |
+            Where-Object { $_.Name -match '^10\.' } | Sort-Object Name -Descending | Select-Object -First 1
+          $toolArch = if ($env:ARCH -eq 'arm64') { 'arm64' } else { 'x64' }
+          $signtool = Join-Path $kitsBin.FullName "$toolArch\signtool.exe"
+          if (-not (Test-Path $signtool)) { $signtool = Join-Path $kitsBin.FullName "x64\signtool.exe" }
+          & $signtool sign /fd SHA256 /f $pfx /p smoke "packages\TinyClips-$env:ASSET_VERSION-$env:ARCH.msix"
+          if ($LASTEXITCODE -ne 0) { throw "signtool failed." }
 
       - name: Install .NET Desktop Runtime 10 (machine-wide)
         shell: pwsh

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,27 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Startup no longer crashes when the shell has no taskbar yet** — root cause of the
+  `Validation-Executable-Error` that blocked the 1.5.3, 1.7.0 and 1.7.1 winget submissions. On the
+  validation VM (reproduced on a GitHub `windows-11-arm` runner) `Shell_NotifyIcon(NIM_ADD)` fails
+  because Explorer's taskbar is not available in that session; H.NotifyIcon's `ForceCreate()`
+  threw `InvalidOperationException: TryCreate failed`, and because the exception left
+  `OnLaunched`, XAML fail-fasted the process with `0xC000027B` even though the
+  `Application.UnhandledException` handler had marked it handled. Tray-icon shell registration is
+  now separated from constructing the icon, failures are caught and retried every 2 s for up to
+  a minute (after which H.NotifyIcon still re-adds the icon on the shell's `TaskbarCreated`
+  broadcast), and every remaining step in `OnLaunched` runs under a per-step guard so nothing can
+  escape it. Hotkeys and capture flows keep working while the icon is pending.
+
+### Added
+- **`Windows Launch Smoke` workflow** (`.github/workflows/windows-launch-smoke.yml`) — manual
+  workflow that mirrors winget's Installation Validation on real x64 and ARM64 runners: installs
+  the .NET 10 Desktop Runtime and Windows App Runtime 1.8, installs either a released MSIX or a
+  freshly built one from the current branch, launches `TinyClips.App.exe` from
+  `C:\Program Files\WindowsApps`, and fails with the exit code plus `crash.log` / event-log
+  stack if the process dies. Run it before opening a winget PR.
+
 ## [v1.7.1-windows] - 2026-08-24
 
 ### Changed

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -44,6 +44,8 @@ public partial class App : Application
     private const uint MonitorDefaultToNearest = 2;
 
     private TaskbarIcon? _taskbarIcon;
+    private DispatcherQueueTimer? _trayIconRetryTimer;
+    private int _trayIconRetryAttempts;
     private SettingsWindow? _settingsWindow;
     private GuideWindow? _guideWindow;
     private ClipsManagerWindow? _clipsManagerWindow;
@@ -80,6 +82,12 @@ public partial class App : Application
     private const double TrayPopupHeight = 242;
     private const double TrayPopupFooterHeight = 48;
     private const double TrayPopupFooterButtonSize = 32;
+    // Shell_NotifyIcon(NIM_ADD) fails while Explorer's taskbar is not yet up (fresh sign-in,
+    // Explorer restart, or a bare automation session such as winget's validation VM). Retry for
+    // a while so the icon appears once the shell is ready; after that H.NotifyIcon re-adds it on
+    // the TaskbarCreated broadcast without further help from us.
+    private static readonly TimeSpan TrayIconRetryInterval = TimeSpan.FromSeconds(2);
+    private const int TrayIconMaxRetryAttempts = 30;
     private GlobalHotKeyManager? _hotKeyManager;
     private DispatcherQueue? _dispatcher;
     private bool _isExiting;
@@ -106,10 +114,14 @@ public partial class App : Application
     {
         _dispatcher = DispatcherQueue.GetForCurrentThread();
 
-        // The tray icon and hotkeys are the app; everything else is best-effort so that an
-        // optional startup step failing (e.g. on a locked-down validation VM) cannot crash launch.
-        WireRecordingEvents();
-        CreateTrayIcon();
+        // Nothing may escape OnLaunched: XAML treats an exception here as fatal and terminates the
+        // process with a stowed exception (0xC000027B) *even when* Application.UnhandledException
+        // marks it handled. That exit code is what winget's Validation-Executable-Error reported
+        // for 1.5.3 / 1.7.0 / 1.7.1, where Shell_NotifyIcon failed on the validation VM. Every
+        // step is therefore guarded; the tray icon and hotkeys are the app, everything else is
+        // best-effort.
+        RunStartupStep(nameof(WireRecordingEvents), WireRecordingEvents);
+        RunStartupStep(nameof(CreateTrayIcon), CreateTrayIcon);
         RunStartupStep(nameof(RegisterGlobalHotKeys), () => RegisterGlobalHotKeys());
         RunStartupStep(nameof(ShowOnboardingIfNeeded), ShowOnboardingIfNeeded);
         RunStartupStep(nameof(HandleFileActivation), HandleFileActivation);
@@ -117,9 +129,9 @@ public partial class App : Application
         _ = Task.Run(() => RunStartupStep("ScreenCaptureWarmUp", () =>
             Services.GetRequiredService<IScreenCaptureService>().WarmUp()));
 #if !TINYCLIPS_STORE_BUILD
-        _ = RunStartupUpdateCheckAsync();
+        RunStartupStep(nameof(RunStartupUpdateCheckAsync), () => _ = RunStartupUpdateCheckAsync());
 #endif
-        EndStartupPhaseAfterFirstDispatcherPass();
+        RunStartupStep(nameof(EndStartupPhaseAfterFirstDispatcherPass), EndStartupPhaseAfterFirstDispatcherPass);
     }
 
     private static void RunStartupStep(string name, Action step)
@@ -155,6 +167,8 @@ public partial class App : Application
         // A XAML-thread exception that reaches the framework terminates the process with a stowed
         // exception (0xC000027B). During launch we log and swallow so a non-fatal startup hiccup
         // cannot produce a crash exit code for a tray app that has no main window to tear down.
+        // NOTE: this does not cover exceptions thrown out of OnLaunched itself - XAML fail-fasts
+        // on those even when Handled is set - which is why OnLaunched guards each step directly.
         // After launch the handler only records diagnostics: continuing past an arbitrary
         // mid-operation failure could leave app state partially mutated, so we let it terminate.
         UnhandledException += (_, e) =>
@@ -249,9 +263,97 @@ public partial class App : Application
         _taskbarIcon.LeftClickCommand = showPopup;
         _taskbarIcon.RightClickCommand = showPopup;
 
-        _taskbarIcon.ForceCreate();
-
         UpdateRecordingState();
+
+        if (!TryRegisterTrayIconWithShell())
+        {
+            ScheduleTrayIconRetry();
+        }
+    }
+
+    /// <summary>
+    /// Asks the shell to add the notification icon. Returns <see langword="false"/> instead of
+    /// throwing when <c>Shell_NotifyIcon</c> refuses (no taskbar yet); the <see cref="TaskbarIcon"/>
+    /// stays alive so a later attempt, or the shell's own <c>TaskbarCreated</c> broadcast, can add it.
+    /// </summary>
+    private bool TryRegisterTrayIconWithShell()
+    {
+        if (_taskbarIcon is null || _isExiting)
+        {
+            return true;
+        }
+
+        if (_taskbarIcon.IsCreated)
+        {
+            return true;
+        }
+
+        try
+        {
+            _taskbarIcon.ForceCreate();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Tray icon registration failed (attempt {_trayIconRetryAttempts + 1}): {ex.Message}");
+            if (_trayIconRetryAttempts == 0)
+            {
+                CrashDiagnostics.Log("TaskbarIcon.ForceCreate", ex, handled: true);
+            }
+
+            return false;
+        }
+    }
+
+    private void ScheduleTrayIconRetry()
+    {
+        if (_trayIconRetryTimer is not null || _dispatcher is null || _isExiting)
+        {
+            return;
+        }
+
+        _trayIconRetryTimer = _dispatcher.CreateTimer();
+        _trayIconRetryTimer.Interval = TrayIconRetryInterval;
+        _trayIconRetryTimer.IsRepeating = true;
+        _trayIconRetryTimer.Tick += OnTrayIconRetryTick;
+        _trayIconRetryTimer.Start();
+    }
+
+    private void OnTrayIconRetryTick(DispatcherQueueTimer sender, object args)
+    {
+        _trayIconRetryAttempts++;
+        var registered = TryRegisterTrayIconWithShell();
+        if (registered)
+        {
+            Debug.WriteLine($"Tray icon registered after {_trayIconRetryAttempts} retr{(_trayIconRetryAttempts == 1 ? "y" : "ies")}.");
+        }
+        else if (_trayIconRetryAttempts < TrayIconMaxRetryAttempts)
+        {
+            return;
+        }
+        else
+        {
+            // Give up polling; H.NotifyIcon still listens for TaskbarCreated and the hotkeys keep
+            // the app usable. Recorded once so a persistent failure leaves evidence in crash.log.
+            CrashDiagnostics.Log(
+                "TaskbarIcon.ForceCreate",
+                new InvalidOperationException($"Tray icon still not registered after {_trayIconRetryAttempts} attempts; waiting for TaskbarCreated."),
+                handled: true);
+        }
+
+        StopTrayIconRetry();
+    }
+
+    private void StopTrayIconRetry()
+    {
+        if (_trayIconRetryTimer is null)
+        {
+            return;
+        }
+
+        _trayIconRetryTimer.Stop();
+        _trayIconRetryTimer.Tick -= OnTrayIconRetryTick;
+        _trayIconRetryTimer = null;
     }
 
     /// <summary>
@@ -2991,6 +3093,7 @@ public partial class App : Application
         ReleaseDisplaySleepAssertion();
         _hotKeyManager?.Dispose();
         _hotKeyManager = null;
+        StopTrayIconRetry();
         _taskbarIcon?.Dispose();
         _taskbarIcon = null;
         _automationNotificationAnnouncer?.Close();


### PR DESCRIPTION
## Root cause of the winget `Validation-Executable-Error` (1.5.3 / 1.7.0 / 1.7.1)

Reproduced the winget Installation Validation harness on a real **`windows-11-arm`** GitHub runner (install .NET 10 Desktop Runtime + Windows App Runtime 1.8 + the released MSIX, then launch `TinyClips.App.exe` from `C:\Program Files\WindowsApps`). The released 1.7.1 arm64 package died after 8 s with **exit code `0xC000027B`** - the exact code in the moderator's log - while x64 survived.

`crash.log` from the run:

```
Application.UnhandledException | handled
System.InvalidOperationException: TryCreate failed.
   at H.NotifyIcon.Core.TrayIcon.Create()
   at H.NotifyIcon.TaskbarIcon.ForceCreate(Boolean enablesEfficiencyMode)
   at TinyClips.App.App.CreateTrayIcon()
   at TinyClips.App.App.OnLaunched(LaunchActivatedEventArgs args)
```

`Shell_NotifyIcon(NIM_ADD)` fails because the validation session has no Explorer taskbar. The exception escaped `OnLaunched`, and **XAML fail-fasts on exceptions thrown out of `OnLaunched` even when `Application.UnhandledException` sets `Handled = true`** - the log literally says `handled` right before the process died. That is why the Aug 21 hardening (#300-ish) didn't help.

## Fix

- Split `TaskbarIcon` construction from shell registration. `ForceCreate()` failures are caught and retried on a `DispatcherQueueTimer` (2 s, up to 30 attempts); H.NotifyIcon independently re-adds the icon on the shell's `TaskbarCreated` broadcast. Hotkeys/capture keep working while the icon is pending.
- Every step in `OnLaunched` now runs under `RunStartupStep`, so nothing can escape it.
- Comment in `RegisterGlobalExceptionHandlers` corrected about the `OnLaunched` gap.

## Verification

- New **`Windows Launch Smoke`** workflow (`workflow_dispatch`; `source=release` or `source=build`) mirrors the winget harness on x64 + ARM64 runners and uploads `crash.log` / event-log diagnostics.
- [Run on released 1.7.1](https://github.com/jamesmontemagno/tiny-clips/actions/runs/32785230584): arm64 **crashed** `0xC000027B` after 8 s (x64 passed).
- [Run on this branch (`source=build`)](https://github.com/jamesmontemagno/tiny-clips/actions/runs/32786374404): arm64 **passed** - `crash.log` shows `TaskbarIcon.ForceCreate | handled` (same shell failure) and the process was still alive after 60 s with no `Application Error` event.
- `dotnet build` x64 + ARM64 Debug: OK. `dotnet test` Core: 168/168.

## Next steps

Cut a 1.7.2 Windows release and resubmit to winget; run the smoke workflow with `source=release` against the new tag first.

Note (not changed here): the csproj comment claims `PublishReadyToRun` doesn't apply to the MSIX `dotnet build`; it does (managed DLLs in the shipped 1.7.1 MSIX are R2R-compiled). Harmless, but the comment is wrong.