### PR TITLE
Mark v1.7.2-windows release; launch smoke starts Explorer

### DIFF
--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -174,6 +174,23 @@ jobs:
           "PKG_INSTALL=$($pkg.InstallLocation)" | Out-File $env:GITHUB_ENV -Append
           "PKG_PFN=$($pkg.PackageFamilyName)" | Out-File $env:GITHUB_ENV -Append
 
+      - name: Start the Explorer shell (taskbar) like a real desktop session
+        shell: pwsh
+        run: |
+          # Hosted runners have an interactive session but no Explorer, so Shell_NotifyIcon has no
+          # taskbar to talk to. The winget validation VM does have a shell (it screenshots the app),
+          # so start Explorer here to exercise the post-tray-icon startup path as well.
+          if (-not (Get-Process explorer -ErrorAction SilentlyContinue)) {
+            Start-Process explorer.exe
+            Start-Sleep -Seconds 15
+          }
+          Get-Process explorer -ErrorAction SilentlyContinue | Select-Object Id, SessionId, StartTime
+          Add-Type -AssemblyName System.Windows.Forms
+          $tray = [System.Windows.Forms.Screen]::PrimaryScreen
+          "Primary screen: $($tray.Bounds.Width)x$($tray.Bounds.Height), work area $($tray.WorkingArea.Width)x$($tray.WorkingArea.Height)"
+          $shellTray = (Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr FindWindow(string c, string w);' -Name U -Namespace W -PassThru)::FindWindow('Shell_TrayWnd', $null)
+          "Shell_TrayWnd hwnd: $shellTray"
+
       - name: Launch TinyClips.App.exe like the winget harness
         id: launch
         shell: pwsh
@@ -183,10 +200,21 @@ jobs:
           $start = Get-Date
           $proc = Start-Process $exe -WorkingDirectory $env:TEMP -PassThru
           $deadline = $start.AddSeconds([int]$env:WAIT_SECONDS)
+          $shot = $false
           while ((Get-Date) -lt $deadline) {
             Start-Sleep -Seconds 2
             $proc.Refresh()
             if ($proc.HasExited) { break }
+            if (-not $shot -and ((Get-Date) - $start).TotalSeconds -ge 15) {
+              $shot = $true
+              New-Item -ItemType Directory -Force diag | Out-Null
+              Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+              $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+              $bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
+              $g = [System.Drawing.Graphics]::FromImage($bmp)
+              $g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
+              $bmp.Save("diag\desktop-15s.png"); $g.Dispose(); $bmp.Dispose()
+            }
           }
           $proc.Refresh()
           if ($proc.HasExited) {

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -180,16 +180,41 @@ jobs:
           # Hosted runners have an interactive session but no Explorer, so Shell_NotifyIcon has no
           # taskbar to talk to. The winget validation VM does have a shell (it screenshots the app),
           # so start Explorer here to exercise the post-tray-icon startup path as well.
-          if (-not (Get-Process explorer -ErrorAction SilentlyContinue)) {
-            Start-Process explorer.exe
-            Start-Sleep -Seconds 15
-          }
-          Get-Process explorer -ErrorAction SilentlyContinue | Select-Object Id, SessionId, StartTime
+          "Processes before: " + ((Get-Process | Where-Object { $_.Name -match 'oobe|CloudExperience|explorer|WWAHost|ShellHost|StartMenu|SearchHost|sihost|ShellExperienceHost' } | ForEach-Object { "$($_.Name)($($_.Id))" }) -join ', ')
+          # The image boots into OOBE ("Choose privacy settings"), which keeps the shell from
+          # servicing Shell_NotifyIcon. Stop it and (re)start Explorer.
+          Get-Process | Where-Object { $_.Name -match 'msoobe|CloudExperienceHost|WWAHost' } | ForEach-Object { "Stopping $($_.Name)"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+          Get-Process explorer -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+          Start-Sleep -Seconds 3
+          Start-Process explorer.exe
+          Start-Sleep -Seconds 20
+          "Processes after: " + ((Get-Process | Where-Object { $_.Name -match 'oobe|CloudExperience|explorer|WWAHost|ShellHost|StartMenu|SearchHost|sihost|ShellExperienceHost' } | ForEach-Object { "$($_.Name)($($_.Id))" }) -join ', ')
           Add-Type -AssemblyName System.Windows.Forms
-          $tray = [System.Windows.Forms.Screen]::PrimaryScreen
-          "Primary screen: $($tray.Bounds.Width)x$($tray.Bounds.Height), work area $($tray.WorkingArea.Width)x$($tray.WorkingArea.Height)"
-          $shellTray = (Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern IntPtr FindWindow(string c, string w);' -Name U -Namespace W -PassThru)::FindWindow('Shell_TrayWnd', $null)
-          "Shell_TrayWnd hwnd: $shellTray"
+          $scr = [System.Windows.Forms.Screen]::PrimaryScreen
+          "Primary screen: $($scr.Bounds.Width)x$($scr.Bounds.Height), work area $($scr.WorkingArea.Width)x$($scr.WorkingArea.Height)"
+          $u = Add-Type -MemberDefinition @'
+          [DllImport("user32.dll")] public static extern IntPtr FindWindow(string c, string w);
+          [DllImport("user32.dll")] public static extern IntPtr FindWindowEx(IntPtr p, IntPtr a, string c, string w);
+          [DllImport("user32.dll")] public static extern bool IsHungAppWindow(IntPtr h);
+          [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)] public struct NOTIFYICONDATA { public int cbSize; public IntPtr hWnd; public int uID; public int uFlags; public int uCallbackMessage; public IntPtr hIcon; [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string szTip; public int dwState; public int dwStateMask; [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)] public string szInfo; public int uTimeoutOrVersion; [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)] public string szInfoTitle; public int dwInfoFlags; public Guid guidItem; public IntPtr hBalloonIcon; }
+          [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)] public static extern bool Shell_NotifyIcon(int msg, ref NOTIFYICONDATA d);
+          [DllImport("user32.dll")] public static extern IntPtr LoadIcon(IntPtr h, IntPtr name);
+          [DllImport("user32.dll")] public static extern IntPtr GetDesktopWindow();
+          '@ -Name U -Namespace W -PassThru
+          $tray = $u::FindWindow('Shell_TrayWnd', $null)
+          "Shell_TrayWnd hwnd: $tray  hung: $(if ($tray -ne [IntPtr]::Zero) { $u::IsHungAppWindow($tray) } else { 'n/a' })"
+          "TrayNotifyWnd: $($u::FindWindowEx($tray, [IntPtr]::Zero, 'TrayNotifyWnd', $null))"
+          # Probe Shell_NotifyIcon(NIM_ADD) the way H.NotifyIcon does, using a throwaway window.
+          $f = New-Object System.Windows.Forms.Form; $f.Show(); $f.Hide()
+          $d = New-Object W.U+NOTIFYICONDATA
+          $d.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($d); $d.hWnd = $f.Handle; $d.uID = 1
+          $d.uFlags = 0x1 -bor 0x2 -bor 0x4; $d.uCallbackMessage = 0x401; $d.szTip = 'probe'
+          $d.hIcon = $u::LoadIcon([IntPtr]::Zero, [IntPtr]32512)
+          $sw = [Diagnostics.Stopwatch]::StartNew()
+          $ok = $u::Shell_NotifyIcon(0, [ref]$d); $err = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+          "Shell_NotifyIcon(NIM_ADD) probe: $ok (Win32 error $err) in $($sw.ElapsedMilliseconds) ms"
+          if ($ok) { [void]$u::Shell_NotifyIcon(2, [ref]$d) }
+          $f.Close()
 
       - name: Launch TinyClips.App.exe like the winget harness
         id: launch
@@ -207,6 +232,15 @@ jobs:
             if ($proc.HasExited) { break }
             if (-not $shot -and ((Get-Date) - $start).TotalSeconds -ge 15) {
               $shot = $true
+              # Bring the app's first window (first-run onboarding) to the foreground, as a user
+              # or the harness would, so Window.Activated handlers run.
+              $p = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
+              if ($p -and $p.MainWindowHandle -ne 0) {
+                "Activating main window $($p.MainWindowHandle) '$($p.MainWindowTitle)'"
+                $act = Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h); [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);' -Name A -Namespace W -PassThru
+                [void]$act::ShowWindow($p.MainWindowHandle, 5); [void]$act::SetForegroundWindow($p.MainWindowHandle)
+                Start-Sleep -Seconds 3
+              } else { "No main window handle yet" }
               New-Item -ItemType Directory -Force diag | Out-Null
               Add-Type -AssemblyName System.Windows.Forms, System.Drawing
               $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -200,13 +200,13 @@ jobs:
           [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)] public static extern bool Shell_NotifyIcon(int msg, ref NOTIFYICONDATA d);
           [DllImport("user32.dll")] public static extern IntPtr LoadIcon(IntPtr h, IntPtr name);
           [DllImport("user32.dll")] public static extern IntPtr GetDesktopWindow();
-          '@ -Name U -Namespace W -PassThru
+          '@ -Name U -Namespace W -PassThru | Where-Object { $_.Name -eq 'U' }
           $tray = $u::FindWindow('Shell_TrayWnd', $null)
           "Shell_TrayWnd hwnd: $tray  hung: $(if ($tray -ne [IntPtr]::Zero) { $u::IsHungAppWindow($tray) } else { 'n/a' })"
           "TrayNotifyWnd: $($u::FindWindowEx($tray, [IntPtr]::Zero, 'TrayNotifyWnd', $null))"
           # Probe Shell_NotifyIcon(NIM_ADD) the way H.NotifyIcon does, using a throwaway window.
           $f = New-Object System.Windows.Forms.Form; $f.Show(); $f.Hide()
-          $d = New-Object W.U+NOTIFYICONDATA
+          $d = New-Object 'W.U+NOTIFYICONDATA'
           $d.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($d); $d.hWnd = $f.Handle; $d.uID = 1
           $d.uFlags = 0x1 -bor 0x2 -bor 0x4; $d.uCallbackMessage = 0x401; $d.szTip = 'probe'
           $d.hIcon = $u::LoadIcon([IntPtr]::Zero, [IntPtr]32512)
@@ -268,7 +268,8 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force diag | Out-Null
-          $start = [DateTime]::Parse('${{ steps.launch.outputs.launch_start }}')
+          $startText = '${{ steps.launch.outputs.launch_start }}'
+          $start = if ($startText) { [DateTime]::Parse($startText) } else { (Get-Date).AddMinutes(-10) }
 
           foreach ($log in @(
               "$env:LOCALAPPDATA\TinyClips\Logs\crash.log",

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,8 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+## [v1.7.2-windows] - 2026-08-24
+
 ### Fixed
 - **Startup no longer crashes when the shell has no taskbar yet** — root cause of the
   `Validation-Executable-Error` that blocked the 1.5.3, 1.7.0 and 1.7.1 winget submissions. On the

--- a/windows/src/TinyClips.App/Infrastructure/WindowChromeController.cs
+++ b/windows/src/TinyClips.App/Infrastructure/WindowChromeController.cs
@@ -52,8 +52,8 @@ internal sealed class WindowChromeController
     // Sets the AppWindow icon once on first activation and self-unsubscribes.
     private void OnActivatedSetIcon(object sender, WindowActivatedEventArgs args)
     {
-        _window.AppWindow.SetIcon(@"Assets\AppIcon.ico");
         _window.Activated -= OnActivatedSetIcon;
+        WindowIcon.Apply(_window.AppWindow);
     }
 
     private void OnRootElementLoaded(object sender, RoutedEventArgs args)

--- a/windows/src/TinyClips.App/Infrastructure/WindowIcon.cs
+++ b/windows/src/TinyClips.App/Infrastructure/WindowIcon.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using Microsoft.UI.Windowing;
+using TinyClips.Core.Services;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// Sets the taskbar / Alt+Tab icon of a standard window.
+/// <para>
+/// <see cref="AppWindow.SetIcon(string)"/> requires a fully qualified path: a relative path is
+/// resolved against the process working directory, which is only the package folder when the app
+/// is started from Start or Explorer. Launchers that start the exe with some other working
+/// directory (the winget validation harness uses <c>E:\</c>) would otherwise get a
+/// <see cref="System.IO.FileNotFoundException"/> thrown from <c>Window.Activated</c>, which XAML
+/// treats as fatal once startup has completed (0xC000027B). So the path is resolved against the
+/// executable's directory and any failure is logged instead of propagated.
+/// </para>
+/// </summary>
+internal static class WindowIcon
+{
+    private const string RelativeIconPath = @"Assets\AppIcon.ico";
+
+    private static readonly Lazy<string?> ResolvedIconPath = new(ResolveIconPath);
+
+    public static void Apply(AppWindow appWindow)
+    {
+        var path = ResolvedIconPath.Value;
+        if (path is null)
+        {
+            return;
+        }
+
+        try
+        {
+            appWindow.SetIcon(path);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"AppWindow.SetIcon failed for '{path}': {ex}");
+            CrashDiagnostics.Log("WindowIcon.Apply", ex, handled: true);
+        }
+    }
+
+    private static string? ResolveIconPath()
+    {
+        try
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, RelativeIconPath);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+
+            Debug.WriteLine($"Window icon not found at '{path}'.");
+            CrashDiagnostics.Log(
+                "WindowIcon.Resolve",
+                new FileNotFoundException("Window icon not found.", path),
+                handled: true);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Window icon path resolution failed: {ex}");
+            CrashDiagnostics.Log("WindowIcon.Resolve", ex, handled: true);
+        }
+
+        return null;
+    }
+}

--- a/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/SettingsWindow.xaml.cs
@@ -68,8 +68,8 @@ public sealed partial class SettingsWindow : Window
 
     private void OnActivatedSetIcon(object sender, WindowActivatedEventArgs args)
     {
-        AppWindow.SetIcon(@"Assets\AppIcon.ico");
         Activated -= OnActivatedSetIcon;
+        WindowIcon.Apply(AppWindow);
     }
 
     private void OnRootGridLoaded(object sender, RoutedEventArgs args)


### PR DESCRIPTION
- Stamp \[v1.7.2-windows] - 2026-08-24\ in windows/CHANGELOG.md (tag and release already published from the #303 merge commit).
- Launch smoke workflow: start explorer.exe before launching so Shell_NotifyIcon can actually register the tray icon and the post-icon startup path is exercised; capture a desktop screenshot at 15 s into diagnostics.

Context: microsoft/winget-pkgs#423525 (1.7.2) still hit Validation-Executable-Error on arm64; this closes the gap between the runner (no shell) and the validation VM (has a shell).