### PR TITLE
Windows 1.7.3: self-contained MSIX, tray retry backoff, app icon on welcome

### DIFF
--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -1,7 +1,8 @@
 name: Windows Launch Smoke (winget harness repro)
 
 # Reproduces the winget-pkgs "Installation Validation" step on real x64 and ARM64 runners:
-# install a framework-dependent MSIX together with its declared dependencies, launch
+# install an MSIX (the runtimes are installed too so older framework-dependent releases still
+# work; current releases are self-contained and ignore them), launch
 # TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the harness does), and report
 # whether the process survives. On a crash the job collects the app's crash.log plus the
 # ".NET Runtime" / "Application Error" event-log records, which carry the managed stack that the
@@ -104,8 +105,9 @@ jobs:
             -c Release `
             -p:Platform=$platform `
             -p:RuntimeIdentifier=win-$env:ARCH `
-            -p:SelfContained=false `
-            -p:WindowsAppSDKSelfContained=false `
+            -p:SelfContained=true `
+            -p:WindowsAppSDKSelfContained=true `
+            -p:PublishTrimmed=false `
             -p:EnableMsixTooling=true `
             -p:GenerateAppxPackageOnBuild=true `
             -p:AppxPackageDir=$packageDirFull `

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -71,14 +71,12 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/windows | Out-Null
 
-          # Framework-dependent MSIX (small package). The app does NOT bundle the .NET or
-          # Windows App SDK runtimes; instead they are declared as winget PackageDependencies
-          # in the installer manifest (Microsoft.DotNet.DesktopRuntime.10 and
-          # Microsoft.WindowsAppRuntime.1.8). winget installs those dependency packages before
-          # the app, and the Windows App SDK runtime is also auto-acquired by the OS on machines
-          # with the Store/App Installer. NOTE: a framework-dependent MSIX cannot be verified in
-          # Windows Sandbox (it has no Store, so framework auto-acquisition fails with
-          # 0x80073cf3) - validate on a real machine or via the winget validation pipeline.
+          # Self-contained MSIX: the package bundles both the .NET 10 runtime and the Windows App
+          # SDK runtime, so it has no framework-package or winget dependencies and runs on a clean
+          # machine (including Windows Sandbox) with nothing else installed. This is larger than a
+          # framework-dependent package (~3x) but removes the target machine's runtime versions as
+          # a variable - adopted while chasing winget's Validation-Executable-Error on 1.7.x.
+          # PublishTrimmed is forced off: trimming WinUI 3 + H.NotifyIcon + NAudio is not safe.
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -93,8 +91,9 @@ jobs:
               -c Release `
               -p:Platform=$($p.Platform) `
               -p:RuntimeIdentifier=$($p.Rid) `
-              -p:SelfContained=false `
-              -p:WindowsAppSDKSelfContained=false `
+              -p:SelfContained=true `
+              -p:WindowsAppSDKSelfContained=true `
+              -p:PublishTrimmed=false `
               -p:EnableMsixTooling=true `
               -p:GenerateAppxPackageOnBuild=true `
               -p:AppxPackageDir=$packageDirFull `
@@ -110,11 +109,10 @@ jobs:
             if (-not $produced) { throw "No MSIX produced for $($p.Platform)." }
 
             # Guard against silently shipping the wrong kind of package. Unpack the MSIX and
-            # assert it is genuinely framework-dependent: (1) the AppxManifest declares the
-            # WindowsAppRuntime framework dependency (so the declared winget dependency matches
-            # the package), and (2) the payload does NOT contain the .NET runtime (coreclr.dll),
-            # confirming the .NET runtime is framework-dependent and delivered via the declared
-            # Microsoft.DotNet.DesktopRuntime.10 winget dependency.
+            # assert it is genuinely self-contained: (1) the AppxManifest declares NO
+            # WindowsAppRuntime framework dependency (the runtime is bundled), and (2) the payload
+            # contains the .NET runtime (coreclr.dll). The winget manifest declares no
+            # dependencies, so a framework-dependent package here would fail to install.
             $verifyDir = Join-Path $packageDir "verify"
             Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
             $zipCopy = "$($produced.FullName).zip"
@@ -122,13 +120,17 @@ jobs:
             Expand-Archive $zipCopy -DestinationPath $verifyDir -Force
 
             $appxManifest = Get-Content (Join-Path $verifyDir "AppxManifest.xml") -Raw
-            if ($appxManifest -notmatch '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
-              throw "Framework-dependent MSIX for $($p.Platform) is missing the WindowsAppRuntime framework dependency."
+            if ($appxManifest -match '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
+              throw "Self-contained MSIX for $($p.Platform) still declares a WindowsAppRuntime framework dependency - expected WindowsAppSDKSelfContained=true."
             }
 
-            if (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue) {
-              throw "MSIX for $($p.Platform) bundles the .NET runtime (coreclr.dll) - expected a framework-dependent (SelfContained=false) build."
+            if (-not (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue)) {
+              throw "MSIX for $($p.Platform) does not bundle the .NET runtime (coreclr.dll) - expected a self-contained (SelfContained=true) build."
             }
+            if (-not (Get-ChildItem $verifyDir -Recurse -Filter "Microsoft.UI.Xaml.dll" -ErrorAction SilentlyContinue)) {
+              throw "MSIX for $($p.Platform) does not bundle the Windows App SDK runtime (Microsoft.UI.Xaml.dll) - expected WindowsAppSDKSelfContained=true."
+            }
+            "$($p.Platform): self-contained package verified ($([math]::Round($produced.Length / 1MB, 1)) MB)"
             Remove-Item $zipCopy -Force -ErrorAction SilentlyContinue
             Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -263,11 +265,9 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
-          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
-          # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # Installer manifest for the signed, self-contained MSIX produced by the Windows Release
+          # workflow. The package bundles the .NET and Windows App SDK runtimes, so it declares no
+          # winget package dependencies. Do not set Scope here.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -276,10 +276,6 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
-          Dependencies:
-            PackageDependencies:
-              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -4,8 +4,9 @@ name: WinGet Submission
 # repository (microsoft/winget-pkgs). Run this AFTER you've eyeballed the GitHub release.
 #
 # Unlike the PowerToys "wingetcreate update" approach, this regenerates our full multi-file
-# manifest from source (windows/packaging/winget) so the framework Dependencies block is
-# always present, instead of inheriting whatever the previously published version declared.
+# manifest from source (windows/packaging/winget) so the installer manifest always matches the
+# package we ship (currently self-contained, no Dependencies block), instead of inheriting
+# whatever the previously published version declared.
 #
 # Requires a repository secret named WINGET_CREATE_GITHUB_TOKEN: a classic PAT from an
 # account that can fork microsoft/winget-pkgs, with the `public_repo` scope. wingetcreate
@@ -88,11 +89,9 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
-          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
-          # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # Installer manifest for the signed, self-contained MSIX produced by the Windows Release
+          # workflow. The package bundles the .NET and Windows App SDK runtimes, so it declares no
+          # winget package dependencies. Do not set Scope here.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -101,10 +100,6 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
-          Dependencies:
-            PackageDependencies:
-              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/${{ github.repository }}/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,26 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Changed
+- **Self-contained MSIX** — the release package now bundles the .NET 10 runtime and the Windows
+  App SDK 1.8 runtime (`SelfContained=true`, `WindowsAppSDKSelfContained=true`, trimming off), and
+  the winget manifest no longer declares `Microsoft.DotNet.DesktopRuntime.10` /
+  `Microsoft.WindowsAppRuntime.1.8` dependencies. The package is larger (~3×) but installs and runs
+  on a clean machine with nothing else present, and removes the target machine's runtime versions
+  as a variable while we chase winget's `Validation-Executable-Error`. See
+  `windows/packaging/README.md` for the trade-offs and how to revert.
+- **Tray icon registration retries back off exponentially** (5 → 10 → 20 → 40 s, ~2.5 min total)
+  instead of every 2 s. A failed `Shell_NotifyIcon` call can block the UI thread for the shell's
+  4-second reply timeout, so the old cadence could keep the process "Not Responding" for minutes on
+  a machine whose taskbar was slow to answer. H.NotifyIcon still re-adds the icon on
+  `TaskbarCreated` after the retries stop.
+- **Welcome screen shows the real app icon** — the first onboarding step now uses the Tiny Clips
+  app icon instead of a generic camera glyph on an accent tile.
+
+### Fixed
+- Window title-bar icon is resolved to an absolute path under the app's install folder and any
+  `AppWindow.SetIcon` failure is logged rather than propagated from `Window.Activated`.
+
 ## [v1.7.2-windows] - 2026-08-24
 
 ### Fixed

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -20,10 +20,10 @@ cd windows
 winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
 winapp cert install
 
-# Produce framework-dependent MSIX packages (x64 and arm64). The .NET and Windows App SDK
-# runtimes are NOT bundled; they are declared as winget package dependencies instead.
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
+# Produce self-contained MSIX packages (x64 and arm64). The .NET and Windows App SDK runtimes
+# are bundled, so the package has no framework dependencies and runs on a clean machine.
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
 winapp package src\TinyClips.App\bin\x64\Release\net10.0-windows10.0.26100.0\win-x64 --output TinyClips-x64.msix
 winapp package src\TinyClips.App\bin\arm64\Release\net10.0-windows10.0.26100.0\win-arm64 --output TinyClips-arm64.msix
 
@@ -36,54 +36,44 @@ Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`).
 ### Automated Windows release workflow
 
 `.github/workflows/windows-release.yml` runs for tags like `v1.0.1-windows` and maps them to
-MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **framework-dependent** MSIX
-packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates
-a versioned winget manifest artifact, and creates the GitHub Release.
+MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **self-contained** MSIX packages,
+signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates a versioned
+winget manifest artifact, and creates the GitHub Release.
 
-#### Framework-dependent + declared winget dependencies (and how)
+#### Self-contained packages (and why)
 
-The package is kept small by **not** bundling the runtimes. The winget installer manifest declares
-both runtimes as package dependencies, so winget installs them before the app:
+Since 1.7.3 the package bundles both runtimes (`-p:SelfContained=true` for .NET and
+`-p:WindowsAppSDKSelfContained=true` for the Windows App SDK), with trimming explicitly off
+(`-p:PublishTrimmed=false`; WinUI 3, H.NotifyIcon, NAudio and System.Drawing rely on reflection
+that trimming breaks). The winget installer manifest therefore declares **no** package
+dependencies. The release workflow unpacks each MSIX and asserts it is genuinely self-contained
+(no `WindowsAppRuntime` framework dependency in the AppxManifest, and both `coreclr.dll` and
+`Microsoft.UI.Xaml.dll` present in the payload) before signing.
 
-| winget `PackageDependency` | Provides |
-|---|---|
-| `Microsoft.WindowsAppRuntime.1.8` | The Windows App SDK runtime (WinUI 3, etc.) |
-| `Microsoft.DotNet.DesktopRuntime.10` | The .NET 10 Desktop Runtime |
+The trade-off is size (~3x a framework-dependent package) and that runtime security fixes ship
+with a Tiny Clips release instead of via the shared framework packages. We switched while
+chasing winget's repeated `Validation-Executable-Error` on 1.7.x: it removes the validation VM's
+runtime versions as a variable, and a self-contained MSIX can be verified end-to-end in Windows
+Sandbox (which has no Store and so cannot auto-acquire framework packages).
 
-The matching MSBuild properties are `-p:SelfContained=false` (do not bundle .NET) and
-`-p:WindowsAppSDKSelfContained=false` (do not bundle the Windows App SDK runtime). The release
-workflow unpacks each MSIX and asserts it is genuinely framework-dependent (the AppxManifest
-declares the `WindowsAppRuntime` dependency and the payload contains no bundled `coreclr.dll`)
-before signing.
+Versions 1.0.x–1.7.2 were framework-dependent and declared `Microsoft.WindowsAppRuntime.1.8` and
+`Microsoft.DotNet.DesktopRuntime.10` as winget dependencies. If we ever go back, restore that
+`Dependencies` block in both workflows and the template, flip the workflow guards, and do not add
+`Scope: user` (the dependency installers are machine-scope and winget validation rejects it).
 
-> ⚠️ **Both runtimes are delivered differently.** The Windows App SDK runtime is an MSIX
-> *framework package*, so on machines with the Store/App Installer the OS can auto-acquire it
-> during deployment, and winget can also install the declared `Microsoft.WindowsAppRuntime.1.8`
-> dependency. The .NET Desktop Runtime is **not** an MSIX framework — the OS will not auto-deliver
-> it — so it is installed via the declared `Microsoft.DotNet.DesktopRuntime.10` winget dependency.
+#### Verifying on a clean machine
 
-> ⚠️ **Do not verify a framework-dependent build in Windows Sandbox.** Sandbox has no Microsoft
-> Store, so MSIX framework auto-acquisition fails and the install dies at ~95% with `0x80073cf3`
-> (`This package has a dependency missing from your system`). That is a Sandbox artifact, not a
-> real failure. Validate on a real machine (with the runtimes absent, then `winget install` and
-> let winget resolve the dependencies) or rely on winget's Installation Validation pipeline.
-
-#### Verifying on a real clean machine
-
-On a normal Windows machine (with the Store/App Installer) that does not yet have the runtimes,
-`winget install --manifest <dir>` should install `Microsoft.DotNet.DesktopRuntime.10` and
-`Microsoft.WindowsAppRuntime.1.8` first, then the app. A pass is the app process running with the
-tray icon present and no `.NET Desktop Runtime` prompt.
-
-Do not add `Scope: user` to the installer manifest. The TinyClips MSIX installs per-user by
-default, but the runtime dependency installers are machine-scope/unknown-scope packages; forcing
-user scope causes winget validation to reject those dependencies with "No suitable installer found."
+Install the MSIX on a clean machine or in Windows Sandbox (no runtimes required), launch
+`TinyClips.App.exe` from `C:\Program Files\WindowsApps\Refractored.TinyClips_*` with an unrelated
+working directory (that is what winget's harness does), and confirm the process stays alive with
+the tray icon present. The `Windows Launch Smoke` workflow automates exactly this on x64 and ARM64
+runners (`source=release` for a published tag, `source=build` for the current branch).
 
 ```pwsh
-# Build a framework-dependent, packaged MSIX (x64)
+# Build a self-contained, packaged MSIX (x64)
 dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `
   -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
-  -p:SelfContained=false -p:WindowsAppSDKSelfContained=false `
+  -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false `
   -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
   -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
   -p:AppxPackageDir=<out>\ -p:AppxPackageSigningEnabled=false

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# Installer manifest for the signed, framework-dependent MSIX produced by `winapp pack`.
-# The package does not bundle the .NET or Windows App SDK runtimes; they are declared below
-# as winget package dependencies so winget installs them before the app. Do not set Scope:
-# the dependency installers are machine-scope/unknown scope, and forcing user scope makes
-# winget reject them during validation.
+# Installer manifest for the signed, self-contained MSIX produced by the Windows Release workflow.
+# The package bundles the .NET and Windows App SDK runtimes, so it declares no winget package
+# dependencies. Do not set Scope.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
 #   winget hash --msix <path-to-msix>
@@ -15,10 +13,6 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix

--- a/windows/src/TinyClips.App/App.xaml.cs
+++ b/windows/src/TinyClips.App/App.xaml.cs
@@ -83,11 +83,16 @@ public partial class App : Application
     private const double TrayPopupFooterHeight = 48;
     private const double TrayPopupFooterButtonSize = 32;
     // Shell_NotifyIcon(NIM_ADD) fails while Explorer's taskbar is not yet up (fresh sign-in,
-    // Explorer restart, or a bare automation session such as winget's validation VM). Retry for
-    // a while so the icon appears once the shell is ready; after that H.NotifyIcon re-adds it on
-    // the TaskbarCreated broadcast without further help from us.
-    private static readonly TimeSpan TrayIconRetryInterval = TimeSpan.FromSeconds(2);
-    private const int TrayIconMaxRetryAttempts = 30;
+    // Explorer restart, or a bare automation session such as winget's validation VM). Retry so
+    // the icon appears once the shell is ready; after that H.NotifyIcon re-adds it on the
+    // TaskbarCreated broadcast without further help from us.
+    //
+    // Each failed Shell_NotifyIcon call can block the calling (UI) thread for the shell's
+    // 4-second reply timeout, so the retries back off exponentially: a fixed 2 s cadence would
+    // keep the UI thread pinned and make the process look hung to the user and to automation.
+    private static readonly TimeSpan TrayIconInitialRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan TrayIconMaxRetryDelay = TimeSpan.FromSeconds(40);
+    private const int TrayIconMaxRetryAttempts = 6; // 5 + 10 + 20 + 40 + 40 + 40 s ≈ 2.5 min
     private GlobalHotKeyManager? _hotKeyManager;
     private DispatcherQueue? _dispatcher;
     private bool _isExiting;
@@ -313,8 +318,8 @@ public partial class App : Application
         }
 
         _trayIconRetryTimer = _dispatcher.CreateTimer();
-        _trayIconRetryTimer.Interval = TrayIconRetryInterval;
-        _trayIconRetryTimer.IsRepeating = true;
+        _trayIconRetryTimer.Interval = TrayIconInitialRetryDelay;
+        _trayIconRetryTimer.IsRepeating = false;
         _trayIconRetryTimer.Tick += OnTrayIconRetryTick;
         _trayIconRetryTimer.Start();
     }
@@ -327,8 +332,12 @@ public partial class App : Application
         {
             Debug.WriteLine($"Tray icon registered after {_trayIconRetryAttempts} retr{(_trayIconRetryAttempts == 1 ? "y" : "ies")}.");
         }
-        else if (_trayIconRetryAttempts < TrayIconMaxRetryAttempts)
+        else if (_trayIconRetryAttempts < TrayIconMaxRetryAttempts && !_isExiting)
         {
+            // Exponential backoff, capped: the next delay doubles until TrayIconMaxRetryDelay.
+            var next = TimeSpan.FromTicks(Math.Min(sender.Interval.Ticks * 2, TrayIconMaxRetryDelay.Ticks));
+            sender.Interval = next;
+            sender.Start();
             return;
         }
         else

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -51,6 +51,7 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-48_altform-lightunplated.png" />
     <Content Include="Assets\AppIcon.ico" />
+    <Content Include="Assets\AppIcon-512.png" />
     <Content Include="Assets\TrayIcon.ico" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
   </ItemGroup>
@@ -105,13 +106,16 @@
   <PropertyGroup>
     <!--
       ReadyToRun pre-compiles IL so the first capture after launch doesn't pay JIT cost for every
-      overlay window type. Applies to `dotnet publish`; the MSIX `dotnet build` path in CI is
-      framework-dependent and unaffected.
+      overlay window type. It applies to `dotnet publish` and to the MSIX packaging path (the
+      packaging targets run the publish pipeline), so Release MSIX payloads ship R2R images.
     -->
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release'">True</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == ''">False</PublishReadyToRun>
+    <!--
+      Trimming is opt-in only. The release workflow passes -p:PublishTrimmed=false explicitly:
+      WinUI 3 + H.NotifyIcon + NAudio + System.Drawing rely on reflection that trimming breaks.
+    -->
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug' and ('$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true')">True</PublishTrimmed>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/windows/src/TinyClips.App/Views/OnboardingWindow.xaml
+++ b/windows/src/TinyClips.App/Views/OnboardingWindow.xaml
@@ -53,18 +53,13 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Spacing="16">
-                <Border
-                    Width="88"
-                    Height="88"
+                <Image
+                    Width="96"
+                    Height="96"
                     HorizontalAlignment="Center"
-                    Background="{ThemeResource AccentFillColorDefaultBrush}"
-                    CornerRadius="20">
-                    <FontIcon
-                        FontFamily="Segoe Fluent Icons"
-                        FontSize="44"
-                        Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                        Glyph="&#xE722;" />
-                </Border>
+                    AutomationProperties.Name="Tiny Clips app icon"
+                    Source="ms-appx:///Assets/AppIcon-512.png"
+                    Stretch="Uniform" />
                 <TextBlock
                     HorizontalAlignment="Center"
                     Style="{StaticResource TitleLargeTextBlockStyle}"


### PR DESCRIPTION
Third attempt at clearing winget's \Validation-Executable-Error\ (microsoft/winget-pkgs#423525 for 1.7.2 still failed on arm64; released 1.7.2 is clean on x64 Sandbox, arm64 runner and a real ARM64 desktop).

## Changes
- **Self-contained MSIX**: release/smoke/winget workflows now build with \SelfContained=true\, \WindowsAppSDKSelfContained=true\, \PublishTrimmed=false\; package guards inverted (must contain \coreclr.dll\ + \Microsoft.UI.Xaml.dll\, must not declare a WindowsAppRuntime dependency); winget manifest drops the two runtime dependencies. ~119 MB vs 21 MB. Docs in \windows/packaging/README.md\ explain trade-offs and how to revert.
- **Tray retry backoff**: 5 → 10 → 20 → 40 s (6 attempts) instead of every 2 s. Each failed \Shell_NotifyIcon\ can block the UI thread for the shell's 4 s timeout, so the old cadence could leave the process 'Not Responding' for minutes on a slow shell.
- **Welcome screen** shows the real app icon (\Assets/AppIcon-512.png\, now Content).
- csproj comment fix (R2R does apply to MSIX builds) and trimming made opt-in only.

## Verification
- Debug x64 build OK; Core tests 168/168.
- Local self-contained x64 Release MSIX built with the exact release recipe, signed with a throwaway cert, installed in **Windows Sandbox with no .NET runtime present**: installs, runs 60 s from a foreign cwd, no crash.log, welcome screen shows the icon.

After merge: tag \1.7.3-windows\, run Launch Smoke (\source=release\), then \winget-submit\.