### PR TITLE
Windows 1.7.4: framework-dependent MSIX again + NuGet updates

### DIFF
--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -1,8 +1,7 @@
 name: Windows Launch Smoke (winget harness repro)
 
 # Reproduces the winget-pkgs "Installation Validation" step on real x64 and ARM64 runners:
-# install an MSIX (the runtimes are installed too so older framework-dependent releases still
-# work; current releases are self-contained and ignore them), launch
+# install the framework-dependent MSIX together with its declared runtime dependencies, launch
 # TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the harness does), and report
 # whether the process survives. On a crash the job collects the app's crash.log plus the
 # ".NET Runtime" / "Application Error" event-log records, which carry the managed stack that the
@@ -105,8 +104,8 @@ jobs:
             -c Release `
             -p:Platform=$platform `
             -p:RuntimeIdentifier=win-$env:ARCH `
-            -p:SelfContained=true `
-            -p:WindowsAppSDKSelfContained=true `
+            -p:SelfContained=false `
+            -p:WindowsAppSDKSelfContained=false `
             -p:PublishTrimmed=false `
             -p:EnableMsixTooling=true `
             -p:GenerateAppxPackageOnBuild=true `

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -71,12 +71,14 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/windows | Out-Null
 
-          # Self-contained MSIX: the package bundles both the .NET 10 runtime and the Windows App
-          # SDK runtime, so it has no framework-package or winget dependencies and runs on a clean
-          # machine (including Windows Sandbox) with nothing else installed. This is larger than a
-          # framework-dependent package (~3x) but removes the target machine's runtime versions as
-          # a variable - adopted while chasing winget's Validation-Executable-Error on 1.7.x.
-          # PublishTrimmed is forced off: trimming WinUI 3 + H.NotifyIcon + NAudio is not safe.
+          # Framework-dependent MSIX (small package). The app does NOT bundle the .NET or
+          # Windows App SDK runtimes; instead they are declared as winget PackageDependencies
+          # in the installer manifest (Microsoft.DotNet.DesktopRuntime.10 and
+          # Microsoft.WindowsAppRuntime.1.8). winget installs those dependency packages before
+          # the app, and the Windows App SDK runtime is also auto-acquired by the OS on machines
+          # with the Store/App Installer. NOTE: a framework-dependent MSIX cannot be verified in
+          # Windows Sandbox (it has no Store, so framework auto-acquisition fails with
+          # 0x80073cf3) - validate on a real machine or via the winget validation pipeline.
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -91,9 +93,8 @@ jobs:
               -c Release `
               -p:Platform=$($p.Platform) `
               -p:RuntimeIdentifier=$($p.Rid) `
-              -p:SelfContained=true `
-              -p:WindowsAppSDKSelfContained=true `
-              -p:PublishTrimmed=false `
+              -p:SelfContained=false `
+              -p:WindowsAppSDKSelfContained=false `
               -p:EnableMsixTooling=true `
               -p:GenerateAppxPackageOnBuild=true `
               -p:AppxPackageDir=$packageDirFull `
@@ -109,10 +110,11 @@ jobs:
             if (-not $produced) { throw "No MSIX produced for $($p.Platform)." }
 
             # Guard against silently shipping the wrong kind of package. Unpack the MSIX and
-            # assert it is genuinely self-contained: (1) the AppxManifest declares NO
-            # WindowsAppRuntime framework dependency (the runtime is bundled), and (2) the payload
-            # contains the .NET runtime (coreclr.dll). The winget manifest declares no
-            # dependencies, so a framework-dependent package here would fail to install.
+            # assert it is genuinely framework-dependent: (1) the AppxManifest declares the
+            # WindowsAppRuntime framework dependency (so the declared winget dependency matches
+            # the package), and (2) the payload does NOT contain the .NET runtime (coreclr.dll),
+            # confirming the .NET runtime is framework-dependent and delivered via the declared
+            # Microsoft.DotNet.DesktopRuntime.10 winget dependency.
             $verifyDir = Join-Path $packageDir "verify"
             Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
             $zipCopy = "$($produced.FullName).zip"
@@ -120,17 +122,13 @@ jobs:
             Expand-Archive $zipCopy -DestinationPath $verifyDir -Force
 
             $appxManifest = Get-Content (Join-Path $verifyDir "AppxManifest.xml") -Raw
-            if ($appxManifest -match '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
-              throw "Self-contained MSIX for $($p.Platform) still declares a WindowsAppRuntime framework dependency - expected WindowsAppSDKSelfContained=true."
+            if ($appxManifest -notmatch '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
+              throw "Framework-dependent MSIX for $($p.Platform) is missing the WindowsAppRuntime framework dependency."
             }
 
-            if (-not (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue)) {
-              throw "MSIX for $($p.Platform) does not bundle the .NET runtime (coreclr.dll) - expected a self-contained (SelfContained=true) build."
+            if (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue) {
+              throw "MSIX for $($p.Platform) bundles the .NET runtime (coreclr.dll) - expected a framework-dependent (SelfContained=false) build."
             }
-            if (-not (Get-ChildItem $verifyDir -Recurse -Filter "Microsoft.UI.Xaml.dll" -ErrorAction SilentlyContinue)) {
-              throw "MSIX for $($p.Platform) does not bundle the Windows App SDK runtime (Microsoft.UI.Xaml.dll) - expected WindowsAppSDKSelfContained=true."
-            }
-            "$($p.Platform): self-contained package verified ($([math]::Round($produced.Length / 1MB, 1)) MB)"
             Remove-Item $zipCopy -Force -ErrorAction SilentlyContinue
             Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -265,9 +263,11 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, self-contained MSIX produced by the Windows Release
-          # workflow. The package bundles the .NET and Windows App SDK runtimes, so it declares no
-          # winget package dependencies. Do not set Scope here.
+          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
+          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
+          # they are declared below as winget package dependencies so winget installs them before
+          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
+          # scope, and forcing user scope makes winget reject them during validation.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -276,6 +276,10 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
+          Dependencies:
+            PackageDependencies:
+              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -4,9 +4,8 @@ name: WinGet Submission
 # repository (microsoft/winget-pkgs). Run this AFTER you've eyeballed the GitHub release.
 #
 # Unlike the PowerToys "wingetcreate update" approach, this regenerates our full multi-file
-# manifest from source (windows/packaging/winget) so the installer manifest always matches the
-# package we ship (currently self-contained, no Dependencies block), instead of inheriting
-# whatever the previously published version declared.
+# manifest from source (windows/packaging/winget) so the framework Dependencies block is
+# always present, instead of inheriting whatever the previously published version declared.
 #
 # Requires a repository secret named WINGET_CREATE_GITHUB_TOKEN: a classic PAT from an
 # account that can fork microsoft/winget-pkgs, with the `public_repo` scope. wingetcreate
@@ -89,9 +88,11 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, self-contained MSIX produced by the Windows Release
-          # workflow. The package bundles the .NET and Windows App SDK runtimes, so it declares no
-          # winget package dependencies. Do not set Scope here.
+          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
+          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
+          # they are declared below as winget package dependencies so winget installs them before
+          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
+          # scope, and forcing user scope makes winget reject them during validation.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -100,6 +101,10 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
+          Dependencies:
+            PackageDependencies:
+              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/${{ github.repository }}/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,19 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Changed
+- **Back to a framework-dependent MSIX.** 1.7.3's self-contained package did not change winget's
+  arm64 `Validation-Executable-Error`, so it bought nothing for ~100 MB. The package again declares
+  `Microsoft.DotNet.DesktopRuntime.10` and `Microsoft.WindowsAppRuntime.1.8` as winget
+  dependencies and the release workflow guards are restored.
+- **Dependency updates** — Windows App SDK 1.8.260804001 (staying on 1.8), Win2D 1.4.0,
+  H.NotifyIcon.WinUI 2.4.1, CommunityToolkit.Mvvm 8.4.2, Microsoft.Extensions.* 10.0.11,
+  System.Drawing.Common 10.0.11, Vortice 3.8.3, Windows SDK BuildTools 10.0.28000.2526 /
+  WinApp 0.6.1, NAudio 3.0.1 (its `ISampleProvider`/`IWaveProvider.Read` are now `Span<T>`-based;
+  the limiter, mute and timeline providers were updated and `MMDevice.CreateAudioClient()` replaces
+  the obsolete property), plus test tooling (Microsoft.NET.Test.Sdk 18.9, xunit.runner 4.0,
+  coverlet 10).
+
 ## [v1.7.3-windows] - 2026-08-25
 
 ### Changed

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -20,10 +20,10 @@ cd windows
 winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
 winapp cert install
 
-# Produce self-contained MSIX packages (x64 and arm64). The .NET and Windows App SDK runtimes
-# are bundled, so the package has no framework dependencies and runs on a clean machine.
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false
+# Produce framework-dependent MSIX packages (x64 and arm64). The .NET and Windows App SDK
+# runtimes are NOT bundled; they are declared as winget package dependencies instead.
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
+dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
 winapp package src\TinyClips.App\bin\x64\Release\net10.0-windows10.0.26100.0\win-x64 --output TinyClips-x64.msix
 winapp package src\TinyClips.App\bin\arm64\Release\net10.0-windows10.0.26100.0\win-arm64 --output TinyClips-arm64.msix
 
@@ -36,44 +36,54 @@ Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`).
 ### Automated Windows release workflow
 
 `.github/workflows/windows-release.yml` runs for tags like `v1.0.1-windows` and maps them to
-MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **self-contained** MSIX packages,
-signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates a versioned
-winget manifest artifact, and creates the GitHub Release.
+MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **framework-dependent** MSIX
+packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates
+a versioned winget manifest artifact, and creates the GitHub Release.
 
-#### Self-contained packages (and why)
+#### Framework-dependent + declared winget dependencies (and how)
 
-Since 1.7.3 the package bundles both runtimes (`-p:SelfContained=true` for .NET and
-`-p:WindowsAppSDKSelfContained=true` for the Windows App SDK), with trimming explicitly off
-(`-p:PublishTrimmed=false`; WinUI 3, H.NotifyIcon, NAudio and System.Drawing rely on reflection
-that trimming breaks). The winget installer manifest therefore declares **no** package
-dependencies. The release workflow unpacks each MSIX and asserts it is genuinely self-contained
-(no `WindowsAppRuntime` framework dependency in the AppxManifest, and both `coreclr.dll` and
-`Microsoft.UI.Xaml.dll` present in the payload) before signing.
+The package is kept small by **not** bundling the runtimes. The winget installer manifest declares
+both runtimes as package dependencies, so winget installs them before the app:
 
-The trade-off is size (~3x a framework-dependent package) and that runtime security fixes ship
-with a Tiny Clips release instead of via the shared framework packages. We switched while
-chasing winget's repeated `Validation-Executable-Error` on 1.7.x: it removes the validation VM's
-runtime versions as a variable, and a self-contained MSIX can be verified end-to-end in Windows
-Sandbox (which has no Store and so cannot auto-acquire framework packages).
+| winget `PackageDependency` | Provides |
+|---|---|
+| `Microsoft.WindowsAppRuntime.1.8` | The Windows App SDK runtime (WinUI 3, etc.) |
+| `Microsoft.DotNet.DesktopRuntime.10` | The .NET 10 Desktop Runtime |
 
-Versions 1.0.x–1.7.2 were framework-dependent and declared `Microsoft.WindowsAppRuntime.1.8` and
-`Microsoft.DotNet.DesktopRuntime.10` as winget dependencies. If we ever go back, restore that
-`Dependencies` block in both workflows and the template, flip the workflow guards, and do not add
-`Scope: user` (the dependency installers are machine-scope and winget validation rejects it).
+The matching MSBuild properties are `-p:SelfContained=false` (do not bundle .NET) and
+`-p:WindowsAppSDKSelfContained=false` (do not bundle the Windows App SDK runtime). The release
+workflow unpacks each MSIX and asserts it is genuinely framework-dependent (the AppxManifest
+declares the `WindowsAppRuntime` dependency and the payload contains no bundled `coreclr.dll`)
+before signing.
 
-#### Verifying on a clean machine
+> ⚠️ **Both runtimes are delivered differently.** The Windows App SDK runtime is an MSIX
+> *framework package*, so on machines with the Store/App Installer the OS can auto-acquire it
+> during deployment, and winget can also install the declared `Microsoft.WindowsAppRuntime.1.8`
+> dependency. The .NET Desktop Runtime is **not** an MSIX framework — the OS will not auto-deliver
+> it — so it is installed via the declared `Microsoft.DotNet.DesktopRuntime.10` winget dependency.
 
-Install the MSIX on a clean machine or in Windows Sandbox (no runtimes required), launch
-`TinyClips.App.exe` from `C:\Program Files\WindowsApps\Refractored.TinyClips_*` with an unrelated
-working directory (that is what winget's harness does), and confirm the process stays alive with
-the tray icon present. The `Windows Launch Smoke` workflow automates exactly this on x64 and ARM64
-runners (`source=release` for a published tag, `source=build` for the current branch).
+> ⚠️ **Do not verify a framework-dependent build in Windows Sandbox.** Sandbox has no Microsoft
+> Store, so MSIX framework auto-acquisition fails and the install dies at ~95% with `0x80073cf3`
+> (`This package has a dependency missing from your system`). That is a Sandbox artifact, not a
+> real failure. Validate on a real machine (with the runtimes absent, then `winget install` and
+> let winget resolve the dependencies) or rely on winget's Installation Validation pipeline.
+
+#### Verifying on a real clean machine
+
+On a normal Windows machine (with the Store/App Installer) that does not yet have the runtimes,
+`winget install --manifest <dir>` should install `Microsoft.DotNet.DesktopRuntime.10` and
+`Microsoft.WindowsAppRuntime.1.8` first, then the app. A pass is the app process running with the
+tray icon present and no `.NET Desktop Runtime` prompt.
+
+Do not add `Scope: user` to the installer manifest. The TinyClips MSIX installs per-user by
+default, but the runtime dependency installers are machine-scope/unknown-scope packages; forcing
+user scope causes winget validation to reject those dependencies with "No suitable installer found."
 
 ```pwsh
-# Build a self-contained, packaged MSIX (x64)
+# Build a framework-dependent, packaged MSIX (x64)
 dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `
   -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
-  -p:SelfContained=true -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=false `
+  -p:SelfContained=false -p:WindowsAppSDKSelfContained=false `
   -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
   -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
   -p:AppxPackageDir=<out>\ -p:AppxPackageSigningEnabled=false

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# Installer manifest for the signed, self-contained MSIX produced by the Windows Release workflow.
-# The package bundles the .NET and Windows App SDK runtimes, so it declares no winget package
-# dependencies. Do not set Scope.
+# Installer manifest for the signed, framework-dependent MSIX produced by `winapp pack`.
+# The package does not bundle the .NET or Windows App SDK runtimes; they are declared below
+# as winget package dependencies so winget installs them before the app. Do not set Scope:
+# the dependency installers are machine-scope/unknown scope, and forcing user scope makes
+# winget reject them during validation.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
 #   winget hash --msix <path-to-msix>
@@ -13,6 +15,10 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -79,14 +79,14 @@
   -->
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260529003" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.2" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260804001" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/AudioCaptureService.cs
@@ -300,7 +300,7 @@ public sealed class AudioCaptureService : IDisposable
 
             var bytesWanted = frameCount * Channels * (BitsPerSample / 8);
             var buffer = new byte[bytesWanted];
-            var read = _output.Read(buffer, 0, bytesWanted);
+            var read = _output.Read(buffer.AsSpan());
             if (read <= 0)
             {
                 return null;
@@ -425,12 +425,15 @@ public sealed class AudioCaptureService : IDisposable
 
         public WaveFormat WaveFormat => _source.WaveFormat;
 
-        public int Read(float[] buffer, int offset, int count)
+        public int Read(float[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public int Read(Span<float> buffer)
         {
-            var read = _source.Read(buffer, offset, count);
+            var read = _source.Read(buffer);
             if (read > 0 && _isMuted())
             {
-                Array.Clear(buffer, offset, read);
+                buffer[..read].Clear();
             }
 
             return read;

--- a/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/SoftKneeLimiterSampleProvider.cs
@@ -27,9 +27,12 @@ public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
 
     public WaveFormat WaveFormat => _source.WaveFormat;
 
-    public int Read(float[] buffer, int offset, int count)
+    public int Read(float[] buffer, int offset, int count) =>
+        Read(buffer.AsSpan(offset, count));
+
+    public int Read(Span<float> buffer)
     {
-        var read = _source.Read(buffer, offset, count);
+        var read = _source.Read(buffer);
         if (read <= 0)
         {
             return read;
@@ -37,7 +40,7 @@ public sealed class SoftKneeLimiterSampleProvider : ISampleProvider
 
         try
         {
-            LimitInPlace(buffer.AsSpan(offset, read));
+            LimitInPlace(buffer[..read]);
         }
         catch (Exception ex)
         {

--- a/windows/src/TinyClips.Core/Capture/TimelineAlignedWaveProvider.cs
+++ b/windows/src/TinyClips.Core/Capture/TimelineAlignedWaveProvider.cs
@@ -51,11 +51,10 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
     {
         WaveFormat = waveFormat;
         _sourceName = sourceName ?? "audio";
-        _buffer = new BufferedWaveProvider(waveFormat)
+        _buffer = new BufferedWaveProvider(waveFormat, TimeSpan.FromSeconds(5))
         {
             ReadFully = true,
             DiscardOnBufferOverflow = true,
-            BufferDuration = TimeSpan.FromSeconds(5),
         };
     }
 
@@ -280,10 +279,13 @@ internal sealed class TimelineAlignedWaveProvider : IWaveProvider
     /// written cursor advances to cover them. The next packet then sees an overlap and is trimmed,
     /// instead of landing late behind silence the muxer has already consumed.
     /// </summary>
-    public int Read(byte[] buffer, int offset, int count)
+    public int Read(byte[] buffer, int offset, int count) =>
+        Read(buffer.AsSpan(offset, count));
+
+    public int Read(Span<byte> buffer)
     {
         var bufferedBefore = _buffer.BufferedBytes;
-        var read = _buffer.Read(buffer, offset, count);
+        var read = _buffer.Read(buffer);
         if (read > bufferedBefore)
         {
             var underrunFrames = (read - bufferedBefore) / WaveFormat.BlockAlign;

--- a/windows/src/TinyClips.Core/Capture/TimestampedWasapiCapture.cs
+++ b/windows/src/TinyClips.Core/Capture/TimestampedWasapiCapture.cs
@@ -33,7 +33,7 @@ internal sealed class TimestampedWasapiCapture : IDisposable
     public TimestampedWasapiCapture(MMDevice device, bool isLoopback)
     {
         _device = device;
-        _audioClient = device.AudioClient;
+        _audioClient = device.CreateAudioClient();
         _isLoopback = isLoopback;
 
         // WASAPI's shared-mode mix format is a WaveFormatExtensible. Initialize WASAPI with

--- a/windows/src/TinyClips.Core/TinyClips.Core.csproj
+++ b/windows/src/TinyClips.Core/TinyClips.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!--
     TinyClips.Core: UI-free domain layer (capture pipeline, services, models).
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
-    <PackageReference Include="Vortice.Direct3D11" Version="3.8.1" />
-    <PackageReference Include="Vortice.DXGI" Version="3.8.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="NAudio" Version="3.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
+    <PackageReference Include="Vortice.Direct3D11" Version="3.8.3" />
+    <PackageReference Include="Vortice.DXGI" Version="3.8.3" />
   </ItemGroup>
 
 </Project>

--- a/windows/tests/TinyClips.Core.Tests/RecordingTimelineTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/RecordingTimelineTests.cs
@@ -413,7 +413,7 @@ public sealed class RecordingTimelineTests
     private static short[] ReadSamples(IWaveProvider provider, int count)
     {
         var bytes = new byte[count * sizeof(short)];
-        Assert.Equal(bytes.Length, provider.Read(bytes, 0, bytes.Length));
+        Assert.Equal(bytes.Length, provider.Read(bytes.AsSpan()));
         var samples = new short[count];
         Buffer.BlockCopy(bytes, 0, samples, 0, bytes.Length);
         return samples;

--- a/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
+++ b/windows/tests/TinyClips.Core.Tests/SoftKneeLimiterSampleProviderTests.cs
@@ -128,10 +128,10 @@ public sealed class SoftKneeLimiterSampleProviderTests
 
         public WaveFormat WaveFormat { get; } = WaveFormat.CreateIeeeFloatWaveFormat(48000, 2);
 
-        public int Read(float[] buffer, int offset, int count)
+        public int Read(Span<float> buffer)
         {
-            var available = Math.Min(count, _samples.Length - _position);
-            Array.Copy(_samples, _position, buffer, offset, available);
+            var available = Math.Min(buffer.Length, _samples.Length - _position);
+            _samples.AsSpan(_position, available).CopyTo(buffer);
             _position += available;
             return available;
         }

--- a/windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj
+++ b/windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Reverts the 1.7.3 self-contained packaging (release, winget-submit, smoke workflows, template, docs) - it did not change winget's arm64 \Validation-Executable-Error\ (microsoft/winget-pkgs#424081), so back to the 21 MB framework-dependent MSIX with declared runtime dependencies.
- NuGet updates: WinAppSDK **1.8.260804001** (staying on 1.8 by design), Win2D 1.4.0, H.NotifyIcon.WinUI 2.4.1, CommunityToolkit.Mvvm 8.4.2, Microsoft.Extensions.* 10.0.11, System.Drawing.Common 10.0.11, Vortice 3.8.3, SDK BuildTools 10.0.28000.2526 / WinApp 0.6.1, NAudio 3.0.1, Microsoft.NET.Test.Sdk 18.9.0, xunit.runner.visualstudio 4.0.0, coverlet 10.0.1.
- NAudio 3 API changes handled: \ISampleProvider\/\IWaveProvider.Read\ are Span-only (limiter, mute and timeline providers + tests), \BufferedWaveProvider\ takes duration in ctor, \MMDevice.CreateAudioClient()\ replaces the obsolete property.

Verified: x64 + ARM64 Debug builds, Core tests 168/168.