### PR TITLE
Move tests to xUnit.net v3 (Microsoft.Testing.Platform)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -15,8 +15,11 @@ own `CHANGELOG.md` at the repository root.
   System.Drawing.Common 10.0.11, Vortice 3.8.3, Windows SDK BuildTools 10.0.28000.2526 /
   WinApp 0.6.1, NAudio 3.0.1 (its `ISampleProvider`/`IWaveProvider.Read` are now `Span<T>`-based;
   the limiter, mute and timeline providers were updated and `MMDevice.CreateAudioClient()` replaces
-  the obsolete property), plus test tooling (Microsoft.NET.Test.Sdk 18.9, xunit.runner 4.0,
-  coverlet 10).
+  the obsolete property). Tests moved to **xUnit.net v3** (`xunit.v3` 4.0) running on
+  Microsoft.Testing.Platform — xUnit v2 is deprecated. A root `global.json` opts `dotnet test` into
+  the new MTP runner; the test project is now an executable and no longer references
+  `Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio` or `coverlet.collector`. The
+  `dotnet test` command is unchanged.
 
 ## [v1.7.3-windows] - 2026-08-25
 

--- a/windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj
+++ b/windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- xUnit.net v3 test projects are executables. -->
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,10 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
xunit 2.x is deprecated. Switch the Core tests to \xunit.v3\ 4.0.0 (MTP v2):
- root \global.json\ opts \dotnet test\ into the Microsoft.Testing.Platform runner (required on .NET 10 SDK; VSTest mode is no longer supported there)
- test project is now \OutputType=Exe\; removed \Microsoft.NET.Test.Sdk\, \xunit.runner.visualstudio\, \coverlet.collector\
- \dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Debug|Release\ unchanged; 168/168 pass locally in both configurations.