### PR TITLE
Pin WinAppSDK to winget-deliverable runtime; add Windows Sandbox validation tooling

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -19,6 +19,10 @@ env:
   APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
   PACKAGE_FAMILY_NAME: Refractored.TinyClips_vmshqmcyy894t
   SIGNTOOL_TIMESTAMP_URL: http://timestamp.acs.microsoft.com
+  # Highest WindowsAppRuntime 1.8 version installable via winget's Microsoft.WindowsAppRuntime.1.8
+  # (manifests/m/Microsoft/WindowsAppRuntime/1/8 in microsoft/winget-pkgs; 1.8.9 = 8000.879.2017.0).
+  # The MSIX's MinVersion must not exceed this or winget installs fail on dependency resolution.
+  WINGET_WINDOWSAPPRUNTIME_MAX_VERSION: 8000.879.2017.0
 
 jobs:
   build-sign-release:
@@ -76,9 +80,9 @@ jobs:
           # in the installer manifest (Microsoft.DotNet.DesktopRuntime.10 and
           # Microsoft.WindowsAppRuntime.1.8). winget installs those dependency packages before
           # the app, and the Windows App SDK runtime is also auto-acquired by the OS on machines
-          # with the Store/App Installer. NOTE: a framework-dependent MSIX cannot be verified in
-          # Windows Sandbox (it has no Store, so framework auto-acquisition fails with
-          # 0x80073cf3) - validate on a real machine or via the winget validation pipeline.
+          # with the Store/App Installer. Validate locally with
+          # windows/packaging/sandbox/Invoke-SandboxValidation.ps1 (installs the runtimes in a fresh
+          # Windows Sandbox first) and on ARM64 via the Windows Launch Smoke workflow.
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -125,6 +129,18 @@ jobs:
             if ($appxManifest -notmatch '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
               throw "Framework-dependent MSIX for $($p.Platform) is missing the WindowsAppRuntime framework dependency."
             }
+
+            # The declared winget dependency Microsoft.WindowsAppRuntime.1.8 can only deliver the
+            # runtime versions published in winget-pkgs. If the SDK bump raised the package's
+            # MinVersion past that, every winget install fails with a missing-dependency error.
+            $runtimeDependency = [regex]::Match($appxManifest, '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime\.1\.8"[^>]*MinVersion="([^"]+)"')
+            if (-not $runtimeDependency.Success) { throw "Could not read the WindowsAppRuntime.1.8 MinVersion for $($p.Platform)." }
+            $minVersion = [version]$runtimeDependency.Groups[1].Value
+            $wingetMax = [version]$env:WINGET_WINDOWSAPPRUNTIME_MAX_VERSION
+            if ($minVersion -gt $wingetMax) {
+              throw "MSIX for $($p.Platform) requires WindowsAppRuntime.1.8 >= $minVersion, but winget's Microsoft.WindowsAppRuntime.1.8 only provides up to $wingetMax. Pin Microsoft.WindowsAppSDK to a version whose runtime winget ships (see the csproj comment), or raise WINGET_WINDOWSAPPRUNTIME_MAX_VERSION after winget-pkgs publishes the newer runtime."
+            }
+            "$($p.Platform): WindowsAppRuntime.1.8 MinVersion $minVersion <= winget-available $wingetMax"
 
             if (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue) {
               throw "MSIX for $($p.Platform) bundles the .NET runtime (coreclr.dll) - expected a framework-dependent (SelfContained=false) build."

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -10,13 +10,24 @@ own `CHANGELOG.md` at the repository root.
   arm64 `Validation-Executable-Error`, so it bought nothing for ~100 MB. The package again declares
   `Microsoft.DotNet.DesktopRuntime.10` and `Microsoft.WindowsAppRuntime.1.8` as winget
   dependencies and the release workflow guards are restored.
-- **Dependency updates** — Windows App SDK 1.8.260804001 (staying on 1.8), Win2D 1.4.0,
+- **Dependency updates** — Win2D 1.4.0,
   H.NotifyIcon.WinUI 2.4.1, CommunityToolkit.Mvvm 8.4.2, Microsoft.Extensions.* 10.0.11,
   System.Drawing.Common 10.0.11, Vortice 3.8.3, Windows SDK BuildTools 10.0.28000.2526 /
   WinApp 0.6.1, NAudio 3.0.1 (its `ISampleProvider`/`IWaveProvider.Read` are now `Span<T>`-based;
   the limiter, mute and timeline providers were updated and `MMDevice.CreateAudioClient()` replaces
   the obsolete property), plus test tooling (Microsoft.NET.Test.Sdk 18.9, xunit.runner 4.0,
   coverlet 10).
+- **Windows App SDK stays pinned at 1.8.260529003.** Newer 1.8 SDKs raise the MSIX's
+  `Microsoft.WindowsAppRuntime.1.8` `MinVersion` (e.g. 1.8.260804001 → `8000.946.1701.0`) beyond
+  the runtime winget's `Microsoft.WindowsAppRuntime.1.8` package can install (1.8.9 =
+  `8000.879.2017.0`), which would break every winget install. The release workflow now asserts
+  `MinVersion` ≤ the winget-available runtime (`WINGET_WINDOWSAPPRUNTIME_MAX_VERSION`).
+
+### Added
+- **Windows Sandbox validation scripts** (`windows/packaging/sandbox/`) — one command installs both
+  runtimes in a fresh Sandbox, installs a built or released MSIX, launches it exactly like winget's
+  harness (full `WindowsApps` path, foreign working directory), clicks through onboarding and
+  requires the process to stay alive, collecting `crash.log` and event-log stacks on failure.
 
 ## [v1.7.3-windows] - 2026-08-25
 

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -62,11 +62,28 @@ before signing.
 > dependency. The .NET Desktop Runtime is **not** an MSIX framework — the OS will not auto-deliver
 > it — so it is installed via the declared `Microsoft.DotNet.DesktopRuntime.10` winget dependency.
 
-> ⚠️ **Do not verify a framework-dependent build in Windows Sandbox.** Sandbox has no Microsoft
-> Store, so MSIX framework auto-acquisition fails and the install dies at ~95% with `0x80073cf3`
-> (`This package has a dependency missing from your system`). That is a Sandbox artifact, not a
-> real failure. Validate on a real machine (with the runtimes absent, then `winget install` and
-> let winget resolve the dependencies) or rely on winget's Installation Validation pipeline.
+> ⚠️ **Keep `Microsoft.WindowsAppSDK` pinned to a version whose runtime winget ships.** The MSIX's
+> `Microsoft.WindowsAppRuntime.1.8` `MinVersion` follows the SDK NuGet version, and winget's
+> `Microsoft.WindowsAppRuntime.1.8` package (`manifests/m/Microsoft/WindowsAppRuntime/1/8` in
+> winget-pkgs) only provides the runtime builds Microsoft has published there — 1.8.9 = `8000.879.2017.0`
+> = SDK `1.8.260529003`. A newer SDK (e.g. `1.8.260804001` → `8000.946.1701.0`) makes every winget
+> install fail on dependency resolution. The release workflow asserts `MinVersion` ≤
+> `WINGET_WINDOWSAPPRUNTIME_MAX_VERSION`; raise both together once winget-pkgs publishes the newer
+> runtime.
+
+#### Verifying locally in Windows Sandbox (recommended before every release)
+
+```pwsh
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4     # working tree
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4   # published tag
+```
+
+This installs both runtimes from their installers in a fresh Sandbox (so framework-dependent
+packages *do* work there — without that step Sandbox fails with `0x80073cf3` because it has no
+Store to auto-acquire frameworks), installs the MSIX, launches it exactly like winget's harness,
+clicks through onboarding and requires the process to stay alive. See
+[`sandbox/README.md`](sandbox/README.md). Sandbox is x64-only; for ARM64 run the
+*Windows Launch Smoke* workflow (`source=release`, `windows-11-arm` runner).
 
 #### Verifying on a real clean machine
 

--- a/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
+++ b/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
@@ -73,9 +73,10 @@ if ($Source -eq 'Release') {
     $packageDir = Join-Path $WorkDir 'build'
     Remove-Item $packageDir -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Force $packageDir | Out-Null
-    $manifestBackup = Get-Content $manifestPath -Raw
+    $manifestBackup = [IO.File]::ReadAllBytes($manifestPath)
     try {
-        ($manifestBackup -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$Version.0`${2}") | Set-Content $manifestPath -Encoding UTF8 -NoNewline
+        $text = [Text.Encoding]::UTF8.GetString($manifestBackup)
+        [IO.File]::WriteAllText($manifestPath, ($text -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$Version.0`${2}"), (New-Object Text.UTF8Encoding $true))
         dotnet build $appProject -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
             -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false `
             -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
@@ -83,7 +84,7 @@ if ($Source -eq 'Release') {
             -p:AppxPackageSigningEnabled=false -nologo -v minimal
         if ($LASTEXITCODE -ne 0) { throw 'MSIX build failed.' }
     } finally {
-        Set-Content $manifestPath $manifestBackup -NoNewline
+        [IO.File]::WriteAllBytes($manifestPath, $manifestBackup)
     }
     $produced = Get-ChildItem $packageDir -Recurse -Filter *.msix | Where-Object Name -notmatch 'symbols' | Select-Object -First 1
     if (-not $produced) { throw 'No MSIX produced.' }

--- a/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
+++ b/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
@@ -1,0 +1,155 @@
+<#
+.SYNOPSIS
+  One-command Windows Sandbox validation of a Tiny Clips MSIX, mirroring winget's Installation
+  Validation: fresh OS, runtimes installed from their installers, MSIX installed, app launched
+  from C:\Program Files\WindowsApps with an unrelated working directory, first-run onboarding
+  clicked through, process must stay alive.
+
+.DESCRIPTION
+  Run from the repository root on the host. Requires Windows Sandbox (optional feature
+  "Containers-DisposableClientVM"), the Windows 10/11 SDK (signtool), and - for -Source Build -
+  the .NET 10 SDK. Windows Sandbox is x64-only, so this validates the x64 package; use the
+  "Windows Launch Smoke" GitHub workflow for ARM64.
+
+  Only one Sandbox instance can run at a time; close any open Sandbox window first.
+
+.PARAMETER Source
+  Release  - download TinyClips-<Version>-x64.msix from the GitHub release tag v<Version>-windows
+             (already Azure-signed; no certificate needed).
+  Build    - build the MSIX from the working tree with the exact release recipe and sign it with a
+             throwaway self-signed certificate that the Sandbox trusts.
+
+.PARAMETER Version
+  Asset version, e.g. 1.7.4 (used for the download name or to stamp the build).
+
+.PARAMETER WaitSeconds
+  How long the app must stay alive to pass. Default 60.
+
+.PARAMETER WorkDir
+  Host folder mapped into the Sandbox as C:\share. Default: %TEMP%\tinyclips-sandbox.
+
+.EXAMPLE
+  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4
+.EXAMPLE
+  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Release', 'Build')] [string] $Source = 'Build',
+    [Parameter(Mandatory)] [string] $Version,
+    [int] $WaitSeconds = 60,
+    [string] $WorkDir = (Join-Path $env:TEMP 'tinyclips-sandbox')
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$appProject = Join-Path $repo 'windows\src\TinyClips.App\TinyClips.App.csproj'
+$manifestPath = Join-Path $repo 'windows\src\TinyClips.App\Package.appxmanifest'
+$msixName = "TinyClips-$Version-x64.msix"
+
+if (-not (Get-Command WindowsSandbox.exe -ErrorAction SilentlyContinue)) { throw 'Windows Sandbox is not installed (Turn Windows features on or off -> Windows Sandbox).' }
+if (Get-Process WindowsSandbox* -ErrorAction SilentlyContinue) { throw 'A Windows Sandbox instance is already running; close it first.' }
+
+New-Item -ItemType Directory -Force $WorkDir | Out-Null
+Remove-Item (Join-Path $WorkDir 'sandbox-result.txt'), (Join-Path $WorkDir '*.png'), (Join-Path $WorkDir 'smoke.cer') -ErrorAction SilentlyContinue
+
+# --- Runtimes (cached between runs) ---
+$dotnet = Join-Path $WorkDir 'windowsdesktop-runtime.exe'
+$war = Join-Path $WorkDir 'WindowsAppRuntimeInstall.exe'
+if (-not (Test-Path $dotnet)) { Write-Host 'Downloading .NET 10 Desktop Runtime installer...'; Invoke-WebRequest 'https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe' -OutFile $dotnet -MaximumRedirection 10 }
+if (-not (Test-Path $war)) {
+    # Same runtime build winget's Microsoft.WindowsAppRuntime.1.8 (1.8.9) installs: 8000.879.2017.0.
+    Write-Host 'Downloading Windows App Runtime 1.8 installer...'
+    Invoke-WebRequest 'https://aka.ms/windowsappsdk/1.8/1.8.260529003/windowsappruntimeinstall-x64.exe' -OutFile $war -MaximumRedirection 10
+}
+
+# --- Package ---
+$msixPath = Join-Path $WorkDir $msixName
+if ($Source -eq 'Release') {
+    Write-Host "Downloading $msixName from release v$Version-windows..."
+    gh release download "v$Version-windows" --repo jamesmontemagno/tiny-clips --pattern $msixName --dir $WorkDir --clobber
+    if ($LASTEXITCODE -ne 0) { throw 'gh release download failed.' }
+} else {
+    Write-Host "Building framework-dependent x64 MSIX $Version from the working tree..."
+    $packageDir = Join-Path $WorkDir 'build'
+    Remove-Item $packageDir -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force $packageDir | Out-Null
+    $manifestBackup = Get-Content $manifestPath -Raw
+    try {
+        ($manifestBackup -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$Version.0`${2}") | Set-Content $manifestPath -Encoding UTF8 -NoNewline
+        dotnet build $appProject -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
+            -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false `
+            -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
+            -p:AppxPackageDir="$packageDir\" -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
+            -p:AppxPackageSigningEnabled=false -nologo -v minimal
+        if ($LASTEXITCODE -ne 0) { throw 'MSIX build failed.' }
+    } finally {
+        Set-Content $manifestPath $manifestBackup -NoNewline
+    }
+    $produced = Get-ChildItem $packageDir -Recurse -Filter *.msix | Where-Object Name -notmatch 'symbols' | Select-Object -First 1
+    if (-not $produced) { throw 'No MSIX produced.' }
+    Copy-Item $produced.FullName $msixPath -Force
+
+    Write-Host 'Signing with a throwaway self-signed certificate...'
+    $subject = ([xml](Get-Content $manifestPath)).Package.Identity.Publisher
+    $cert = New-SelfSignedCertificate -Type Custom -Subject $subject -KeyUsage DigitalSignature -FriendlyName 'TinyClips sandbox validation' `
+        -CertStoreLocation Cert:\CurrentUser\My -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3', '2.5.29.19={text}')
+    try {
+        Export-Certificate -Cert $cert -FilePath (Join-Path $WorkDir 'smoke.cer') -Force | Out-Null
+        $pfx = Join-Path $WorkDir 'smoke.pfx'
+        $pwd = ConvertTo-SecureString 'sandbox' -Force -AsPlainText
+        Export-PfxCertificate -Cert $cert -FilePath $pfx -Password $pwd | Out-Null
+        $kits = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory | Where-Object Name -match '^10\.' | Sort-Object Name -Descending | Select-Object -First 1
+        if (-not $kits) { throw 'Windows SDK (signtool) not found.' }
+        & (Join-Path $kits.FullName 'x64\signtool.exe') sign /fd SHA256 /f $pfx /p sandbox $msixPath | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw 'signtool failed.' }
+    } finally {
+        Remove-Item "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $WorkDir 'smoke.pfx') -ErrorAction SilentlyContinue
+    }
+}
+
+# Report what the package demands vs. what winget can install.
+$verify = Join-Path $WorkDir 'verify'
+Remove-Item $verify -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item $msixPath "$msixPath.zip" -Force; Expand-Archive "$msixPath.zip" $verify -Force; Remove-Item "$msixPath.zip"
+$dep = ([xml](Get-Content (Join-Path $verify 'AppxManifest.xml'))).Package.Dependencies.PackageDependency | Where-Object Name -eq 'Microsoft.WindowsAppRuntime.1.8'
+Write-Host "Package requires Microsoft.WindowsAppRuntime.1.8 >= $($dep.MinVersion) (winget 1.8.9 provides 8000.879.2017.0)"
+Remove-Item $verify -Recurse -Force -ErrorAction SilentlyContinue
+
+# --- Sandbox ---
+Copy-Item (Join-Path $PSScriptRoot 'Validate-TinyClips.ps1') (Join-Path $WorkDir 'Validate-TinyClips.ps1') -Force
+@{ Msix = $msixName; WaitSeconds = $WaitSeconds } | ConvertTo-Json | Set-Content (Join-Path $WorkDir 'config.json')
+$wsb = Join-Path $WorkDir 'TinyClips.wsb'
+@"
+<Configuration>
+  <vGPU>Disable</vGPU>
+  <AudioInput>Disable</AudioInput>
+  <VideoInput>Disable</VideoInput>
+  <Networking>Enable</Networking>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>$WorkDir</HostFolder>
+      <SandboxFolder>C:\share</SandboxFolder>
+      <ReadOnly>false</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <LogonCommand>
+    <Command>powershell -ExecutionPolicy Bypass -NoProfile -File C:\share\Validate-TinyClips.ps1</Command>
+  </LogonCommand>
+</Configuration>
+"@ | Set-Content $wsb -Encoding UTF8
+
+Write-Host "Starting Windows Sandbox (runtime install takes ~8-10 minutes; leave the window alone)..."
+Start-Process $wsb
+$result = Join-Path $WorkDir 'sandbox-result.txt'
+$deadline = (Get-Date).AddMinutes(20)
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep 15
+    if ((Test-Path $result) -and (Select-String -Path $result -Pattern '^.*DONE$' -Quiet)) { break }
+}
+Write-Host ''
+if (Test-Path $result) { Get-Content $result } else { Write-Warning 'No result file produced (Sandbox did not start or the logon command failed).' }
+Write-Host ''
+Write-Host "Screenshots: $(Join-Path $WorkDir 'welcome.png'), $(Join-Path $WorkDir 'after-onboarding.png')"
+Write-Host 'Close the Sandbox window when done.'
+if ((Test-Path $result) -and (Select-String -Path $result -Pattern 'RESULT: PASS' -Quiet)) { exit 0 } else { exit 1 }

--- a/windows/packaging/sandbox/README.md
+++ b/windows/packaging/sandbox/README.md
@@ -1,0 +1,84 @@
+# Windows Sandbox validation
+
+Reproduces winget's **Installation Validation** step locally, on a throwaway Windows install, in
+one command. Use it before tagging a Windows release and before opening a winget-pkgs PR.
+
+What it checks, in order:
+
+1. Fresh Windows (Sandbox) with **no** .NET or Windows App SDK runtime.
+2. Installs the .NET 10 Desktop Runtime and the Windows App Runtime 1.8 from their installers —
+   the same runtime build winget's `Microsoft.WindowsAppRuntime.1.8` dependency delivers
+   (`8000.879.2017.0`), so a package whose `MinVersion` is too new fails here too.
+3. Installs the framework-dependent MSIX (`Add-AppxPackage`) and verifies it actually registered.
+4. Launches `TinyClips.App.exe` by full path from `C:\Program Files\WindowsApps\…` with an unrelated
+   working directory (`C:\Windows\Temp`) — exactly how the winget harness starts the app.
+5. Brings the first-run Welcome window to the foreground and presses Enter three times
+   (Next → Next → Get started).
+6. Requires the process to still be alive after `WaitSeconds` (default 60).
+7. Writes `sandbox-result.txt`, two screenshots, the app's `crash.log` (if any) and any
+   `Application Error` / `.NET Runtime` event-log entries to the shared folder.
+
+## Prerequisites (host)
+
+- Windows 10/11 Pro/Enterprise with **Windows Sandbox** enabled
+  (*Turn Windows features on or off → Windows Sandbox*). Sandbox is x64-only.
+- Windows 10/11 SDK (for `signtool.exe`) — needed for `-Source Build`.
+- .NET 10 SDK — needed for `-Source Build`.
+- `gh` CLI, authenticated — needed for `-Source Release`.
+- **No other Sandbox instance running.** Only one can run at a time; the script refuses to start
+  if one is open. If you close the window mid-run, re-run the script from scratch.
+
+## Usage
+
+From the repository root:
+
+```pwsh
+# Validate a published release (Azure-signed, no certificate juggling)
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4
+
+# Validate the current working tree: builds the MSIX with the release recipe and signs it with a
+# throwaway self-signed certificate that only the Sandbox trusts
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4
+```
+
+The run takes ~10–12 minutes; almost all of it is the .NET runtime installer (silent, nothing on
+screen). Then the Windows App Runtime installer's console flashes briefly, the Welcome window
+appears, gets clicked through, and the script prints the result:
+
+```
+18:05:28   installed
+18:05:31   Refractored.TinyClips_1.7.4.0_x64__vmshqmcyy894t
+18:05:32 Launching C:\Program Files\WindowsApps\...\TinyClips.App.exe (cwd C:\Windows\Temp)
+18:05:52 Activating 'Welcome to Tiny Clips' and clicking through onboarding (3x Enter)
+18:06:34 RESULT: PASS - alive after 60s
+18:06:34 No crash.log
+```
+
+Exit code 0 = PASS. Anything else: read `sandbox-result.txt` — a `RESULT: FAIL` line carries the
+exit code (`0xC000027B` = XAML stowed exception), followed by `crash.log` and the event-log
+stack.
+
+Artifacts land in `%TEMP%\tinyclips-sandbox\` (override with `-WorkDir`). Runtime installers are
+cached there between runs.
+
+## Files
+
+| File | Where it runs | Purpose |
+|---|---|---|
+| `Invoke-SandboxValidation.ps1` | host | Downloads/builds + signs the MSIX, fetches the runtime installers, writes the `.wsb`, starts Sandbox, waits for and prints the result. |
+| `Validate-TinyClips.ps1` | inside Sandbox (LogonCommand) | Installs runtimes + MSIX, launches and drives the app, collects evidence. Reads `config.json` written by the host script. |
+
+## Gotchas we hit
+
+- **`Add-AppxPackage` can print success while the package never registers.** Seen when the MSIX's
+  `Microsoft.WindowsAppRuntime.1.8` `MinVersion` (set by the `Microsoft.WindowsAppSDK` NuGet version)
+  was newer than the installed runtime. `Validate-TinyClips.ps1` checks `Get-AppxPackage` afterwards
+  and fails loudly. The release workflow also asserts `MinVersion` ≤ what winget ships
+  (`WINGET_WINDOWSAPPRUNTIME_MAX_VERSION` in `windows-release.yml`).
+- **Framework-dependent packages *do* work in Sandbox** as long as the runtimes are installed from
+  their installers first (which this script does). Without them, install fails with `0x80073CF3`
+  because Sandbox has no Store to auto-acquire framework packages.
+- **Sandbox ≠ ARM64.** For ARM64 use the *Windows Launch Smoke* GitHub workflow
+  (`windows-11-arm` runner), or a real ARM64 machine with the gist-style test script.
+- Don't hand-edit `Validate-TinyClips.ps1` with regex replacements in a shell: a `$_` in a
+  replacement string expands to the whole script and you get a self-reinstalling loop.

--- a/windows/packaging/sandbox/Validate-TinyClips.ps1
+++ b/windows/packaging/sandbox/Validate-TinyClips.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+  Runs INSIDE Windows Sandbox (as the LogonCommand). Installs the .NET Desktop Runtime and the
+  Windows App Runtime, installs the Tiny Clips MSIX, launches it the way winget's validation
+  harness does (full exe path, unrelated working directory), clicks through first-run onboarding,
+  and writes a verdict + crash evidence to C:\share\sandbox-result.txt.
+
+  Driven by windows\packaging\sandbox\Invoke-SandboxValidation.ps1 on the host; do not run on a
+  real machine (it installs runtimes machine-wide and trusts a throwaway certificate).
+#>
+$ErrorActionPreference = 'Continue'
+$share = 'C:\share'
+$log = Join-Path $share 'sandbox-result.txt'
+$cfg = Get-Content (Join-Path $share 'config.json') -Raw | ConvertFrom-Json
+function Out($m) { $line = "$(Get-Date -Format 'HH:mm:ss') $m"; $line | Tee-Object -FilePath $log -Append }
+Remove-Item $log -ErrorAction SilentlyContinue
+
+Out "Tiny Clips sandbox validation: $($cfg.Msix)"
+Out "OS: $([Environment]::OSVersion.VersionString)  Arch: $env:PROCESSOR_ARCHITECTURE"
+
+Out 'Installing .NET Desktop Runtime (takes ~8 min in Sandbox)...'
+$p = Start-Process "$share\windowsdesktop-runtime.exe" -ArgumentList '/install', '/quiet', '/norestart' -Wait -PassThru
+Out "  exit $($p.ExitCode)"
+Out 'Installing Windows App Runtime 1.8...'
+$p = Start-Process "$share\WindowsAppRuntimeInstall.exe" -ArgumentList '--quiet' -Wait -PassThru
+Out "  exit $($p.ExitCode)"
+Out "  runtime: $((Get-AppxPackage 'Microsoft.WindowsAppRuntime.1.8*' | Select-Object -First 1).Version)"
+
+if (Test-Path "$share\smoke.cer") {
+    Import-Certificate -FilePath "$share\smoke.cer" -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null
+    Out 'Trusted throwaway signing certificate.'
+}
+
+Out 'Installing MSIX...'
+try { Add-AppxPackage -Path (Join-Path $share $cfg.Msix); Out '  installed' }
+catch { Out "  FAILED: $_"; Out 'DONE'; return }
+Start-Sleep 3
+$pkg = Get-AppxPackage -Name Refractored.TinyClips
+if (-not $pkg) {
+    # Add-AppxPackage can report success while the package did not register (seen when the
+    # package's WindowsAppRuntime MinVersion exceeded the installed runtime).
+    Out '  FAILED: package not found after install (dependency MinVersion mismatch?)'
+    Get-AppxPackage 'Microsoft.WindowsAppRuntime*' | ForEach-Object { Out "    installed runtime: $($_.PackageFullName)" }
+    Out 'DONE'; return
+}
+Out "  $($pkg.PackageFullName)"
+$exe = Join-Path $pkg.InstallLocation 'TinyClips.App.exe'
+
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+$u = Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h); [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);' -Name U -Namespace W -PassThru
+function Shot($name) {
+    $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+    $bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
+    $g = [System.Drawing.Graphics]::FromImage($bmp); $g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
+    $bmp.Save("$share\$name.png"); $g.Dispose(); $bmp.Dispose()
+}
+
+# Like the harness: full path, unrelated working directory.
+Out "Launching $exe (cwd C:\Windows\Temp)"
+$start = Get-Date
+$proc = Start-Process $exe -WorkingDirectory 'C:\Windows\Temp' -PassThru
+if (-not $proc) { Out '  FAILED to start'; Out 'DONE'; return }
+Start-Sleep 20
+$proc.Refresh(); Out "20s: exited=$($proc.HasExited)"
+Shot 'welcome'
+
+$p2 = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
+if ($p2 -and $p2.MainWindowHandle -ne 0) {
+    Out "Activating '$($p2.MainWindowTitle)' and clicking through onboarding (3x Enter)"
+    [void]$u::ShowWindow($p2.MainWindowHandle, 5); [void]$u::SetForegroundWindow($p2.MainWindowHandle); Start-Sleep 2
+    foreach ($i in 1..3) { [System.Windows.Forms.SendKeys]::SendWait('{ENTER}'); Start-Sleep 2 }
+} else { Out 'No main window (onboarding already completed?)' }
+Start-Sleep 3
+Shot 'after-onboarding'
+$proc.Refresh(); Out "after onboarding: exited=$($proc.HasExited)"
+
+$remaining = [Math]::Max(0, $cfg.WaitSeconds - [int]((Get-Date) - $start).TotalSeconds)
+Start-Sleep $remaining
+$proc.Refresh()
+if ($proc.HasExited) { Out "RESULT: FAIL - process exited with code $($proc.ExitCode) (0x$('{0:X8}' -f $proc.ExitCode))" }
+else { Out "RESULT: PASS - alive after $($cfg.WaitSeconds)s"; Stop-Process -Id $proc.Id -Force }
+
+$crash = "$env:LOCALAPPDATA\Packages\$($pkg.PackageFamilyName)\LocalCache\Local\TinyClips\Logs\crash.log"
+if (Test-Path $crash) { Out '--- crash.log ---'; Get-Content $crash | ForEach-Object { Out $_ } } else { Out 'No crash.log' }
+Get-WinEvent -FilterHashtable @{ LogName = 'Application'; ProviderName = 'Application Error', '.NET Runtime'; StartTime = $start } -ErrorAction SilentlyContinue |
+    ForEach-Object { Out "[$($_.ProviderName)] $($_.Message)" }
+Out 'DONE'

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"

--- a/windows/src/TinyClips.App/Package.appxmanifest
+++ b/windows/src/TinyClips.App/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -80,7 +80,13 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260804001" />
+    <!--
+      Pinned: the MSIX's WindowsAppRuntime MinVersion follows this SDK version, and winget's
+      Microsoft.WindowsAppRuntime.1.8 package (our declared dependency) currently tops out at the
+      runtime built from 1.8.260529003 (8000.879.2017.0). Newer 1.8 SDKs raise MinVersion above
+      what winget can install. Bump only after winget-pkgs ships the matching runtime version.
+    -->
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260529003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />


### PR DESCRIPTION
## Found by Sandbox validation of the 1.7.4 build
The NuGet bump to Microsoft.WindowsAppSDK **1.8.260804001** (#307) raised the MSIX's \Microsoft.WindowsAppRuntime.1.8\ MinVersion to **8000.946.1701.0**. winget's \Microsoft.WindowsAppRuntime.1.8\ package tops out at **1.8.9 = 8000.879.2017.0** (built from SDK 1.8.260529003), so every winget install would have failed dependency resolution. \Add-AppxPackage\ even reported success while the package silently did not register.

- Pin \Microsoft.WindowsAppSDK\ back to **1.8.260529003** (csproj comment explains why). Win2D 1.4.0 and all other updates from #307 stay.
- Release workflow asserts the MSIX MinVersion ≤ \WINGET_WINDOWSAPPRUNTIME_MAX_VERSION\ (8000.879.2017.0) so this cannot recur silently.

## Windows Sandbox validation tooling (\windows/packaging/sandbox/\)
One command reproduces winget's Installation Validation: fresh Sandbox → install .NET 10 Desktop Runtime + WinAppRuntime 1.8 (the winget-deliverable build) → install MSIX (built+self-signed from the tree, or downloaded from a release) → launch from \WindowsApps\ with a foreign cwd → click through onboarding → must stay alive; collects \crash.log\ / event-log stacks.

\\\pwsh
.\\windows\\packaging\\sandbox\\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4
\\\

Verified end-to-end on this branch: \RESULT: PASS - alive after 60s\, runtime 8000.879.2017.0, no crash.log. Packaging README updated (the old 'do not verify in Sandbox' note was wrong once the runtimes are installed first).