### PR TITLE
ci(windows): diagnose Partner Center auth failures in Store publish

### DIFF
--- a/.github/actions/diagnose-partner-center/action.yml
+++ b/.github/actions/diagnose-partner-center/action.yml
@@ -1,0 +1,105 @@
+name: Diagnose Partner Center credentials
+description: >-
+  Reproduces the two calls the Microsoft Store Developer CLI makes during
+  `msstore reconfigure` so an authentication failure points at a specific cause
+  instead of the CLI's generic "Really failed to auth" message.
+
+inputs:
+  tenant-id:
+    description: Microsoft Entra tenant ID for the Partner Center account.
+    required: true
+  seller-id:
+    description: Partner Center seller ID (numeric).
+    required: true
+  client-id:
+    description: Application (client) ID of the Entra application.
+    required: true
+  client-secret:
+    description: Client secret for the Entra application.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check Partner Center credentials
+      shell: pwsh
+      env:
+        PARTNER_CENTER_TENANT_ID: ${{ inputs.tenant-id }}
+        PARTNER_CENTER_SELLER_ID: ${{ inputs.seller-id }}
+        PARTNER_CENTER_CLIENT_ID: ${{ inputs.client-id }}
+        PARTNER_CENTER_CLIENT_SECRET: ${{ inputs.client-secret }}
+      run: |
+        # The secret and the access token are never written to the log.
+        $tenantId = "$env:PARTNER_CENTER_TENANT_ID".Trim()
+        $clientId = "$env:PARTNER_CENTER_CLIENT_ID".Trim()
+        $sellerId = "$env:PARTNER_CENTER_SELLER_ID".Trim()
+        $clientSecret = "$env:PARTNER_CENTER_CLIENT_SECRET".Trim()
+
+        Write-Host "--- Secret shape ---"
+        foreach ($entry in @(
+          @{ Name = "tenantId";     Value = "$env:PARTNER_CENTER_TENANT_ID" }
+          @{ Name = "clientId";     Value = "$env:PARTNER_CENTER_CLIENT_ID" }
+          @{ Name = "sellerId";     Value = "$env:PARTNER_CENTER_SELLER_ID" }
+          @{ Name = "clientSecret"; Value = "$env:PARTNER_CENTER_CLIENT_SECRET" }
+        )) {
+          $raw = $entry.Value
+          $padded = $raw -ne $raw.Trim()
+          Write-Host "$($entry.Name): length=$($raw.Length) hasSurroundingWhitespace=$padded"
+        }
+
+        $guidPattern = '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+        if ($tenantId -notmatch $guidPattern) {
+          Write-Host "::warning::The tenant ID is not a GUID."
+        }
+        if ($clientId -notmatch $guidPattern) {
+          Write-Host "::warning::The client ID is not a GUID."
+        }
+        if ($sellerId -notmatch '^\d+$') {
+          Write-Host "::warning::The seller ID is not numeric. Partner Center seller IDs are numbers, not GUIDs, and are shown under Account settings > Account details."
+        }
+
+        Write-Host "`n--- Step 1: request a Store submission API token from Microsoft Entra ID ---"
+        $accessToken = $null
+        try {
+          $tokenResponse = Invoke-RestMethod -Method Post `
+            -Uri "https://login.microsoftonline.com/$tenantId/oauth2/token" `
+            -ContentType "application/x-www-form-urlencoded" `
+            -Body @{
+              grant_type    = "client_credentials"
+              client_id     = $clientId
+              client_secret = $clientSecret
+              resource      = "https://manage.devcenter.microsoft.com"
+            }
+          $accessToken = $tokenResponse.access_token
+          Write-Host "Token acquired. The Entra application and client secret are valid."
+        }
+        catch {
+          $detail = if ($_.ErrorDetails.Message) { $_.ErrorDetails.Message } else { $_.Exception.Message }
+          $code = if ($detail -match '(AADSTS\d+)') { $Matches[1] } else { "unknown" }
+          Write-Host "::error::Entra token request failed ($code)."
+          switch -Regex ($code) {
+            'AADSTS7000215' { Write-Host "::error::Invalid client secret. It has most likely expired. Create a new secret and update the PARTNER_CENTER_CLIENT_SECRET environment secret." }
+            'AADSTS700016'  { Write-Host "::error::The client ID does not exist in this tenant. The client ID and tenant ID do not belong together." }
+            'AADSTS90002'   { Write-Host "::error::The tenant was not found. Check the tenant ID." }
+            'AADSTS7000222' { Write-Host "::error::The client secret has expired. Create a new one." }
+            default         { Write-Host "::error::See the raw response below." }
+          }
+          if ($clientSecret) { $detail = $detail -replace [regex]::Escape($clientSecret), "***" }
+          Write-Host $detail
+          throw "Partner Center diagnosis failed at the Entra token step."
+        }
+
+        Write-Host "`n--- Step 2: call the Store submission API with that token ---"
+        try {
+          Invoke-RestMethod -Method Get `
+            -Uri "https://manage.devcenter.microsoft.com/v1.0/my/applications?top=1" `
+            -Headers @{ Authorization = "Bearer $accessToken" } | Out-Null
+          Write-Host "The Store submission API responded. Credentials and the Partner Center association look correct."
+        }
+        catch {
+          $status = $_.Exception.Response.StatusCode.value__
+          Write-Host "::error::The Store submission API returned HTTP $status."
+          Write-Host "::error::The Entra credentials are valid, so the application itself is not the problem. The application is not associated with the Partner Center account. In Partner Center, open Account settings > User management > Microsoft Entra applications, add this application, and give it the Manager role. Registering the application only in the Entra portal is not enough."
+          if ($_.ErrorDetails.Message) { Write-Host $_.ErrorDetails.Message }
+          throw "Partner Center diagnosis failed at the submission API step."
+        }

--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -7,12 +7,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Windows release tag (for example, v1.6.1-windows)'
-        required: true
+        description: 'Windows release tag (for example, v1.6.1-windows). Not needed when running diagnostics only.'
+        required: false
         type: string
       publish:
         description: 'Publish the package after the protected-environment approval'
         required: true
+        default: false
+        type: boolean
+      diagnose_only:
+        description: 'Only check the Partner Center credentials. Skips packaging and publishing.'
+        required: false
         default: false
         type: boolean
 
@@ -27,8 +32,27 @@ env:
   APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
 
 jobs:
+  diagnose:
+    name: Diagnose Partner Center credentials
+    if: github.event_name == 'workflow_dispatch' && inputs.diagnose_only
+    runs-on: ubuntu-latest
+    environment: microsoft-store
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check Partner Center credentials
+        uses: ./.github/actions/diagnose-partner-center
+        with:
+          tenant-id: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          seller-id: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          client-id: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          client-secret: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+
   package:
     name: Package Microsoft Store upload
+    if: github.event_name == 'push' || !inputs.diagnose_only
     runs-on: windows-latest
 
     steps:
@@ -109,6 +133,9 @@ jobs:
     environment: microsoft-store
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Download Store package
         uses: actions/download-artifact@v8
         with:
@@ -140,80 +167,12 @@ jobs:
           }
 
       - name: Diagnose Partner Center credentials
-        shell: pwsh
-        env:
-          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
-          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
-          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
-          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
-        run: |
-          # msstore reconfigure only reports "Really failed to auth", so reproduce the two
-          # underlying calls here to identify whether the Entra credentials or the Partner
-          # Center association is the problem. Never print the secret or the access token.
-          $tenantId = $env:PARTNER_CENTER_TENANT_ID.Trim()
-          $clientId = $env:PARTNER_CENTER_CLIENT_ID.Trim()
-          $sellerId = $env:PARTNER_CENTER_SELLER_ID.Trim()
-          $clientSecret = $env:PARTNER_CENTER_CLIENT_SECRET.Trim()
-
-          function Show-Shape($name, $value) {
-            $trimmedDiffers = $value -ne ($value.Trim())
-            Write-Host "$name : length=$($value.Length) hasSurroundingWhitespace=$trimmedDiffers"
-          }
-          Show-Shape "tenantId" $env:PARTNER_CENTER_TENANT_ID
-          Show-Shape "clientId" $env:PARTNER_CENTER_CLIENT_ID
-          Show-Shape "sellerId" $env:PARTNER_CENTER_SELLER_ID
-          Show-Shape "clientSecret" $env:PARTNER_CENTER_CLIENT_SECRET
-
-          $guidPattern = '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
-          if ($tenantId -notmatch $guidPattern) { Write-Host "::warning::PARTNER_CENTER_TENANT_ID is not a GUID." }
-          if ($clientId -notmatch $guidPattern) { Write-Host "::warning::PARTNER_CENTER_CLIENT_ID is not a GUID." }
-          if ($sellerId -match $guidPattern) { Write-Host "::warning::PARTNER_CENTER_SELLER_ID looks like a GUID; Partner Center seller IDs are numeric." }
-
-          Write-Host "`n--- Step 1: request a devcenter token from Microsoft Entra ID ---"
-          $body = @{
-            grant_type    = "client_credentials"
-            client_id     = $clientId
-            client_secret = $clientSecret
-            resource      = "https://manage.devcenter.microsoft.com"
-          }
-
-          $accessToken = $null
-          try {
-            $tokenResponse = Invoke-RestMethod -Method Post `
-              -Uri "https://login.microsoftonline.com/$tenantId/oauth2/token" `
-              -Body $body -ContentType "application/x-www-form-urlencoded"
-            $accessToken = $tokenResponse.access_token
-            Write-Host "Token acquired. The Entra app registration and client secret are valid."
-          }
-          catch {
-            $detail = ""
-            if ($_.ErrorDetails.Message) { $detail = $_.ErrorDetails.Message }
-            $code = if ($detail -match '(AADSTS\d+)') { $Matches[1] } else { "unknown" }
-            Write-Host "::error::Entra token request failed ($code)."
-            switch -Regex ($code) {
-              'AADSTS7000215' { Write-Host "::error::Invalid client secret. It has most likely expired - create a new secret in Partner Center and update PARTNER_CENTER_CLIENT_SECRET." }
-              'AADSTS700016'  { Write-Host "::error::The client ID was not found in this tenant. PARTNER_CENTER_CLIENT_ID and PARTNER_CENTER_TENANT_ID do not belong together." }
-              'AADSTS90002'   { Write-Host "::error::The tenant was not found. Check PARTNER_CENTER_TENANT_ID." }
-              default         { Write-Host "::error::See the raw response below." }
-            }
-            Write-Host ($detail -replace [regex]::Escape($clientSecret), "***")
-            throw "Partner Center credential diagnosis failed at the Entra token step."
-          }
-
-          Write-Host "`n--- Step 2: call the Store submission API with that token ---"
-          try {
-            Invoke-RestMethod -Method Get `
-              -Uri "https://manage.devcenter.microsoft.com/v1.0/my/applications?top=1" `
-              -Headers @{ Authorization = "Bearer $accessToken" } | Out-Null
-            Write-Host "Store submission API responded. Credentials and Partner Center association look correct."
-          }
-          catch {
-            $status = $_.Exception.Response.StatusCode.value__
-            Write-Host "::error::Store submission API returned HTTP $status."
-            Write-Host "::error::The Entra credentials are valid, but the app is not usable against Partner Center. Confirm the Entra application was added under Partner Center > Account settings > User management > Microsoft Entra applications with the Manager role, and that the account has completed at least one manual submission."
-            if ($_.ErrorDetails.Message) { Write-Host $_.ErrorDetails.Message }
-            throw "Partner Center credential diagnosis failed at the submission API step."
-          }
+        uses: ./.github/actions/diagnose-partner-center
+        with:
+          tenant-id: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          seller-id: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          client-id: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          client-secret: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
 
       - name: Setup Microsoft Store Developer CLI
         uses: microsoft/microsoft-store-apppublisher@v1.4

--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -139,6 +139,82 @@ jobs:
             throw "Configure the following before enabling Store publication: $($missing -join ', ')."
           }
 
+      - name: Diagnose Partner Center credentials
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+        run: |
+          # msstore reconfigure only reports "Really failed to auth", so reproduce the two
+          # underlying calls here to identify whether the Entra credentials or the Partner
+          # Center association is the problem. Never print the secret or the access token.
+          $tenantId = $env:PARTNER_CENTER_TENANT_ID.Trim()
+          $clientId = $env:PARTNER_CENTER_CLIENT_ID.Trim()
+          $sellerId = $env:PARTNER_CENTER_SELLER_ID.Trim()
+          $clientSecret = $env:PARTNER_CENTER_CLIENT_SECRET.Trim()
+
+          function Show-Shape($name, $value) {
+            $trimmedDiffers = $value -ne ($value.Trim())
+            Write-Host "$name : length=$($value.Length) hasSurroundingWhitespace=$trimmedDiffers"
+          }
+          Show-Shape "tenantId" $env:PARTNER_CENTER_TENANT_ID
+          Show-Shape "clientId" $env:PARTNER_CENTER_CLIENT_ID
+          Show-Shape "sellerId" $env:PARTNER_CENTER_SELLER_ID
+          Show-Shape "clientSecret" $env:PARTNER_CENTER_CLIENT_SECRET
+
+          $guidPattern = '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+          if ($tenantId -notmatch $guidPattern) { Write-Host "::warning::PARTNER_CENTER_TENANT_ID is not a GUID." }
+          if ($clientId -notmatch $guidPattern) { Write-Host "::warning::PARTNER_CENTER_CLIENT_ID is not a GUID." }
+          if ($sellerId -match $guidPattern) { Write-Host "::warning::PARTNER_CENTER_SELLER_ID looks like a GUID; Partner Center seller IDs are numeric." }
+
+          Write-Host "`n--- Step 1: request a devcenter token from Microsoft Entra ID ---"
+          $body = @{
+            grant_type    = "client_credentials"
+            client_id     = $clientId
+            client_secret = $clientSecret
+            resource      = "https://manage.devcenter.microsoft.com"
+          }
+
+          $accessToken = $null
+          try {
+            $tokenResponse = Invoke-RestMethod -Method Post `
+              -Uri "https://login.microsoftonline.com/$tenantId/oauth2/token" `
+              -Body $body -ContentType "application/x-www-form-urlencoded"
+            $accessToken = $tokenResponse.access_token
+            Write-Host "Token acquired. The Entra app registration and client secret are valid."
+          }
+          catch {
+            $detail = ""
+            if ($_.ErrorDetails.Message) { $detail = $_.ErrorDetails.Message }
+            $code = if ($detail -match '(AADSTS\d+)') { $Matches[1] } else { "unknown" }
+            Write-Host "::error::Entra token request failed ($code)."
+            switch -Regex ($code) {
+              'AADSTS7000215' { Write-Host "::error::Invalid client secret. It has most likely expired - create a new secret in Partner Center and update PARTNER_CENTER_CLIENT_SECRET." }
+              'AADSTS700016'  { Write-Host "::error::The client ID was not found in this tenant. PARTNER_CENTER_CLIENT_ID and PARTNER_CENTER_TENANT_ID do not belong together." }
+              'AADSTS90002'   { Write-Host "::error::The tenant was not found. Check PARTNER_CENTER_TENANT_ID." }
+              default         { Write-Host "::error::See the raw response below." }
+            }
+            Write-Host ($detail -replace [regex]::Escape($clientSecret), "***")
+            throw "Partner Center credential diagnosis failed at the Entra token step."
+          }
+
+          Write-Host "`n--- Step 2: call the Store submission API with that token ---"
+          try {
+            Invoke-RestMethod -Method Get `
+              -Uri "https://manage.devcenter.microsoft.com/v1.0/my/applications?top=1" `
+              -Headers @{ Authorization = "Bearer $accessToken" } | Out-Null
+            Write-Host "Store submission API responded. Credentials and Partner Center association look correct."
+          }
+          catch {
+            $status = $_.Exception.Response.StatusCode.value__
+            Write-Host "::error::Store submission API returned HTTP $status."
+            Write-Host "::error::The Entra credentials are valid, but the app is not usable against Partner Center. Confirm the Entra application was added under Partner Center > Account settings > User management > Microsoft Entra applications with the Manager role, and that the account has completed at least one manual submission."
+            if ($_.ErrorDetails.Message) { Write-Host $_.ErrorDetails.Message }
+            throw "Partner Center credential diagnosis failed at the submission API step."
+          }
+
       - name: Setup Microsoft Store Developer CLI
         uses: microsoft/microsoft-store-apppublisher@v1.4
 


### PR DESCRIPTION
`msstore reconfigure` fails with only `Really failed to auth`, which gives us nothing to act on (see run 32919945969).

This adds a **Diagnose Partner Center credentials** step before `msstore reconfigure` that reproduces the two calls the CLI makes internally:

1. **Microsoft Entra ID token request** (`client_credentials` against resource `https://manage.devcenter.microsoft.com`). Failure here means the credentials themselves are wrong, and the step decodes the `AADSTS` code into a specific cause — expired client secret, mismatched client/tenant, or bad tenant.
2. **Store submission API call** using that token. If step 1 succeeds but this returns 401/403, the credentials are fine but the Entra application is not associated with Partner Center under *Account settings > User management > Microsoft Entra applications*.

It also reports the length and surrounding-whitespace state of each secret, and warns if the tenant/client IDs are not GUIDs or the seller ID looks like a GUID instead of a number.

The client secret and the access token are never printed; the secret is additionally scrubbed from any echoed error body.

No app or packaging code changes.