### PR TITLE
ci(windows): publish the msixupload by file path

### DIFF
--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -196,6 +196,7 @@ jobs:
             throw "The downloaded Store package is missing."
           }
 
-          # msstore publish takes the directory holding the package, not the file itself.
-          msstore publish "." --inputDirectory $upload.Directory.FullName --appId $env:STORE_PRODUCT_ID
+          # Pass the package file itself. Pointing msstore at a directory makes it look for a
+          # project to infer a publisher from, which does not exist in this workflow.
+          msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID
           if ($LASTEXITCODE -ne 0) { throw "msstore publish failed." }


### PR DESCRIPTION
Run 33003749591 got past the flag error from #318 and failed on the next one:

```
We could not find a project publisher for the project at '.'.
```

`msstore publish` treats its positional argument as a project root and tries to infer a publisher from the project type. This job downloads a prebuilt `.msixupload` artifact and has no project to inspect.

The documented approach for a prebuilt package is to pass the package path as the positional argument and drop `--inputDirectory`:

```
msstore publish <path-to-.msixupload> --appId <appId>
```

Refs microsoft/msstore-cli#89.