### PR TITLE
ci(windows): set an explicit msstore upload timeout

### DIFF
--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -198,5 +198,7 @@ jobs:
 
           # Pass the package file itself. Pointing msstore at a directory makes it look for a
           # project to infer a publisher from, which does not exist in this workflow.
-          msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID
+          # --uploadTimeout must be set explicitly: when omitted the CLI has defaulted it to 0,
+          # which cancels the blob upload immediately. See microsoft/msstore-cli#162.
+          msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID --uploadTimeout 900
           if ($LASTEXITCODE -ne 0) { throw "msstore publish failed." }


### PR DESCRIPTION
Run 33004586338 got all the way to the upload. It found the app, created and configured the submission, prepared the bundle, then died at 0 percent:

```
Uploading Bundle to Azure blob: 0%
Error while uploading the application package.
```

This matches microsoft/msstore-cli#162: when `--uploadTimeout` is omitted the CLI defaults it to 0 seconds, so the upload is cancelled the moment it begins. The failure after roughly 24 seconds at 0 percent on a 42 MB bundle fits.

Sets `--uploadTimeout 900`.