### PR TITLE
Windows: add native MSIX auto-updates for direct installs

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -18,6 +18,7 @@ permissions:
 concurrency:
   group: windows-release
   cancel-in-progress: false
+  queue: max
 
 env:
   APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
@@ -512,8 +513,15 @@ jobs:
             }
             foreach ($currentInstaller in Get-ChildItem $currentDir -Filter *.appinstaller) {
               [xml]$current = Get-Content $currentInstaller.FullName -Raw
-              if ([version]$current.AppInstaller.Version -gt [version]$env:PACKAGE_VERSION) {
+              $currentVersion = [version]$current.AppInstaller.Version
+              $candidateVersion = [version]$env:PACKAGE_VERSION
+              if ($currentVersion -gt $candidateVersion) {
                 throw "Refusing to downgrade windows-latest from $($current.AppInstaller.Version) to $env:PACKAGE_VERSION."
+              }
+              $candidateInstaller = Join-Path $rollingDir $currentInstaller.Name
+              if ($currentVersion -eq $candidateVersion -and
+                  (Get-FileHash $currentInstaller.FullName).Hash -ne (Get-FileHash $candidateInstaller).Hash) {
+                throw "Refusing to replace windows-latest version $env:PACKAGE_VERSION with different App Installer metadata."
               }
             }
           }

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -15,6 +15,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: windows-release
+  cancel-in-progress: false
+
 env:
   APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
   PACKAGE_FAMILY_NAME: Refractored.TinyClips_vmshqmcyy894t
@@ -92,6 +96,18 @@ jobs:
             $packageDir = "artifacts/windows/package/$($p.Asset)"
             New-Item -ItemType Directory -Force -Path $packageDir | Out-Null
             $packageDirFull = (Resolve-Path $packageDir).Path + [IO.Path]::DirectorySeparatorChar
+            $stableReleaseBase = "https://github.com/jamesmontemagno/tiny-clips/releases/download/windows-latest"
+            $packageUri = "https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix"
+            $appInstallerUri = "$stableReleaseBase/TinyClips-$($p.Asset).appinstaller"
+
+            & ./windows/packaging/New-AppInstaller.ps1 `
+              -ManifestPath windows/src/TinyClips.App/Package.appxmanifest `
+              -ManifestOutputPath windows/src/TinyClips.App/Package.AutoUpdate.appxmanifest `
+              -AppInstallerPath windows/src/TinyClips.App/install.appinstaller `
+              -Architecture $p.Asset `
+              -PackageUri $packageUri `
+              -AppInstallerUri $appInstallerUri
+            Copy-Item windows/src/TinyClips.App/install.appinstaller "artifacts/windows/TinyClips-$($p.Asset).appinstaller" -Force
 
             dotnet build $env:APP_PROJECT `
               -c Release `
@@ -105,6 +121,7 @@ jobs:
               -p:AppxBundle=Never `
               -p:UapAppxPackageBuildMode=SideloadOnly `
               -p:AppxPackageSigningEnabled=false `
+              -p:TinyClipsAutoUpdateBuild=true `
               -v:minimal
             if ($LASTEXITCODE -ne 0) { throw "MSIX build failed for $($p.Platform)." }
 
@@ -144,6 +161,49 @@ jobs:
 
             if (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue) {
               throw "MSIX for $($p.Platform) bundles the .NET runtime (coreclr.dll) - expected a framework-dependent (SelfContained=false) build."
+            }
+
+            [xml]$packagedManifest = $appxManifest
+            $manifestNamespaces = [Xml.XmlNamespaceManager]::new($packagedManifest.NameTable)
+            $manifestNamespaces.AddNamespace("foundation", "http://schemas.microsoft.com/appx/manifest/foundation/windows10")
+            $manifestNamespaces.AddNamespace("uap13", "http://schemas.microsoft.com/appx/manifest/uap/windows10/13")
+            $appInstallerDeclaration = $packagedManifest.SelectSingleNode(
+              "/foundation:Package/foundation:Properties/uap13:AutoUpdate/uap13:AppInstaller",
+              $manifestNamespaces
+            )
+            if (-not $appInstallerDeclaration -or $appInstallerDeclaration.File -ne "install.appinstaller") {
+              throw "Direct MSIX for $($p.Platform) is missing the uap13 AutoUpdate declaration."
+            }
+
+            $embeddedAppInstallerPath = Join-Path $verifyDir "install.appinstaller"
+            if (-not (Test-Path $embeddedAppInstallerPath)) {
+              throw "Direct MSIX for $($p.Platform) does not contain install.appinstaller."
+            }
+
+            [xml]$embeddedAppInstaller = Get-Content $embeddedAppInstallerPath -Raw
+            $appInstallerNamespaces = [Xml.XmlNamespaceManager]::new($embeddedAppInstaller.NameTable)
+            $appInstallerNamespaces.AddNamespace("ai", "http://schemas.microsoft.com/appx/appinstaller/2018")
+            $appInstallerRoot = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller", $appInstallerNamespaces)
+            $mainPackage = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller/ai:MainPackage", $appInstallerNamespaces)
+            $onLaunch = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller/ai:UpdateSettings/ai:OnLaunch", $appInstallerNamespaces)
+
+            if ($appInstallerRoot.Version -ne $env:PACKAGE_VERSION -or $mainPackage.Version -ne $env:PACKAGE_VERSION) {
+              throw "App Installer version for $($p.Platform) does not match $env:PACKAGE_VERSION."
+            }
+            if ($mainPackage.Name -ne "Refractored.TinyClips" -or
+                $mainPackage.Publisher -ne "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US" -or
+                $mainPackage.ProcessorArchitecture -ne $p.Asset -or
+                $mainPackage.Uri -ne $packageUri -or
+                $appInstallerRoot.Uri -ne $appInstallerUri) {
+              throw "App Installer identity or stable URL is invalid for $($p.Platform)."
+            }
+            if (-not $onLaunch -or $onLaunch.HoursBetweenUpdateChecks -ne "24") {
+              throw "App Installer for $($p.Platform) must check on launch about every 24 hours."
+            }
+
+            $standaloneAppInstallerPath = "artifacts/windows/TinyClips-$($p.Asset).appinstaller"
+            if ((Get-FileHash $embeddedAppInstallerPath).Hash -ne (Get-FileHash $standaloneAppInstallerPath).Hash) {
+              throw "Embedded and standalone App Installer files differ for $($p.Platform)."
             }
             Remove-Item $zipCopy -Force -ErrorAction SilentlyContinue
             Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -352,7 +412,10 @@ jobs:
 
           $notes += ""
           $notes += "## Install"
-          $notes += "Tiny Clips is published in the [winget community repository](https://github.com/microsoft/winget-pkgs). Install it from any Windows 11 terminal:"
+          $notes += 'For direct installation with automatic updates, download the `.appinstaller` for your architecture below. Windows checks for a signed update when Tiny Clips launches if about 24 hours have passed.'
+          $notes += 'Direct installation requires the [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/10.0); winget installs that prerequisite automatically.'
+          $notes += ""
+          $notes += "Tiny Clips is also published in the [winget community repository](https://github.com/microsoft/winget-pkgs). Install it from any Windows 11 terminal:"
           $notes += ""
           $notes += '```text'
           $notes += 'winget install Refractored.TinyClips'
@@ -379,6 +442,7 @@ jobs:
           name: windows-release
           path: |
             artifacts/windows/*.msix
+            artifacts/windows/*.appinstaller
             artifacts/windows/*.txt
             artifacts/windows/winget/*.yaml
             artifacts/windows/wack/*.xml
@@ -391,9 +455,118 @@ jobs:
           body_path: artifacts/windows/release-notes.md
           files: |
             artifacts/windows/*.msix
+            artifacts/windows/*.appinstaller
             artifacts/windows/winget-hashes.txt
             artifacts/windows/wack/*.xml
+          overwrite_files: false
+          preserve_order: true
+          fail_on_unmatched_files: true
           draft: false
           prerelease: ${{ contains(github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name, 'beta') || contains(github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name, 'alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote stable direct-install assets
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $rollingDir = "artifacts/windows/rolling"
+          New-Item -ItemType Directory -Force -Path $rollingDir | Out-Null
+          Copy-Item "artifacts/windows/TinyClips-x64.appinstaller" $rollingDir -Force
+          Copy-Item "artifacts/windows/TinyClips-arm64.appinstaller" $rollingDir -Force
+
+          $rollingReleaseCreated = $false
+          gh release view windows-latest --repo "${{ github.repository }}" *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create windows-latest `
+              --repo "${{ github.repository }}" `
+              --target "${{ github.sha }}" `
+              --title "Tiny Clips for Windows (auto-update channel)" `
+              --notes "Stable App Installer metadata for direct MSIX installs. Each file references the signed, immutable MSIX in its versioned Windows release." `
+              --latest=false
+            if ($LASTEXITCODE -ne 0) { throw "Could not create the windows-latest rolling release." }
+            $rollingReleaseCreated = $true
+          }
+
+          $currentDir = "artifacts/windows/current-appinstaller"
+          New-Item -ItemType Directory -Force -Path $currentDir | Out-Null
+          if (-not $rollingReleaseCreated) {
+            $downloadedCurrent = $false
+            for ($attempt = 1; $attempt -le 3 -and -not $downloadedCurrent; $attempt++) {
+              gh release download windows-latest `
+                --repo "${{ github.repository }}" `
+                --pattern "*.appinstaller" `
+                --dir $currentDir `
+                --clobber
+              $downloadedCurrent = $LASTEXITCODE -eq 0
+              if (-not $downloadedCurrent -and $attempt -lt 3) { Start-Sleep -Seconds (5 * $attempt) }
+            }
+            if (-not $downloadedCurrent) {
+              throw "Could not read the existing windows-latest channel; refusing to promote without a downgrade check."
+            }
+            foreach ($architecture in @("x64", "arm64")) {
+              if (-not (Test-Path "$currentDir/TinyClips-$architecture.appinstaller")) {
+                throw "The existing windows-latest channel is missing its $architecture App Installer; repair it before promoting."
+              }
+            }
+            foreach ($currentInstaller in Get-ChildItem $currentDir -Filter *.appinstaller) {
+              [xml]$current = Get-Content $currentInstaller.FullName -Raw
+              if ([version]$current.AppInstaller.Version -gt [version]$env:PACKAGE_VERSION) {
+                throw "Refusing to downgrade windows-latest from $($current.AppInstaller.Version) to $env:PACKAGE_VERSION."
+              }
+            }
+          }
+          $global:LASTEXITCODE = 0
+
+          function Publish-AppInstallers([string] $sourceDirectory) {
+            for ($attempt = 1; $attempt -le 3; $attempt++) {
+              gh release upload windows-latest `
+                "$sourceDirectory/TinyClips-x64.appinstaller" `
+                "$sourceDirectory/TinyClips-arm64.appinstaller" `
+                --repo "${{ github.repository }}" `
+                --clobber 2>&1 | ForEach-Object { Write-Host $_ }
+              if ($LASTEXITCODE -eq 0) { return $true }
+              if ($attempt -lt 3) { Start-Sleep -Seconds (5 * $attempt) }
+            }
+            return $false
+          }
+
+          function Restore-PreviousChannel {
+            if ($rollingReleaseCreated) {
+              gh release delete windows-latest --repo "${{ github.repository }}" --cleanup-tag --yes
+              return
+            }
+            if (-not (Publish-AppInstallers $currentDir)) {
+              throw "Promotion failed and the previous windows-latest channel could not be restored."
+            }
+          }
+
+          if (-not (Publish-AppInstallers $rollingDir)) {
+            Restore-PreviousChannel
+            throw "Could not publish rolling App Installer assets after three attempts."
+          }
+
+          try {
+            $verifyDir = "artifacts/windows/verify-appinstaller"
+            New-Item -ItemType Directory -Force -Path $verifyDir | Out-Null
+            gh release download windows-latest `
+              --repo "${{ github.repository }}" `
+              --pattern "*.appinstaller" `
+              --dir $verifyDir `
+              --clobber
+            if ($LASTEXITCODE -ne 0) { throw "Could not download rolling App Installer assets for verification." }
+
+            foreach ($architecture in @("x64", "arm64")) {
+              $local = "$rollingDir/TinyClips-$architecture.appinstaller"
+              $publishedFile = "$verifyDir/TinyClips-$architecture.appinstaller"
+              if (-not (Test-Path $publishedFile) -or
+                  (Get-FileHash $local).Hash -ne (Get-FileHash $publishedFile).Hash) {
+                throw "Published $architecture App Installer does not match the release artifact."
+              }
+            }
+          }
+          catch {
+            Restore-PreviousChannel
+            throw
+          }

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -187,6 +187,7 @@ jobs:
             $appInstallerRoot = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller", $appInstallerNamespaces)
             $mainPackage = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller/ai:MainPackage", $appInstallerNamespaces)
             $onLaunch = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller/ai:UpdateSettings/ai:OnLaunch", $appInstallerNamespaces)
+            $backgroundTask = $embeddedAppInstaller.SelectSingleNode("/ai:AppInstaller/ai:UpdateSettings/ai:AutomaticBackgroundTask", $appInstallerNamespaces)
 
             if ($appInstallerRoot.Version -ne $env:PACKAGE_VERSION -or $mainPackage.Version -ne $env:PACKAGE_VERSION) {
               throw "App Installer version for $($p.Platform) does not match $env:PACKAGE_VERSION."
@@ -200,6 +201,9 @@ jobs:
             }
             if (-not $onLaunch -or $onLaunch.HoursBetweenUpdateChecks -ne "24") {
               throw "App Installer for $($p.Platform) must check on launch about every 24 hours."
+            }
+            if (-not $backgroundTask) {
+              throw "App Installer for $($p.Platform) must check for updates in the background."
             }
 
             $standaloneAppInstallerPath = "artifacts/windows/TinyClips-$($p.Asset).appinstaller"
@@ -413,7 +417,7 @@ jobs:
 
           $notes += ""
           $notes += "## Install"
-          $notes += 'For direct installation with automatic updates, download the `.appinstaller` for your architecture below. Windows checks for a signed update when Tiny Clips launches if about 24 hours have passed.'
+          $notes += 'For direct installation with automatic updates, download the `.appinstaller` for your architecture below. It always resolves through the stable update channel, so opening one from an older release installs the current Windows version. Windows checks periodically in the background and on launch when about 24 hours have passed.'
           $notes += 'Direct installation requires the [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/10.0); winget installs that prerequisite automatically.'
           $notes += ""
           $notes += "Tiny Clips is also published in the [winget community repository](https://github.com/microsoft/winget-pkgs). Install it from any Windows 11 terminal:"
@@ -422,7 +426,7 @@ jobs:
           $notes += 'winget install Refractored.TinyClips'
           $notes += '```'
           $notes += ""
-          $notes += 'Update later with `winget upgrade Refractored.TinyClips`.'
+          $notes += 'winget installs the same auto-updating direct MSIX. `winget upgrade` and App Installer can both update its package family.'
 
           $notes += ""
           $notes += "## Release validation"
@@ -484,7 +488,7 @@ jobs:
               --repo "${{ github.repository }}" `
               --target "${{ github.sha }}" `
               --title "Tiny Clips for Windows (auto-update channel)" `
-              --notes "Stable App Installer metadata for direct MSIX installs. Each file references the signed, immutable MSIX in its versioned Windows release." `
+              --notes "Stable App Installer metadata for direct MSIX installs. Each file references the signed, immutable MSIX in its versioned Windows release. The source archives identify only the commit that created this channel; use the App Installer assets for current channel state." `
               --latest=false
             if ($LASTEXITCODE -ne 0) { throw "Could not create the windows-latest rolling release." }
             $rollingReleaseCreated = $true

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ Packages/
 # Windows local SDK/release artifacts
 .winapp/
 artifacts/
+windows/src/TinyClips.App/Package.AutoUpdate.appxmanifest
+windows/src/TinyClips.App/install.appinstaller
 
 # Python (tooling/scripts)
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ video (MP4), and animated GIFs of a selected screen region — on **macOS** and 
 - **Global Hotkeys** — Quick capture from anywhere
 - **Configurable** — Save location, clipboard, reveal-in-Finder/Explorer, GIF quality, trimmer toggles, and more
 
-> macOS uses Sparkle for auto-updates; Windows distributes via **winget** (`winget upgrade`) and the Microsoft Store.
+> macOS uses Sparkle for auto-updates; direct Windows installs use MSIX App Installer updates, with **winget** and Microsoft Store options also available.
 
 ## macOS
 

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -6,6 +6,11 @@ own `CHANGELOG.md` at the repository root.
 ## [Unreleased]
 
 ### Changed
+- **Native MSIX auto-updates for direct installs.** Windows GitHub Releases now publish x64 and
+  ARM64 `.appinstaller` files and embed the matching configuration in direct MSIX packages. A
+  dedicated `windows-latest` GitHub Release provides stable update metadata URLs, and Windows checks
+  on launch when about 24 hours have passed. Microsoft Store packages remain on Store-managed
+  updates and do not include the direct update channel.
 - **Clips Library rewritten** as a proper MVVM feature (`ViewModels/ClipsLibrary`,
   `Views/ClipsLibrary`, `Controls/ClipsLibrary`) with macOS Clips Manager parity. New: collapsible
   sidebar with Smart Collections / Collections / Tags and live counts; search across names, tags and

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -49,9 +49,10 @@ own `CHANGELOG.md` at the repository root.
 ### Changed
 - **Native MSIX auto-updates for direct installs.** Windows GitHub Releases now publish x64 and
   ARM64 `.appinstaller` files and embed the matching configuration in direct MSIX packages. A
-  dedicated `windows-latest` GitHub Release provides stable update metadata URLs, and Windows checks
-  on launch when about 24 hours have passed. Microsoft Store packages remain on Store-managed
-  updates and do not include the direct update channel.
+  dedicated `windows-latest` GitHub Release provides stable update metadata URLs. Windows checks
+  periodically in the background and on launch when about 24 hours have passed; winget installs use
+  the same auto-updating direct MSIX. Microsoft Store packages remain on Store-managed updates and
+  do not include the direct update channel.
 - The shared Direct3D 11 device is created with `VIDEO_SUPPORT` (falls back without it) so Media
   Foundation's hardware encoders can bind recorder textures directly.
 - Webcam overlay placement math moved to the shared `WebcamOverlayLayout`; click-ring geometry and

--- a/windows/README.md
+++ b/windows/README.md
@@ -131,10 +131,14 @@ automation review does not replace the documented hands-on results.
 
 ## Distribution
 
-- **Direct (available now):** signed MSIX distributed via **winget** — install with
-  `winget install Refractored.TinyClips` and update with `winget upgrade Refractored.TinyClips`
-  (no separate in-app updater). Fully free.
-- **Microsoft Store (planned):** Store auto-update. Feature set matches Direct; no Windows Pro tier.
+- **Direct (available now):** install the architecture-specific `.appinstaller` from a Windows
+  GitHub Release to receive signed MSIX updates through Windows App Installer (checked on launch
+  about every 24 hours). Direct installation requires the
+  [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/10.0), or use
+  `winget install Refractored.TinyClips` and `winget upgrade Refractored.TinyClips` to have winget
+  manage the runtime dependencies. Fully free.
+- **Microsoft Store:** Store-managed updates only. Store packages do not include the direct
+  `.appinstaller` update channel. Feature set matches Direct; no Windows Pro tier.
 
 See the plan for the full phased roadmap, packaging, and signing details.
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -137,12 +137,13 @@ automation review does not replace the documented hands-on results.
 
 ## Distribution
 
-- **Direct (available now):** install the architecture-specific `.appinstaller` from a Windows
-  GitHub Release to receive signed MSIX updates through Windows App Installer (checked on launch
-  about every 24 hours). Direct installation requires the
-  [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/10.0), or use
-  `winget install Refractored.TinyClips` and `winget upgrade Refractored.TinyClips` to have winget
-  manage the runtime dependencies. Fully free.
+- **Direct (available now):** install with `winget install Refractored.TinyClips`, or use the
+  architecture-specific `.appinstaller` from a Windows GitHub Release as a stable bootstrap for the
+  current version. Both routes install the same MSIX, which checks for signed updates in the
+  background and on launch. winget also installs the required .NET 10 Desktop and Windows App SDK
+  runtimes; standalone App Installer use requires the
+  [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) on a clean machine.
+  `winget upgrade` and App Installer can both update the same package family. Fully free.
 - **Microsoft Store:** Store-managed updates only. Store packages do not include the direct
   `.appinstaller` update channel. Feature set matches Direct; no Windows Pro tier.
 

--- a/windows/packaging/New-AppInstaller.ps1
+++ b/windows/packaging/New-AppInstaller.ps1
@@ -1,0 +1,125 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $ManifestPath,
+
+    [Parameter(Mandatory)]
+    [string] $ManifestOutputPath,
+
+    [Parameter(Mandatory)]
+    [string] $AppInstallerPath,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('x64', 'arm64')]
+    [string] $Architecture,
+
+    [Parameter(Mandatory)]
+    [string] $PackageUri,
+
+    [Parameter(Mandatory)]
+    [string] $AppInstallerUri
+)
+
+$ErrorActionPreference = 'Stop'
+
+foreach ($uriValue in @($PackageUri, $AppInstallerUri)) {
+    $uri = $null
+    if (-not [Uri]::TryCreate($uriValue, [UriKind]::Absolute, [ref] $uri) -or $uri.Scheme -ne 'https') {
+        throw "App Installer URLs must be absolute HTTPS URLs. Got '$uriValue'."
+    }
+}
+
+$manifestDocument = [Xml.XmlDocument]::new()
+$manifestDocument.PreserveWhitespace = $true
+$manifestDocument.Load((Resolve-Path $ManifestPath))
+
+$package = $manifestDocument.DocumentElement
+$identity = $package.SelectSingleNode("*[local-name()='Identity']")
+$properties = $package.SelectSingleNode("*[local-name()='Properties']")
+if (-not $identity -or -not $properties) {
+    throw "The package manifest must contain Identity and Properties elements."
+}
+
+$uap13Namespace = 'http://schemas.microsoft.com/appx/manifest/uap/windows10/13'
+$xmlNamespace = 'http://www.w3.org/2000/xmlns/'
+if (-not $package.GetAttribute('uap13', $xmlNamespace)) {
+    $namespaceAttribute = $manifestDocument.CreateAttribute('xmlns', 'uap13', $xmlNamespace)
+    $namespaceAttribute.Value = $uap13Namespace
+    [void] $package.Attributes.Append($namespaceAttribute)
+}
+
+$ignorableNamespaces = @($package.GetAttribute('IgnorableNamespaces') -split '\s+' | Where-Object { $_ })
+if ($ignorableNamespaces -notcontains 'uap13') {
+    $package.SetAttribute('IgnorableNamespaces', (($ignorableNamespaces + 'uap13') -join ' '))
+}
+
+$namespaceManager = [Xml.XmlNamespaceManager]::new($manifestDocument.NameTable)
+$namespaceManager.AddNamespace('uap13', $uap13Namespace)
+$existingAutoUpdate = $properties.SelectSingleNode('uap13:AutoUpdate', $namespaceManager)
+if ($existingAutoUpdate) {
+    [void] $properties.RemoveChild($existingAutoUpdate)
+}
+
+$autoUpdate = $manifestDocument.CreateElement('uap13', 'AutoUpdate', $uap13Namespace)
+$appInstallerDeclaration = $manifestDocument.CreateElement('uap13', 'AppInstaller', $uap13Namespace)
+$appInstallerDeclaration.SetAttribute('File', 'install.appinstaller')
+[void] $autoUpdate.AppendChild($appInstallerDeclaration)
+[void] $properties.AppendChild($autoUpdate)
+
+function Save-XmlDocument {
+    param(
+        [Parameter(Mandatory)]
+        [Xml.XmlDocument] $Document,
+
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if ($directory) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $settings = [Xml.XmlWriterSettings]::new()
+    $settings.Encoding = [Text.UTF8Encoding]::new($false)
+    $settings.Indent = $true
+    $settings.NewLineChars = "`r`n"
+    $settings.NewLineHandling = [Xml.NewLineHandling]::Replace
+
+    $writer = [Xml.XmlWriter]::Create($Path, $settings)
+    try {
+        $Document.Save($writer)
+    }
+    finally {
+        $writer.Dispose()
+    }
+}
+
+Save-XmlDocument -Document $manifestDocument -Path $ManifestOutputPath
+
+$appInstallerNamespace = 'http://schemas.microsoft.com/appx/appinstaller/2018'
+$appInstallerDocument = [Xml.XmlDocument]::new()
+[void] $appInstallerDocument.AppendChild($appInstallerDocument.CreateXmlDeclaration('1.0', 'utf-8', $null))
+
+$appInstaller = $appInstallerDocument.CreateElement('AppInstaller', $appInstallerNamespace)
+$appInstaller.SetAttribute('Uri', $AppInstallerUri)
+$appInstaller.SetAttribute('Version', $identity.Version)
+[void] $appInstallerDocument.AppendChild($appInstaller)
+
+$mainPackage = $appInstallerDocument.CreateElement('MainPackage', $appInstallerNamespace)
+$mainPackage.SetAttribute('Name', $identity.Name)
+$mainPackage.SetAttribute('Publisher', $identity.Publisher)
+$mainPackage.SetAttribute('Version', $identity.Version)
+$mainPackage.SetAttribute('ProcessorArchitecture', $Architecture)
+$mainPackage.SetAttribute('Uri', $PackageUri)
+[void] $appInstaller.AppendChild($mainPackage)
+
+$updateSettings = $appInstallerDocument.CreateElement('UpdateSettings', $appInstallerNamespace)
+$onLaunch = $appInstallerDocument.CreateElement('OnLaunch', $appInstallerNamespace)
+$onLaunch.SetAttribute('HoursBetweenUpdateChecks', '24')
+$onLaunch.SetAttribute('ShowPrompt', 'false')
+$onLaunch.SetAttribute('UpdateBlocksActivation', 'false')
+[void] $updateSettings.AppendChild($onLaunch)
+[void] $appInstaller.AppendChild($updateSettings)
+
+Save-XmlDocument -Document $appInstallerDocument -Path $AppInstallerPath

--- a/windows/packaging/New-AppInstaller.ps1
+++ b/windows/packaging/New-AppInstaller.ps1
@@ -120,6 +120,7 @@ $onLaunch.SetAttribute('HoursBetweenUpdateChecks', '24')
 $onLaunch.SetAttribute('ShowPrompt', 'false')
 $onLaunch.SetAttribute('UpdateBlocksActivation', 'false')
 [void] $updateSettings.AppendChild($onLaunch)
+[void] $updateSettings.AppendChild($appInstallerDocument.CreateElement('AutomaticBackgroundTask', $appInstallerNamespace))
 [void] $appInstaller.AppendChild($updateSettings)
 
 Save-XmlDocument -Document $appInstallerDocument -Path $AppInstallerPath

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -31,14 +31,42 @@ winapp package src\TinyClips.App\bin\arm64\Release\net10.0-windows10.0.26100.0\w
 winapp sign --package <path-to.msix>
 ```
 
-Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`).
+Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`). The automated release
+workflow also generates architecture-specific `.appinstaller` files for auto-updating direct installs.
 
 ### Automated Windows release workflow
 
 `.github/workflows/windows-release.yml` runs for tags like `v1.0.1-windows` and maps them to
 MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **framework-dependent** MSIX
 packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates
-a versioned winget manifest artifact, and creates the GitHub Release.
+a versioned winget manifest artifact, and creates the GitHub Release. Direct release packages embed
+their generated App Installer configuration; Store packages use their separate manifest and never
+include it.
+
+#### Direct install auto-updates
+
+Each versioned Windows release publishes `TinyClips-x64.appinstaller` and
+`TinyClips-arm64.appinstaller` beside the signed MSIX files. Installing the architecture-specific
+`.appinstaller` opts the direct package into Windows App Installer updates. Windows checks on launch
+when approximately 24 hours have passed since the previous check.
+
+The App Installer files and embedded `uap13:AutoUpdate` metadata use a dedicated rolling GitHub
+Release at `windows-latest`. Its stable App Installer URLs do not change when a new version tag is
+published:
+
+```text
+https://github.com/jamesmontemagno/tiny-clips/releases/download/windows-latest/TinyClips-x64.appinstaller
+```
+
+ARM64 uses the corresponding `TinyClips-arm64.appinstaller` filename. Each rolling App Installer
+file references the signed MSIX on its immutable, versioned Windows release URL. The workflow creates
+that versioned release before promoting the update metadata, refuses to replace a newer installer
+with an older rerun, and verifies the uploaded files. The rolling release is explicitly not marked
+as the repository's latest release, avoiding collisions with interleaved macOS releases.
+
+Direct packages remain framework-dependent. App Installer can acquire the Windows App SDK framework,
+but a clean machine still needs the .NET 10 Desktop Runtime; installing through winget remains the
+easiest bootstrap because winget declares and installs both runtime dependencies.
 
 #### Framework-dependent + declared winget dependencies (and how)
 

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -46,9 +46,12 @@ include it.
 #### Direct install auto-updates
 
 Each versioned Windows release publishes `TinyClips-x64.appinstaller` and
-`TinyClips-arm64.appinstaller` beside the signed MSIX files. Installing the architecture-specific
-`.appinstaller` opts the direct package into Windows App Installer updates. Windows checks on launch
-when approximately 24 hours have passed since the previous check.
+`TinyClips-arm64.appinstaller` beside the signed MSIX files. The direct MSIX itself embeds the
+App Installer configuration, so installing it by any route—including double-click, `Add-AppxPackage`,
+or winget—opts the package into Windows App Installer updates. The `.appinstaller` is a stable
+bootstrap that lets new users install the current version without knowing its versioned asset URL.
+Windows checks in the background approximately every eight hours and also checks on launch when
+24 hours have passed since the previous launch check.
 
 The App Installer files and embedded `uap13:AutoUpdate` metadata use a dedicated rolling GitHub
 Release at `windows-latest`. Its stable App Installer URLs do not change when a new version tag is
@@ -62,11 +65,15 @@ ARM64 uses the corresponding `TinyClips-arm64.appinstaller` filename. Each rolli
 file references the signed MSIX on its immutable, versioned Windows release URL. The workflow creates
 that versioned release before promoting the update metadata, refuses to replace a newer installer
 with an older rerun, and verifies the uploaded files. The rolling release is explicitly not marked
-as the repository's latest release, avoiding collisions with interleaved macOS releases.
+as the repository's latest release, avoiding collisions with interleaved macOS releases. Its
+`windows-latest` git tag and generated source archives identify the commit that first created the
+channel; only the `.appinstaller` assets represent current channel state.
 
 Direct packages remain framework-dependent. App Installer can acquire the Windows App SDK framework,
 but a clean machine still needs the .NET 10 Desktop Runtime; installing through winget remains the
-easiest bootstrap because winget declares and installs both runtime dependencies.
+easiest bootstrap because winget declares and installs both runtime dependencies. winget installs
+the same direct MSIX, so those installations also receive App Installer updates. `winget upgrade`
+and App Installer operate on the same package family; either can advance its installed version.
 
 #### Framework-dependent + declared winget dependencies (and how)
 

--- a/windows/src/TinyClips.App/Controls/Settings/AboutSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/AboutSettingsSection.xaml
@@ -44,7 +44,7 @@
                             <TextBlock
                                 FontSize="12"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="Direct installs check for signed updates about every 24 hours. You can also update through winget."
+                                Text="Release MSIX installs receive signed updates automatically in the background and when Tiny Clips restarts. You can also update through winget."
                                 TextAlignment="Right"
                                 TextWrapping="Wrap" />
                             <TextBlock

--- a/windows/src/TinyClips.App/Controls/Settings/AboutSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/AboutSettingsSection.xaml
@@ -44,7 +44,7 @@
                             <TextBlock
                                 FontSize="12"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Text="Update through winget or download the latest GitHub release."
+                                Text="Direct installs check for signed updates about every 24 hours. You can also update through winget."
                                 TextAlignment="Right"
                                 TextWrapping="Wrap" />
                             <TextBlock

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -47,10 +47,7 @@
 
   <ItemGroup Condition="'$(TinyClipsAutoUpdateBuild)' == 'true' and '$(TinyClipsStoreBuild)' != 'true'">
     <AppxManifest Include="Package.AutoUpdate.appxmanifest" />
-    <Content Include="install.appinstaller">
-      <PackagePath>install.appinstaller</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="install.appinstaller" />
   </ItemGroup>
 
   <Target Name="ValidateTinyClipsAutoUpdateInputs" BeforeTargets="PrepareForBuild" Condition="'$(TinyClipsAutoUpdateBuild)' == 'true'">

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -32,6 +32,8 @@
       - true: Microsoft Store distribution
     -->
     <TinyClipsStoreBuild Condition="'$(TinyClipsStoreBuild)' == ''">false</TinyClipsStoreBuild>
+    <!-- Enabled only by the GitHub Release workflow for direct-install MSIX packages. -->
+    <TinyClipsAutoUpdateBuild Condition="'$(TinyClipsAutoUpdateBuild)' == ''">false</TinyClipsAutoUpdateBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TinyClipsStoreBuild)' == 'true'">
@@ -42,6 +44,20 @@
     <!-- Keep the Store-assigned identity separate from the direct/winget package identity. -->
     <AppxManifest Include="Package.Store.appxmanifest" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TinyClipsAutoUpdateBuild)' == 'true' and '$(TinyClipsStoreBuild)' != 'true'">
+    <AppxManifest Include="Package.AutoUpdate.appxmanifest" />
+    <Content Include="install.appinstaller">
+      <PackagePath>install.appinstaller</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <Target Name="ValidateTinyClipsAutoUpdateInputs" BeforeTargets="PrepareForBuild" Condition="'$(TinyClipsAutoUpdateBuild)' == 'true'">
+    <Error Condition="'$(TinyClipsStoreBuild)' == 'true'" Text="TinyClipsAutoUpdateBuild cannot be enabled for Microsoft Store packages." />
+    <Error Condition="!Exists('Package.AutoUpdate.appxmanifest')" Text="Package.AutoUpdate.appxmanifest must be generated before an auto-update build." />
+    <Error Condition="!Exists('install.appinstaller')" Text="install.appinstaller must be generated before an auto-update build." />
+  </Target>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />


### PR DESCRIPTION
## Summary
- generate architecture-specific `.appinstaller` metadata from the stamped direct-package identity and embed it through `uap13:AutoUpdate`
- check for signed direct-channel updates on launch when 24 hours have elapsed, while keeping Microsoft Store packages on their separate manifest with no reachable self-update metadata
- publish standalone x64/ARM64 App Installer files on each versioned Windows release and promote verified metadata to stable `windows-latest` URLs
- reference immutable versioned MSIX assets, serialize releases, reject downgrades, retry/verify promotion, and restore the prior channel after a failed update
- update Windows distribution/release documentation and in-app guidance

The MSIX/App Installer approach was inspired by Jan De Dobbeleer's [oh-my-posh implementation](https://github.com/JanDeDobbeleer/oh-my-posh/commit/4192cd5749362762d3484bc394af7c3a850bfc61).

## Update channel

Direct installs register the stable architecture-specific metadata URL, for example:

`https://github.com/jamesmontemagno/tiny-clips/releases/download/windows-latest/TinyClips-x64.appinstaller`

That metadata points to the signed MSIX on its immutable versioned Windows release. `OnLaunch HoursBetweenUpdateChecks="24"` limits checks to approximately once per day. The Store workflow continues to use `Package.Store.appxmanifest` and cannot enable `TinyClipsAutoUpdateBuild`.

## Validation
- `dotnet restore windows/TinyClips.Windows.slnx`
- direct x64 Debug build
- Microsoft Store x64 Debug build
- 227 Windows Core tests after merging the latest `main`
- x64 Release MSIX packaging with extracted manifest/payload assertions for `uap13:AutoUpdate`, embedded `install.appinstaller`, identity, version, architecture, stable metadata URL, immutable package URL, and 24-hour cadence
- ARM64 App Installer generation and XML assertions
- workflow YAML lint and embedded PowerShell parser validation

## Caveat

Direct App Installer installs remain framework-dependent and require the .NET 10 Desktop Runtime on a clean machine. The release notes and Windows docs link that prerequisite; winget remains the easiest clean-machine bootstrap because it installs both declared runtimes automatically.