### PR TITLE
Make direct Windows packages NativeAOT self-contained

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -39,7 +39,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [x64, ARM64]
+        include:
+          - platform: x64
+            rid: win-x64
+            architecture: x64
+          - platform: ARM64
+            rid: win-arm64
+            architecture: arm64
 
     steps:
       - name: Report successful skip
@@ -56,18 +62,110 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Restore app for ${{ matrix.platform }}
+      - name: Verify NativeAOT toolchain
         if: ${{ needs.changes.outputs.windows == 'true' }}
-        run: dotnet restore windows/src/TinyClips.App/TinyClips.App.csproj -p:Configuration=Release -p:Platform=${{ matrix.platform }}
+        shell: pwsh
+        run: |
+          $vswhereDirectory = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer"
+          $vswhere = Join-Path $vswhereDirectory "vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe was not found; NativeAOT requires Visual Studio with Desktop development with C++."
+          }
 
-      - name: Build app for ${{ matrix.platform }}
+          $visualStudio = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $visualStudio) {
+            throw "Visual Studio Desktop development with C++ was not found."
+          }
+
+          $linker = Get-ChildItem "$visualStudio\VC\Tools\MSVC" -Recurse -Filter link.exe |
+            Where-Object { $_.FullName -match "\\Hostx64\\${{ matrix.architecture }}\\link\.exe$" } |
+            Select-Object -First 1
+          if (-not $linker) {
+            throw "NativeAOT linker for ${{ matrix.architecture }} was not found."
+          }
+
+          $vswhereDirectory >> $env:GITHUB_PATH
+
+      - name: Restore direct app for ${{ matrix.platform }}
         if: ${{ needs.changes.outputs.windows == 'true' }}
-        run: dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=${{ matrix.platform }} --no-restore
+        run: >-
+          dotnet restore windows/src/TinyClips.App/TinyClips.App.csproj
+          -p:Configuration=Release
+          -p:Platform=${{ matrix.platform }}
+          -p:RuntimeIdentifier=${{ matrix.rid }}
+          -p:TinyClipsDirectReleaseBuild=true
+
+      - name: Build and inspect direct package for ${{ matrix.platform }}
+        if: ${{ needs.changes.outputs.windows == 'true' }}
+        shell: pwsh
+        run: |
+          $packageDirectory = Join-Path (Resolve-Path ".") "artifacts/direct-${{ matrix.architecture }}/"
+          New-Item -ItemType Directory -Force $packageDirectory | Out-Null
+
+          dotnet build windows/src/TinyClips.App/TinyClips.App.csproj `
+            -c Release `
+            -p:Platform=${{ matrix.platform }} `
+            -p:RuntimeIdentifier=${{ matrix.rid }} `
+            -p:TinyClipsDirectReleaseBuild=true `
+            -p:EnableMsixTooling=true `
+            -p:GenerateAppxPackageOnBuild=true `
+            -p:AppxPackageDir=$packageDirectory `
+            -p:AppxBundle=Never `
+            -p:UapAppxPackageBuildMode=SideloadOnly `
+            -p:AppxPackageSigningEnabled=false `
+            -p:AppxSymbolPackageEnabled=false `
+            --no-restore `
+            -v:minimal
+          if ($LASTEXITCODE -ne 0) { throw "Direct package build failed." }
+
+          $msix = Get-ChildItem $packageDirectory -Recurse -Filter *.msix |
+            Where-Object { $_.Name -notmatch "symbols" } |
+            Select-Object -First 1
+          if (-not $msix) { throw "Direct package build produced no MSIX." }
+
+          & windows/packaging/Assert-DirectPackage.ps1 `
+            -MsixPath $msix.FullName `
+            -Architecture ${{ matrix.architecture }}
+          if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed." }
+
+  store-build:
+    name: Build Microsoft Store flavor
+    needs: changes
+    runs-on: windows-latest
+
+    steps:
+      - name: Report successful skip
+        if: ${{ needs.changes.outputs.windows != 'true' }}
+        run: echo "No Windows files changed; skipping the Store flavor build."
+
+      - name: Checkout code
+        if: ${{ needs.changes.outputs.windows == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        if: ${{ needs.changes.outputs.windows == 'true' }}
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build framework-dependent Store flavor
+        if: ${{ needs.changes.outputs.windows == 'true' }}
+        run: >-
+          dotnet build windows/src/TinyClips.App/TinyClips.App.csproj
+          -c Release
+          -p:Platform=x64
+          -p:TinyClipsStoreBuild=true
+          -p:TinyClipsDirectReleaseBuild=false
+          -p:PublishAot=false
+          -p:SelfContained=false
+          -p:WindowsAppSDKSelfContained=false
+          -p:PublishTrimmed=false
+          -v:minimal
 
   test:
     name: Run Core Tests
     runs-on: windows-latest
-    needs: [changes, build]
+    needs: [changes, build, store-build]
 
     steps:
       - name: Report successful skip

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -126,7 +126,6 @@ jobs:
           & windows/packaging/Assert-DirectPackage.ps1 `
             -MsixPath $msix.FullName `
             -Architecture ${{ matrix.architecture }}
-          if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed." }
 
   store-build:
     name: Build Microsoft Store flavor

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -1,11 +1,9 @@
-name: Windows Launch Smoke (winget harness repro)
+name: Windows Launch Smoke (self-contained package)
 
 # Reproduces the winget-pkgs "Installation Validation" step on real x64 and ARM64 runners:
-# install the framework-dependent MSIX together with its declared runtime dependencies, launch
-# TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the harness does), and report
-# whether the process survives. On a crash the job collects the app's crash.log plus the
-# ".NET Runtime" / "Application Error" event-log records, which carry the managed stack that the
-# winget moderators only sometimes paste into the PR.
+# verify the direct MSIX is NativeAOT and bundles Windows App SDK, install it without installing
+# either runtime first, launch TinyClips.App.exe straight from C:\Program Files\WindowsApps (as the
+# harness does), and report whether the process survives. On a crash the job collects diagnostics.
 #
 # source=release downloads the signed MSIX from a GitHub release; source=build packages the
 # checked-out branch with the release recipe and signs it with a throwaway self-signed cert so a
@@ -23,11 +21,11 @@ on:
       release_tag:
         description: "Release tag holding the MSIX assets (source=release)"
         required: false
-        default: "v1.7.1-windows"
+        default: "v1.8.0-windows"
       asset_version:
         description: "Version embedded in the asset name (e.g. 1.7.1)"
         required: true
-        default: "1.7.1"
+        default: "1.8.0"
       wait_seconds:
         description: "How long the app must stay alive to count as a pass"
         required: false
@@ -51,8 +49,8 @@ jobs:
 
     env:
       SOURCE: ${{ inputs.source || 'release' }}
-      RELEASE_TAG: ${{ inputs.release_tag || 'v1.7.1-windows' }}
-      ASSET_VERSION: ${{ inputs.asset_version || '1.7.1' }}
+      RELEASE_TAG: ${{ inputs.release_tag || 'v1.8.0-windows' }}
+      ASSET_VERSION: ${{ inputs.asset_version || '1.8.0' }}
       WAIT_SECONDS: ${{ inputs.wait_seconds || '60' }}
       ARCH: ${{ matrix.arch }}
       GH_TOKEN: ${{ github.token }}
@@ -67,6 +65,9 @@ jobs:
           "Display adapters: $((Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name) -join '; ')"
           "Session: $((Get-Process -Id $PID).SessionId)  Interactive: $([Environment]::UserInteractive)"
 
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Download release MSIX
         if: env.SOURCE == 'release'
         shell: pwsh
@@ -76,15 +77,29 @@ jobs:
             --pattern "TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" --dir packages --clobber
           Get-ChildItem packages
 
-      - name: Checkout code
-        if: env.SOURCE == 'build'
-        uses: actions/checkout@v6
-
       - name: Setup .NET SDK
         if: env.SOURCE == 'build'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
+
+      - name: Verify NativeAOT toolchain
+        if: env.SOURCE == 'build'
+        shell: pwsh
+        run: |
+          $vswhereDirectory = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer"
+          $vswhere = Join-Path $vswhereDirectory "vswhere.exe"
+          if (-not (Test-Path $vswhere)) { throw "vswhere.exe was not found." }
+
+          $visualStudio = & $vswhere -latest -products * -property installationPath
+          if (-not $visualStudio) { throw "Visual Studio was not found." }
+
+          $linker = Get-ChildItem "$visualStudio\VC\Tools\MSVC" -Recurse -Filter link.exe |
+            Where-Object { $_.FullName -match "\\Host(x64|arm64)\\$env:ARCH\\link\.exe$" } |
+            Select-Object -First 1
+          if (-not $linker) { throw "NativeAOT linker for $env:ARCH was not found." }
+
+          $vswhereDirectory >> $env:GITHUB_PATH
 
       - name: Build and package MSIX from this branch
         if: env.SOURCE == 'build'
@@ -104,9 +119,12 @@ jobs:
             -c Release `
             -p:Platform=$platform `
             -p:RuntimeIdentifier=win-$env:ARCH `
-            -p:SelfContained=false `
-            -p:WindowsAppSDKSelfContained=false `
-            -p:PublishTrimmed=false `
+            -p:TinyClipsDirectReleaseBuild=true `
+            -p:PublishAot=true `
+            -p:SelfContained=true `
+            -p:WindowsAppSDKSelfContained=true `
+            -p:PublishTrimmed=true `
+            -p:PublishReadyToRun=false `
             -p:EnableMsixTooling=true `
             -p:GenerateAppxPackageOnBuild=true `
             -p:AppxPackageDir=$packageDirFull `
@@ -121,6 +139,14 @@ jobs:
           if (-not $produced) { throw "No MSIX produced." }
           Copy-Item $produced.FullName "packages/TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" -Force
           Get-ChildItem packages -File
+
+      - name: Verify self-contained NativeAOT package
+        shell: pwsh
+        run: |
+          & windows/packaging/Assert-DirectPackage.ps1 `
+            -MsixPath "packages/TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" `
+            -Architecture $env:ARCH
+          if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed." }
 
       - name: Sign MSIX with a throwaway self-signed certificate
         if: env.SOURCE == 'build'
@@ -144,25 +170,6 @@ jobs:
           if (-not (Test-Path $signtool)) { $signtool = Join-Path $kitsBin.FullName "x64\signtool.exe" }
           & $signtool sign /fd SHA256 /f $pfx /p smoke "packages\TinyClips-$env:ASSET_VERSION-$env:ARCH.msix"
           if ($LASTEXITCODE -ne 0) { throw "signtool failed." }
-
-      - name: Install .NET Desktop Runtime 10 (machine-wide)
-        shell: pwsh
-        run: |
-          $url = "https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-$env:ARCH.exe"
-          Invoke-WebRequest $url -OutFile windowsdesktop-runtime.exe -MaximumRedirection 10
-          $p = Start-Process .\windowsdesktop-runtime.exe -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru
-          "Desktop runtime installer exit code: $($p.ExitCode)"
-          if ($p.ExitCode -notin 0, 1638, 3010) { throw "Desktop runtime install failed." }
-
-      - name: Install Windows App Runtime 1.8
-        shell: pwsh
-        run: |
-          $url = "https://aka.ms/windowsappsdk/1.8/latest/windowsappruntimeinstall-$env:ARCH.exe"
-          Invoke-WebRequest $url -OutFile WindowsAppRuntimeInstall.exe -MaximumRedirection 10
-          $p = Start-Process .\WindowsAppRuntimeInstall.exe -ArgumentList '--quiet' -Wait -PassThru
-          "Windows App Runtime installer exit code: $($p.ExitCode)"
-          if ($p.ExitCode -ne 0) { throw "Windows App Runtime install failed." }
-          Get-AppxPackage Microsoft.WindowsAppRuntime.1.8* | Select-Object Name, Version, Architecture
 
       - name: Install TinyClips MSIX
         shell: pwsh

--- a/.github/workflows/windows-launch-smoke.yml
+++ b/.github/workflows/windows-launch-smoke.yml
@@ -146,7 +146,6 @@ jobs:
           & windows/packaging/Assert-DirectPackage.ps1 `
             -MsixPath "packages/TinyClips-$env:ASSET_VERSION-$env:ARCH.msix" `
             -Architecture $env:ARCH
-          if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed." }
 
       - name: Sign MSIX with a throwaway self-signed certificate
         if: env.SOURCE == 'build'

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -19,10 +19,6 @@ env:
   APP_PROJECT: windows/src/TinyClips.App/TinyClips.App.csproj
   PACKAGE_FAMILY_NAME: Refractored.TinyClips_vmshqmcyy894t
   SIGNTOOL_TIMESTAMP_URL: http://timestamp.acs.microsoft.com
-  # Highest WindowsAppRuntime 1.8 version installable via winget's Microsoft.WindowsAppRuntime.1.8
-  # (manifests/m/Microsoft/WindowsAppRuntime/1/8 in microsoft/winget-pkgs; 1.8.9 = 8000.879.2017.0).
-  # The MSIX's MinVersion must not exceed this or winget installs fail on dependency resolution.
-  WINGET_WINDOWSAPPRUNTIME_MAX_VERSION: 8000.879.2017.0
 
 jobs:
   build-sign-release:
@@ -40,6 +36,32 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
+
+      - name: Verify NativeAOT toolchain
+        shell: pwsh
+        run: |
+          $vswhereDirectory = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer"
+          $vswhere = Join-Path $vswhereDirectory "vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe was not found; NativeAOT requires Visual Studio with Desktop development with C++."
+          }
+
+          $visualStudio = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $visualStudio) {
+            throw "Visual Studio Desktop development with C++ was not found."
+          }
+
+          foreach ($target in @("x64", "arm64")) {
+            $linker = Get-ChildItem "$visualStudio\VC\Tools\MSVC" -Recurse -Filter link.exe |
+              Where-Object { $_.FullName -match "\\Hostx64\\$target\\link\.exe$" } |
+              Select-Object -First 1
+            if (-not $linker) {
+              throw "NativeAOT linker for $target was not found."
+            }
+            "$target linker: $($linker.FullName)"
+          }
+
+          $vswhereDirectory >> $env:GITHUB_PATH
 
       - name: Set release version
         shell: pwsh
@@ -74,15 +96,13 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/windows | Out-Null
+          "### Direct package sizes" >> $env:GITHUB_STEP_SUMMARY
+          "| Architecture | Compressed size |" >> $env:GITHUB_STEP_SUMMARY
+          "|---|---:|" >> $env:GITHUB_STEP_SUMMARY
 
-          # Framework-dependent MSIX (small package). The app does NOT bundle the .NET or
-          # Windows App SDK runtimes; instead they are declared as winget PackageDependencies
-          # in the installer manifest (Microsoft.DotNet.DesktopRuntime.10 and
-          # Microsoft.WindowsAppRuntime.1.8). winget installs those dependency packages before
-          # the app, and the Windows App SDK runtime is also auto-acquired by the OS on machines
-          # with the Store/App Installer. Validate locally with
-          # windows/packaging/sandbox/Invoke-SandboxValidation.ps1 (installs the runtimes in a fresh
-          # Windows Sandbox first) and on ARM64 via the Windows Launch Smoke workflow.
+          # Direct release packages are .NET 10 NativeAOT and bundle the Windows App SDK runtime.
+          # Keep build + MSIX packaging in this one invocation so the executable retains the
+          # registration-free WinRT activatable-class metadata required on clean machines.
           $platforms = @(
             @{ Platform = "x64";   Rid = "win-x64";   Asset = "x64" }
             @{ Platform = "ARM64"; Rid = "win-arm64"; Asset = "arm64" }
@@ -97,8 +117,12 @@ jobs:
               -c Release `
               -p:Platform=$($p.Platform) `
               -p:RuntimeIdentifier=$($p.Rid) `
-              -p:SelfContained=false `
-              -p:WindowsAppSDKSelfContained=false `
+              -p:TinyClipsDirectReleaseBuild=true `
+              -p:PublishAot=true `
+              -p:SelfContained=true `
+              -p:WindowsAppSDKSelfContained=true `
+              -p:PublishTrimmed=true `
+              -p:PublishReadyToRun=false `
               -p:EnableMsixTooling=true `
               -p:GenerateAppxPackageOnBuild=true `
               -p:AppxPackageDir=$packageDirFull `
@@ -113,42 +137,15 @@ jobs:
               Select-Object -First 1
             if (-not $produced) { throw "No MSIX produced for $($p.Platform)." }
 
-            # Guard against silently shipping the wrong kind of package. Unpack the MSIX and
-            # assert it is genuinely framework-dependent: (1) the AppxManifest declares the
-            # WindowsAppRuntime framework dependency (so the declared winget dependency matches
-            # the package), and (2) the payload does NOT contain the .NET runtime (coreclr.dll),
-            # confirming the .NET runtime is framework-dependent and delivered via the declared
-            # Microsoft.DotNet.DesktopRuntime.10 winget dependency.
-            $verifyDir = Join-Path $packageDir "verify"
-            Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
-            $zipCopy = "$($produced.FullName).zip"
-            Copy-Item $produced.FullName $zipCopy -Force
-            Expand-Archive $zipCopy -DestinationPath $verifyDir -Force
+            & windows/packaging/Assert-DirectPackage.ps1 `
+              -MsixPath $produced.FullName `
+              -Architecture $p.Asset
+            if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed for $($p.Platform)." }
 
-            $appxManifest = Get-Content (Join-Path $verifyDir "AppxManifest.xml") -Raw
-            if ($appxManifest -notmatch '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime') {
-              throw "Framework-dependent MSIX for $($p.Platform) is missing the WindowsAppRuntime framework dependency."
-            }
-
-            # The declared winget dependency Microsoft.WindowsAppRuntime.1.8 can only deliver the
-            # runtime versions published in winget-pkgs. If the SDK bump raised the package's
-            # MinVersion past that, every winget install fails with a missing-dependency error.
-            $runtimeDependency = [regex]::Match($appxManifest, '<PackageDependency[^>]*Name="Microsoft\.WindowsAppRuntime\.1\.8"[^>]*MinVersion="([^"]+)"')
-            if (-not $runtimeDependency.Success) { throw "Could not read the WindowsAppRuntime.1.8 MinVersion for $($p.Platform)." }
-            $minVersion = [version]$runtimeDependency.Groups[1].Value
-            $wingetMax = [version]$env:WINGET_WINDOWSAPPRUNTIME_MAX_VERSION
-            if ($minVersion -gt $wingetMax) {
-              throw "MSIX for $($p.Platform) requires WindowsAppRuntime.1.8 >= $minVersion, but winget's Microsoft.WindowsAppRuntime.1.8 only provides up to $wingetMax. Pin Microsoft.WindowsAppSDK to a version whose runtime winget ships (see the csproj comment), or raise WINGET_WINDOWSAPPRUNTIME_MAX_VERSION after winget-pkgs publishes the newer runtime."
-            }
-            "$($p.Platform): WindowsAppRuntime.1.8 MinVersion $minVersion <= winget-available $wingetMax"
-
-            if (Get-ChildItem $verifyDir -Recurse -Filter "coreclr.dll" -ErrorAction SilentlyContinue) {
-              throw "MSIX for $($p.Platform) bundles the .NET runtime (coreclr.dll) - expected a framework-dependent (SelfContained=false) build."
-            }
-            Remove-Item $zipCopy -Force -ErrorAction SilentlyContinue
-            Remove-Item $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
-
-            Copy-Item $produced.FullName "artifacts/windows/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix" -Force
+            $releasePackage = "artifacts/windows/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix"
+            Copy-Item $produced.FullName $releasePackage -Force
+            $sizeMiB = [Math]::Round((Get-Item $releasePackage).Length / 1MB, 2)
+            "| $($p.Asset) | $sizeMiB MiB |" >> $env:GITHUB_STEP_SUMMARY
           }
 
       - name: Azure login
@@ -279,11 +276,9 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
-          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
-          # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # Installer manifest for the signed, NativeAOT self-contained MSIX produced by the
+          # Windows Release workflow. The package bundles .NET native code and Windows App SDK,
+          # so winget runtime package dependencies are intentionally unnecessary.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -292,10 +287,6 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
-          Dependencies:
-            PackageDependencies:
-              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix
@@ -362,6 +353,8 @@ jobs:
 
           $notes += ""
           $notes += "## Release validation"
+          $notes += "- Direct packages are .NET 10 NativeAOT and self-contained for both .NET and Windows App SDK."
+          $notes += "- Package inspection confirmed native architecture/entry point, no CLR payload or WindowsAppRuntime framework dependency, and bundled WinUI/Windows App SDK runtime files."
           $notes += "- Azure Artifact Signing completed for x64 and ARM64 MSIX packages."
           $notes += "- SignTool verification passed for x64 and ARM64 MSIX packages."
           $notes += "- WACK overall result passed for x64 and ARM64 MSIX packages."

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -140,7 +140,6 @@ jobs:
             & windows/packaging/Assert-DirectPackage.ps1 `
               -MsixPath $produced.FullName `
               -Architecture $p.Asset
-            if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed for $($p.Platform)." }
 
             $releasePackage = "artifacts/windows/TinyClips-$env:ASSET_VERSION-$($p.Asset).msix"
             Copy-Item $produced.FullName $releasePackage -Force

--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -98,8 +98,11 @@ jobs:
             -c Release `
             -p:Platform=x64 `
             -p:TinyClipsStoreBuild=true `
+            -p:TinyClipsDirectReleaseBuild=false `
+            -p:PublishAot=false `
             -p:SelfContained=false `
             -p:WindowsAppSDKSelfContained=false `
+            -p:PublishTrimmed=false `
             -p:EnableMsixTooling=true `
             -p:GenerateAppxPackageOnBuild=true `
             -p:AppxPackageDir=$packageDir `

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -71,7 +71,6 @@ jobs:
             & windows/packaging/Assert-DirectPackage.ps1 `
               -MsixPath "packages/TinyClips-$env:ASSET_VERSION-$architecture.msix" `
               -Architecture $architecture
-            if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed for $architecture." }
           }
 
       - name: Generate winget manifest

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -4,8 +4,8 @@ name: WinGet Submission
 # repository (microsoft/winget-pkgs). Run this AFTER you've eyeballed the GitHub release.
 #
 # Unlike the PowerToys "wingetcreate update" approach, this regenerates our full multi-file
-# manifest from source (windows/packaging/winget) so the framework Dependencies block is
-# always present, instead of inheriting whatever the previously published version declared.
+# manifest from source (windows/packaging/winget) so it cannot inherit stale runtime
+# dependencies from an older framework-dependent release.
 #
 # Requires a repository secret named WINGET_CREATE_GITHUB_TOKEN: a classic PAT from an
 # account that can fork microsoft/winget-pkgs, with the `public_repo` scope. wingetcreate
@@ -64,6 +64,16 @@ jobs:
             --dir packages
           Get-ChildItem packages | Format-Table Name, Length
 
+      - name: Verify self-contained NativeAOT packages
+        shell: pwsh
+        run: |
+          foreach ($architecture in @("x64", "arm64")) {
+            & windows/packaging/Assert-DirectPackage.ps1 `
+              -MsixPath "packages/TinyClips-$env:ASSET_VERSION-$architecture.msix" `
+              -Architecture $architecture
+            if ($LASTEXITCODE -ne 0) { throw "Direct package assertions failed for $architecture." }
+          }
+
       - name: Generate winget manifest
         shell: pwsh
         run: |
@@ -88,11 +98,9 @@ jobs:
 
           @"
           # yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-          # Installer manifest for the signed, framework-dependent MSIX produced by the Windows
-          # Release workflow. The package does NOT bundle the .NET or Windows App SDK runtimes;
-          # they are declared below as winget package dependencies so winget installs them before
-          # the app. Do not set Scope here: the dependency installers are machine-scope/unknown
-          # scope, and forcing user scope makes winget reject them during validation.
+          # Installer manifest for the signed, NativeAOT self-contained MSIX produced by the
+          # Windows Release workflow. The package bundles .NET native code and Windows App SDK,
+          # so winget runtime package dependencies are intentionally unnecessary.
           PackageIdentifier: Refractored.TinyClips
           PackageVersion: $env:PACKAGE_VERSION
           MinimumOSVersion: 10.0.22000.0
@@ -101,10 +109,6 @@ jobs:
             - silent
             - silentWithProgress
           PackageFamilyName: $env:PACKAGE_FAMILY_NAME
-          Dependencies:
-            PackageDependencies:
-              - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-              - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
           Installers:
             - Architecture: x64
               InstallerUrl: https://github.com/${{ github.repository }}/releases/download/$env:RELEASE_TAG/TinyClips-$env:ASSET_VERSION-x64.msix

--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -47,6 +47,20 @@ own `CHANGELOG.md` at the repository root.
   selection mode, delete confirmation, context menu, accessibility-name audit).
 
 ### Changed
+- **Direct GitHub Release and winget packages are now .NET 10 NativeAOT and fully
+  self-contained.** x64 and ARM64 MSIX artifacts bundle the Windows App SDK/WinUI runtime and do
+  not require a machine-installed .NET 10 Desktop Runtime or Windows App Runtime. The Microsoft
+  Store package remains framework-dependent and independently configured.
+- Release, pull-request, winget-submission, launch-smoke, and offline Windows Sandbox checks now
+  inspect each direct package for a native architecture-specific executable, no CLR payload, no
+  Windows App Runtime framework dependency, bundled WinUI/runtime files, and embedded
+  registration-free WinRT activation metadata.
+- JSON persistence/update payloads use `System.Text.Json` source generation, the Windows Share
+  contract uses source-generated COM interop, and the remaining picker/device XAML templates use
+  compiled bindings so trimming cannot remove required members.
+- The self-contained x64 package is about 50.9 MiB compressed (126.4 MiB expanded), versus
+  22.4 MiB compressed (72.1 MiB expanded) for a same-source framework-dependent artifact; the
+  28.5 MiB download increase removes both runtime prerequisites.
 - The shared Direct3D 11 device is created with `VIDEO_SUPPORT` (falls back without it) so Media
   Foundation's hardware encoders can bind recorder textures directly.
 - Webcam overlay placement math moved to the shared `WebcamOverlayLayout`; click-ring geometry and

--- a/windows/README.md
+++ b/windows/README.md
@@ -137,7 +137,10 @@ automation review does not replace the documented hands-on results.
 
 ## Distribution
 
-- **Direct (available now):** signed MSIX distributed via **winget** — install with
+- **Direct (available now):** signed x64/ARM64 NativeAOT MSIX distributed through GitHub Releases
+  and **winget**. The package includes the .NET native code and Windows App SDK runtime, so clean
+  Windows 11 machines do not need a separate .NET 10 Desktop Runtime or Windows App Runtime install.
+  Install with
   `winget install Refractored.TinyClips` and update with `winget upgrade Refractored.TinyClips`
   (no separate in-app updater). Fully free.
 - **Microsoft Store (planned):** Store auto-update. Feature set matches Direct; no Windows Pro tier.

--- a/windows/packaging/Assert-DirectPackage.ps1
+++ b/windows/packaging/Assert-DirectPackage.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $MsixPath,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('x64', 'arm64')]
+    [string] $Architecture
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedMsix = (Resolve-Path $MsixPath).Path
+$verifyDirectory = Join-Path ([IO.Path]::GetTempPath()) "tinyclips-package-$([Guid]::NewGuid().ToString('N'))"
+$zipPath = "$resolvedMsix.zip"
+
+function Require-File([string] $Name) {
+    $file = Get-ChildItem $verifyDirectory -Recurse -File |
+        Where-Object { $_.Name -ieq $Name } |
+        Select-Object -First 1
+    if (-not $file) {
+        throw "Direct package is missing required payload '$Name'."
+    }
+
+    return $file
+}
+
+try {
+    Copy-Item $resolvedMsix $zipPath -Force
+    Expand-Archive $zipPath -DestinationPath $verifyDirectory -Force
+
+    [xml] $manifest = Get-Content (Join-Path $verifyDirectory 'AppxManifest.xml') -Raw
+    $manifestArchitecture = [string] $manifest.Package.Identity.ProcessorArchitecture
+    if ($manifestArchitecture -ine $Architecture) {
+        throw "Package architecture '$manifestArchitecture' does not match expected '$Architecture'."
+    }
+
+    $frameworkDependencies = $manifest.SelectNodes("//*[local-name()='PackageDependency']")
+    $windowsAppRuntimeDependency = $frameworkDependencies |
+        Where-Object { $_.Name -like 'Microsoft.WindowsAppRuntime*' }
+    if ($windowsAppRuntimeDependency) {
+        throw "Direct package still declares a Windows App Runtime framework dependency."
+    }
+
+    $appRuntime = Require-File 'Microsoft.WindowsAppRuntime.dll'
+    $xamlRuntime = Require-File 'Microsoft.UI.Xaml.dll'
+    $appExecutable = Require-File 'TinyClips.App.exe'
+
+    foreach ($forbiddenFile in @(
+        'TinyClips.App.dll',
+        'coreclr.dll',
+        'clrjit.dll',
+        'hostfxr.dll',
+        'hostpolicy.dll')) {
+        if (Get-ChildItem $verifyDirectory -Recurse -File |
+            Where-Object { $_.Name -ieq $forbiddenFile } |
+            Select-Object -First 1) {
+            throw "Direct NativeAOT package unexpectedly contains '$forbiddenFile'."
+        }
+    }
+
+    Add-Type -AssemblyName System.Reflection.Metadata
+    $stream = [IO.File]::OpenRead($appExecutable.FullName)
+    try {
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        $expectedMachine = if ($Architecture -eq 'arm64') { 'Arm64' } else { 'Amd64' }
+        $actualMachine = [string] $peReader.PEHeaders.CoffHeader.Machine
+        if ($actualMachine -ne $expectedMachine) {
+            throw "Native executable machine '$actualMachine' does not match expected '$expectedMachine'."
+        }
+        if ($null -ne $peReader.PEHeaders.CorHeader) {
+            throw "TinyClips.App.exe contains a CLR header; expected a NativeAOT executable."
+        }
+        if ($peReader.PEHeaders.PEHeader.AddressOfEntryPoint -eq 0) {
+            throw "TinyClips.App.exe does not have a native entry point."
+        }
+    }
+    finally {
+        if ($peReader) {
+            $peReader.Dispose()
+        }
+        $stream.Dispose()
+    }
+
+    $executableText = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($appExecutable.FullName))
+    if ($executableText.IndexOf('activatableClass', [StringComparison]::OrdinalIgnoreCase) -lt 0) {
+        throw "TinyClips.App.exe is missing embedded registration-free WinRT activatable-class metadata."
+    }
+
+    $msix = Get-Item $resolvedMsix
+    $expandedBytes = (Get-ChildItem $verifyDirectory -Recurse -File | Measure-Object Length -Sum).Sum
+    [pscustomobject]@{
+        Architecture = $Architecture
+        MsixMiB = [Math]::Round($msix.Length / 1MB, 2)
+        ExpandedMiB = [Math]::Round($expandedBytes / 1MB, 2)
+        NativeExecutableMiB = [Math]::Round($appExecutable.Length / 1MB, 2)
+        WindowsAppRuntimeMiB = [Math]::Round($appRuntime.Length / 1MB, 2)
+        XamlRuntimeMiB = [Math]::Round($xamlRuntime.Length / 1MB, 2)
+    } | Format-List
+}
+finally {
+    Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+    Remove-Item $verifyDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/windows/packaging/README.md
+++ b/windows/packaging/README.md
@@ -14,97 +14,77 @@ enables toast notifications, startup tasks, and Store distribution.
 
 ```pwsh
 # From repo root
-cd windows
+$packageDir = (Resolve-Path .).Path + "\artifacts\windows\"
 
-# (Dev only) create + trust a local signing cert
-winapp cert generate --publisher "CN=Refractored LLC, O=Refractored LLC, L=Seattle, S=Washington, C=US"
-winapp cert install
+dotnet build windows\src\TinyClips.App\TinyClips.App.csproj -c Release `
+  -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
+  -p:TinyClipsDirectReleaseBuild=true `
+  -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
+  -p:AppxPackageDir=$packageDir -p:AppxBundle=Never `
+  -p:UapAppxPackageBuildMode=SideloadOnly -p:AppxPackageSigningEnabled=false
 
-# Produce framework-dependent MSIX packages (x64 and arm64). The .NET and Windows App SDK
-# runtimes are NOT bundled; they are declared as winget package dependencies instead.
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
-dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=arm64 -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false
-winapp package src\TinyClips.App\bin\x64\Release\net10.0-windows10.0.26100.0\win-x64 --output TinyClips-x64.msix
-winapp package src\TinyClips.App\bin\arm64\Release\net10.0-windows10.0.26100.0\win-arm64 --output TinyClips-arm64.msix
-
-# Sign the package(s)
-winapp sign --package <path-to.msix>
+.\windows\packaging\Assert-DirectPackage.ps1 `
+  -MsixPath <path-to-x64.msix> -Architecture x64
 ```
 
-Attach the signed `.msix` files to a GitHub Release (e.g. `v1.0.0`).
+Repeat with `Platform=ARM64`, `RuntimeIdentifier=win-arm64`, and
+`Assert-DirectPackage.ps1 -Architecture arm64`. Sign the resulting packages before distribution.
+NativeAOT requires Visual Studio's **Desktop development with C++** workload.
 
 ### Automated Windows release workflow
 
 `.github/workflows/windows-release.yml` runs for tags like `v1.0.1-windows` and maps them to
-MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as **framework-dependent** MSIX
-packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates
-a versioned winget manifest artifact, and creates the GitHub Release.
+MSIX/winget versions like `1.0.1.0`. It builds x64 + ARM64 as NativeAOT self-contained MSIX
+packages, signs them with Azure Artifact Signing, runs WACK, computes winget hashes, generates a
+versioned winget manifest artifact, and creates the GitHub Release.
 
-#### Framework-dependent + declared winget dependencies (and how)
+#### Direct release runtime model
 
-The package is kept small by **not** bundling the runtimes. The winget installer manifest declares
-both runtimes as package dependencies, so winget installs them before the app:
+Direct GitHub Release and winget artifacts use the `TinyClipsDirectReleaseBuild=true` profile:
 
-| winget `PackageDependency` | Provides |
+| MSBuild property | Direct release effect |
 |---|---|
-| `Microsoft.WindowsAppRuntime.1.8` | The Windows App SDK runtime (WinUI 3, etc.) |
-| `Microsoft.DotNet.DesktopRuntime.10` | The .NET 10 Desktop Runtime |
+| `PublishAot=true` | Compiles Tiny Clips and reachable .NET code to an architecture-specific native executable; no JIT or machine-installed .NET runtime is used. |
+| `SelfContained=true` | Makes the .NET deployment contract explicitly self-contained (NativeAOT also implies this). |
+| `WindowsAppSDKSelfContained=true` | Includes WinUI 3 and Windows App SDK runtime files inside the MSIX instead of declaring `Microsoft.WindowsAppRuntime` as a framework dependency. |
+| `PublishTrimmed=true` | Required by NativeAOT; app JSON serialization, COM interop, and XAML bindings use source-generated/compiled paths. |
 
-The matching MSBuild properties are `-p:SelfContained=false` (do not bundle .NET) and
-`-p:WindowsAppSDKSelfContained=false` (do not bundle the Windows App SDK runtime). The release
-workflow unpacks each MSIX and asserts it is genuinely framework-dependent (the AppxManifest
-declares the `WindowsAppRuntime` dependency and the payload contains no bundled `coreclr.dll`)
-before signing.
+Build and package in one MSBuild invocation. Splitting `dotnet publish` from packaging can lose the
+embedded registration-free WinRT `activatableClass` metadata and cause `REGDB_E_CLASSNOTREG` on a
+clean machine.
 
-> ⚠️ **Both runtimes are delivered differently.** The Windows App SDK runtime is an MSIX
-> *framework package*, so on machines with the Store/App Installer the OS can auto-acquire it
-> during deployment, and winget can also install the declared `Microsoft.WindowsAppRuntime.1.8`
-> dependency. The .NET Desktop Runtime is **not** an MSIX framework — the OS will not auto-deliver
-> it — so it is installed via the declared `Microsoft.DotNet.DesktopRuntime.10` winget dependency.
+`Assert-DirectPackage.ps1` unpacks every x64/ARM64 candidate and requires:
 
-> ⚠️ **Keep `Microsoft.WindowsAppSDK` pinned to a version whose runtime winget ships.** The MSIX's
-> `Microsoft.WindowsAppRuntime.1.8` `MinVersion` follows the SDK NuGet version, and winget's
-> `Microsoft.WindowsAppRuntime.1.8` package (`manifests/m/Microsoft/WindowsAppRuntime/1/8` in
-> winget-pkgs) only provides the runtime builds Microsoft has published there — 1.8.9 = `8000.879.2017.0`
-> = SDK `1.8.260529003`. A newer SDK (e.g. `1.8.260804001` → `8000.946.1701.0`) makes every winget
-> install fail on dependency resolution. The release workflow asserts `MinVersion` ≤
-> `WINGET_WINDOWSAPPRUNTIME_MAX_VERSION`; raise both together once winget-pkgs publishes the newer
-> runtime.
+- a native PE for the requested architecture with a native entry point and no CLR header;
+- no `TinyClips.App.dll`, `coreclr.dll`, `clrjit.dll`, `hostfxr.dll`, or `hostpolicy.dll`;
+- bundled `Microsoft.WindowsAppRuntime.dll` and `Microsoft.UI.Xaml.dll`;
+- no `Microsoft.WindowsAppRuntime` framework dependency; and
+- embedded registration-free WinRT activation metadata.
+
+The x64 package is about **50.9 MiB compressed / 126.4 MiB expanded** at 1.8.0, versus
+**22.4 MiB compressed / 72.1 MiB expanded** for a same-source framework-dependent package. The
+download grows by about 28.5 MiB (2.27x). NativeAOT removes the CLR/JIT payload, but the Windows App
+SDK self-contained payload includes optional runtime components, so release size still increases in
+exchange for clean-machine installation.
 
 #### Verifying locally in Windows Sandbox (recommended before every release)
 
 ```pwsh
-.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4     # working tree
-.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4   # published tag
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.8.0     # working tree
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.8.0   # published tag
 ```
 
-This installs both runtimes from their installers in a fresh Sandbox (so framework-dependent
-packages *do* work there — without that step Sandbox fails with `0x80073cf3` because it has no
-Store to auto-acquire frameworks), installs the MSIX, launches it exactly like winget's harness,
-clicks through onboarding and requires the process to stay alive. See
-[`sandbox/README.md`](sandbox/README.md). Sandbox is x64-only; for ARM64 run the
-*Windows Launch Smoke* workflow (`source=release`, `windows-11-arm` runner).
+This starts an **offline** fresh Sandbox, installs no .NET or Windows App Runtime prerequisites,
+installs the MSIX, launches it exactly like winget's harness, clicks through onboarding, and
+requires the process to stay alive. See [`sandbox/README.md`](sandbox/README.md). Sandbox is
+x64-only; for ARM64 run the *Windows Launch Smoke* workflow (`source=release`,
+`windows-11-arm` runner).
 
 #### Verifying on a real clean machine
 
-On a normal Windows machine (with the Store/App Installer) that does not yet have the runtimes,
-`winget install --manifest <dir>` should install `Microsoft.DotNet.DesktopRuntime.10` and
-`Microsoft.WindowsAppRuntime.1.8` first, then the app. A pass is the app process running with the
-tray icon present and no `.NET Desktop Runtime` prompt.
-
-Do not add `Scope: user` to the installer manifest. The TinyClips MSIX installs per-user by
-default, but the runtime dependency installers are machine-scope/unknown-scope packages; forcing
-user scope causes winget validation to reject those dependencies with "No suitable installer found."
-
-```pwsh
-# Build a framework-dependent, packaged MSIX (x64)
-dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Release `
-  -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
-  -p:SelfContained=false -p:WindowsAppSDKSelfContained=false `
-  -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
-  -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
-  -p:AppxPackageDir=<out>\ -p:AppxPackageSigningEnabled=false
-```
+On a normal Windows 11 machine, direct MSIX and winget installation should not prompt for or install
+.NET 10 Desktop Runtime or Windows App Runtime. A pass is the app process running with the tray icon
+present. The winget installer manifest intentionally has no runtime `PackageDependencies`.
 
 Required repository secrets:
 
@@ -146,9 +126,10 @@ The locale manifest already includes:
    `Package.appxmanifest` `Identity`).
 3. Build the Store-configuration MSIX (Store handles signing) and upload via Partner Center
    or `winapp` Store submission.
-4. Build with the Store flavor flag so Store-only distribution behavior is enabled:
-   `dotnet publish src/TinyClips.App/TinyClips.App.csproj -c Release -p:Platform=x64 -p:TinyClipsStoreBuild=true`
-   (repeat for ARM64 as needed).
+4. Build with the Store flavor flag so Store-only distribution behavior is enabled while the
+   direct NativeAOT/self-contained profile stays disabled:
+   `dotnet build windows\src\TinyClips.App\TinyClips.App.csproj -c Release -p:Platform=x64 -p:TinyClipsStoreBuild=true -p:TinyClipsDirectReleaseBuild=false -p:PublishAot=false -p:SelfContained=false -p:WindowsAppSDKSelfContained=false`
+   (the Store workflow creates the x64 + ARM64 upload bundle).
 5. Complete the listing metadata, privacy, and screen-recording capability declarations.
    - Privacy policy URL: `https://tinyclips.app/privacy.html`
 

--- a/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
+++ b/windows/packaging/sandbox/Invoke-SandboxValidation.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
   One-command Windows Sandbox validation of a Tiny Clips MSIX, mirroring winget's Installation
-  Validation: fresh OS, runtimes installed from their installers, MSIX installed, app launched
-  from C:\Program Files\WindowsApps with an unrelated working directory, first-run onboarding
-  clicked through, process must stay alive.
+  Validation: fresh offline OS, self-contained MSIX installed without runtime prerequisites, app
+  launched from C:\Program Files\WindowsApps with an unrelated working directory, first-run
+  onboarding clicked through, process must stay alive.
 
 .DESCRIPTION
   Run from the repository root on the host. Requires Windows Sandbox (optional feature
@@ -20,7 +20,7 @@
              throwaway self-signed certificate that the Sandbox trusts.
 
 .PARAMETER Version
-  Asset version, e.g. 1.7.4 (used for the download name or to stamp the build).
+  Asset version, e.g. 1.8.0 (used for the download name or to stamp the build).
 
 .PARAMETER WaitSeconds
   How long the app must stay alive to pass. Default 60.
@@ -29,9 +29,9 @@
   Host folder mapped into the Sandbox as C:\share. Default: %TEMP%\tinyclips-sandbox.
 
 .EXAMPLE
-  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4
+  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.8.0
 .EXAMPLE
-  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4
+  .\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.8.0
 #>
 [CmdletBinding()]
 param(
@@ -50,17 +50,12 @@ if (-not (Get-Command WindowsSandbox.exe -ErrorAction SilentlyContinue)) { throw
 if (Get-Process WindowsSandbox* -ErrorAction SilentlyContinue) { throw 'A Windows Sandbox instance is already running; close it first.' }
 
 New-Item -ItemType Directory -Force $WorkDir | Out-Null
-Remove-Item (Join-Path $WorkDir 'sandbox-result.txt'), (Join-Path $WorkDir '*.png'), (Join-Path $WorkDir 'smoke.cer') -ErrorAction SilentlyContinue
-
-# --- Runtimes (cached between runs) ---
-$dotnet = Join-Path $WorkDir 'windowsdesktop-runtime.exe'
-$war = Join-Path $WorkDir 'WindowsAppRuntimeInstall.exe'
-if (-not (Test-Path $dotnet)) { Write-Host 'Downloading .NET 10 Desktop Runtime installer...'; Invoke-WebRequest 'https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe' -OutFile $dotnet -MaximumRedirection 10 }
-if (-not (Test-Path $war)) {
-    # Same runtime build winget's Microsoft.WindowsAppRuntime.1.8 (1.8.9) installs: 8000.879.2017.0.
-    Write-Host 'Downloading Windows App Runtime 1.8 installer...'
-    Invoke-WebRequest 'https://aka.ms/windowsappsdk/1.8/1.8.260529003/windowsappruntimeinstall-x64.exe' -OutFile $war -MaximumRedirection 10
-}
+Remove-Item `
+    (Join-Path $WorkDir 'sandbox-result.txt'), `
+    (Join-Path $WorkDir 'welcome.png'), `
+    (Join-Path $WorkDir 'after-onboarding.png'), `
+    (Join-Path $WorkDir 'smoke.cer') `
+    -ErrorAction SilentlyContinue
 
 # --- Package ---
 $msixPath = Join-Path $WorkDir $msixName
@@ -69,7 +64,7 @@ if ($Source -eq 'Release') {
     gh release download "v$Version-windows" --repo jamesmontemagno/tiny-clips --pattern $msixName --dir $WorkDir --clobber
     if ($LASTEXITCODE -ne 0) { throw 'gh release download failed.' }
 } else {
-    Write-Host "Building framework-dependent x64 MSIX $Version from the working tree..."
+    Write-Host "Building NativeAOT self-contained x64 MSIX $Version from the working tree..."
     $packageDir = Join-Path $WorkDir 'build'
     Remove-Item $packageDir -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Force $packageDir | Out-Null
@@ -77,8 +72,11 @@ if ($Source -eq 'Release') {
     try {
         $text = [Text.Encoding]::UTF8.GetString($manifestBackup)
         [IO.File]::WriteAllText($manifestPath, ($text -creplace '(<Identity[\s\S]*?Version=")[^"]+(")', "`${1}$Version.0`${2}"), (New-Object Text.UTF8Encoding $true))
+        $vswhereDirectory = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer'
+        $env:PATH = "$vswhereDirectory;$env:PATH"
         dotnet build $appProject -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64 `
-            -p:SelfContained=false -p:WindowsAppSDKSelfContained=false -p:PublishTrimmed=false `
+            -p:TinyClipsDirectReleaseBuild=true -p:PublishAot=true -p:SelfContained=true `
+            -p:WindowsAppSDKSelfContained=true -p:PublishTrimmed=true -p:PublishReadyToRun=false `
             -p:EnableMsixTooling=true -p:GenerateAppxPackageOnBuild=true `
             -p:AppxPackageDir="$packageDir\" -p:AppxBundle=Never -p:UapAppxPackageBuildMode=SideloadOnly `
             -p:AppxPackageSigningEnabled=false -nologo -v minimal
@@ -109,13 +107,7 @@ if ($Source -eq 'Release') {
     }
 }
 
-# Report what the package demands vs. what winget can install.
-$verify = Join-Path $WorkDir 'verify'
-Remove-Item $verify -Recurse -Force -ErrorAction SilentlyContinue
-Copy-Item $msixPath "$msixPath.zip" -Force; Expand-Archive "$msixPath.zip" $verify -Force; Remove-Item "$msixPath.zip"
-$dep = ([xml](Get-Content (Join-Path $verify 'AppxManifest.xml'))).Package.Dependencies.PackageDependency | Where-Object Name -eq 'Microsoft.WindowsAppRuntime.1.8'
-Write-Host "Package requires Microsoft.WindowsAppRuntime.1.8 >= $($dep.MinVersion) (winget 1.8.9 provides 8000.879.2017.0)"
-Remove-Item $verify -Recurse -Force -ErrorAction SilentlyContinue
+& (Join-Path $repo 'windows\packaging\Assert-DirectPackage.ps1') -MsixPath $msixPath -Architecture x64
 
 # --- Sandbox ---
 Copy-Item (Join-Path $PSScriptRoot 'Validate-TinyClips.ps1') (Join-Path $WorkDir 'Validate-TinyClips.ps1') -Force
@@ -126,7 +118,7 @@ $wsb = Join-Path $WorkDir 'TinyClips.wsb'
   <vGPU>Disable</vGPU>
   <AudioInput>Disable</AudioInput>
   <VideoInput>Disable</VideoInput>
-  <Networking>Enable</Networking>
+  <Networking>Disable</Networking>
   <MappedFolders>
     <MappedFolder>
       <HostFolder>$WorkDir</HostFolder>
@@ -140,7 +132,7 @@ $wsb = Join-Path $WorkDir 'TinyClips.wsb'
 </Configuration>
 "@ | Set-Content $wsb -Encoding UTF8
 
-Write-Host "Starting Windows Sandbox (runtime install takes ~8-10 minutes; leave the window alone)..."
+Write-Host "Starting offline Windows Sandbox (leave the window alone)..."
 Start-Process $wsb
 $result = Join-Path $WorkDir 'sandbox-result.txt'
 $deadline = (Get-Date).AddMinutes(20)

--- a/windows/packaging/sandbox/README.md
+++ b/windows/packaging/sandbox/README.md
@@ -5,11 +5,10 @@ one command. Use it before tagging a Windows release and before opening a winget
 
 What it checks, in order:
 
-1. Fresh Windows (Sandbox) with **no** .NET or Windows App SDK runtime.
-2. Installs the .NET 10 Desktop Runtime and the Windows App Runtime 1.8 from their installers —
-   the same runtime build winget's `Microsoft.WindowsAppRuntime.1.8` dependency delivers
-   (`8000.879.2017.0`), so a package whose `MinVersion` is too new fails here too.
-3. Installs the framework-dependent MSIX (`Add-AppxPackage`) and verifies it actually registered.
+1. Fresh Windows (Sandbox), with networking disabled so App Installer cannot acquire dependencies.
+2. Reports whether .NET 10 Desktop Runtime or Windows App Runtime 1.8 happens to be present; it
+   deliberately installs neither.
+3. Validates and installs the NativeAOT self-contained MSIX (`Add-AppxPackage`).
 4. Launches `TinyClips.App.exe` by full path from `C:\Program Files\WindowsApps\…` with an unrelated
    working directory (`C:\Windows\Temp`) — exactly how the winget harness starts the app.
 5. Brings the first-run Welcome window to the foreground and presses Enter three times
@@ -34,20 +33,18 @@ From the repository root:
 
 ```pwsh
 # Validate a published release (Azure-signed, no certificate juggling)
-.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.7.4
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Release -Version 1.8.0
 
 # Validate the current working tree: builds the MSIX with the release recipe and signs it with a
 # throwaway self-signed certificate that only the Sandbox trusts
-.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.7.4
+.\windows\packaging\sandbox\Invoke-SandboxValidation.ps1 -Source Build -Version 1.8.0
 ```
 
-The run takes ~10–12 minutes; almost all of it is the .NET runtime installer (silent, nothing on
-screen). Then the Windows App Runtime installer's console flashes briefly, the Welcome window
-appears, gets clicked through, and the script prints the result:
+The Welcome window appears, gets clicked through, and the script prints the result:
 
 ```
 18:05:28   installed
-18:05:31   Refractored.TinyClips_1.7.4.0_x64__vmshqmcyy894t
+18:05:31   Refractored.TinyClips_1.8.0.0_x64__vmshqmcyy894t
 18:05:32 Launching C:\Program Files\WindowsApps\...\TinyClips.App.exe (cwd C:\Windows\Temp)
 18:05:52 Activating 'Welcome to Tiny Clips' and clicking through onboarding (3x Enter)
 18:06:34 RESULT: PASS - alive after 60s
@@ -58,26 +55,24 @@ Exit code 0 = PASS. Anything else: read `sandbox-result.txt` — a `RESULT: FAIL
 exit code (`0xC000027B` = XAML stowed exception), followed by `crash.log` and the event-log
 stack.
 
-Artifacts land in `%TEMP%\tinyclips-sandbox\` (override with `-WorkDir`). Runtime installers are
-cached there between runs.
+Artifacts land in `%TEMP%\tinyclips-sandbox\` (override with `-WorkDir`).
 
 ## Files
 
 | File | Where it runs | Purpose |
 |---|---|---|
-| `Invoke-SandboxValidation.ps1` | host | Downloads/builds + signs the MSIX, fetches the runtime installers, writes the `.wsb`, starts Sandbox, waits for and prints the result. |
-| `Validate-TinyClips.ps1` | inside Sandbox (LogonCommand) | Installs runtimes + MSIX, launches and drives the app, collects evidence. Reads `config.json` written by the host script. |
+| `Invoke-SandboxValidation.ps1` | host | Downloads or builds + validates + signs the MSIX, writes the offline `.wsb`, starts Sandbox, waits for and prints the result. |
+| `Validate-TinyClips.ps1` | inside Sandbox (LogonCommand) | Installs the MSIX without runtime prerequisites, launches and drives the app, and collects evidence. Reads `config.json` written by the host script. |
 
 ## Gotchas we hit
 
-- **`Add-AppxPackage` can print success while the package never registers.** Seen when the MSIX's
-  `Microsoft.WindowsAppRuntime.1.8` `MinVersion` (set by the `Microsoft.WindowsAppSDK` NuGet version)
-  was newer than the installed runtime. `Validate-TinyClips.ps1` checks `Get-AppxPackage` afterwards
-  and fails loudly. The release workflow also asserts `MinVersion` ≤ what winget ships
-  (`WINGET_WINDOWSAPPRUNTIME_MAX_VERSION` in `windows-release.yml`).
-- **Framework-dependent packages *do* work in Sandbox** as long as the runtimes are installed from
-  their installers first (which this script does). Without them, install fails with `0x80073CF3`
-  because Sandbox has no Store to auto-acquire framework packages.
+- **`Add-AppxPackage` can print success while the package never registers.**
+  `Validate-TinyClips.ps1` checks `Get-AppxPackage` afterwards and fails loudly.
+- **Networking is disabled intentionally.** A framework-dependent regression must fail instead of
+  being masked by App Installer or Store dependency acquisition.
+- **The host validates package structure before starting Sandbox.** This catches the wrong
+  architecture, managed/CLR output, missing bundled Windows App SDK files, a stale
+  `WindowsAppRuntime` framework dependency, or missing registration-free activation metadata.
 - **Sandbox ≠ ARM64.** For ARM64 use the *Windows Launch Smoke* GitHub workflow
   (`windows-11-arm` runner), or a real ARM64 machine with the gist-style test script.
 - Don't hand-edit `Validate-TinyClips.ps1` with regex replacements in a shell: a `$_` in a

--- a/windows/packaging/sandbox/Validate-TinyClips.ps1
+++ b/windows/packaging/sandbox/Validate-TinyClips.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-  Runs INSIDE Windows Sandbox (as the LogonCommand). Installs the .NET Desktop Runtime and the
-  Windows App Runtime, installs the Tiny Clips MSIX, launches it the way winget's validation
-  harness does (full exe path, unrelated working directory), clicks through first-run onboarding,
-  and writes a verdict + crash evidence to C:\share\sandbox-result.txt.
+  Runs INSIDE an offline Windows Sandbox (as the LogonCommand). Installs the self-contained Tiny
+  Clips MSIX without installing .NET or Windows App Runtime, launches it the way winget's
+  validation harness does (full exe path, unrelated working directory), clicks through first-run
+  onboarding, and writes a verdict + crash evidence to C:\share\sandbox-result.txt.
 
   Driven by windows\packaging\sandbox\Invoke-SandboxValidation.ps1 on the host; do not run on a
-  real machine (it installs runtimes machine-wide and trusts a throwaway certificate).
+  real machine (it installs an MSIX and trusts a throwaway certificate).
 #>
 $ErrorActionPreference = 'Continue'
 $share = 'C:\share'
@@ -18,13 +18,10 @@ Remove-Item $log -ErrorAction SilentlyContinue
 Out "Tiny Clips sandbox validation: $($cfg.Msix)"
 Out "OS: $([Environment]::OSVersion.VersionString)  Arch: $env:PROCESSOR_ARCHITECTURE"
 
-Out 'Installing .NET Desktop Runtime (takes ~8 min in Sandbox)...'
-$p = Start-Process "$share\windowsdesktop-runtime.exe" -ArgumentList '/install', '/quiet', '/norestart' -Wait -PassThru
-Out "  exit $($p.ExitCode)"
-Out 'Installing Windows App Runtime 1.8...'
-$p = Start-Process "$share\WindowsAppRuntimeInstall.exe" -ArgumentList '--quiet' -Wait -PassThru
-Out "  exit $($p.ExitCode)"
-Out "  runtime: $((Get-AppxPackage 'Microsoft.WindowsAppRuntime.1.8*' | Select-Object -First 1).Version)"
+$desktopRuntime = Get-ChildItem "$env:ProgramFiles\dotnet\shared\Microsoft.WindowsDesktop.App\10.*" -ErrorAction SilentlyContinue
+$windowsAppRuntime = Get-AppxPackage 'Microsoft.WindowsAppRuntime.1.8*'
+Out "Preinstalled .NET 10 Desktop Runtime: $(if ($desktopRuntime) { 'yes' } else { 'no' })"
+Out "Preinstalled Windows App Runtime 1.8: $(if ($windowsAppRuntime) { 'yes' } else { 'no' })"
 
 if (Test-Path "$share\smoke.cer") {
     Import-Certificate -FilePath "$share\smoke.cer" -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null

--- a/windows/packaging/winget/Refractored.TinyClips.installer.yaml
+++ b/windows/packaging/winget/Refractored.TinyClips.installer.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
-# Installer manifest for the signed, framework-dependent MSIX produced by `winapp pack`.
-# The package does not bundle the .NET or Windows App SDK runtimes; they are declared below
-# as winget package dependencies so winget installs them before the app. Do not set Scope:
-# the dependency installers are machine-scope/unknown scope, and forcing user scope makes
-# winget reject them during validation.
+# Installer manifest for the signed, NativeAOT self-contained MSIX produced by the Windows
+# Release workflow. The package bundles .NET native code and Windows App SDK, so no runtime
+# package dependencies are required.
 # Fill in InstallerUrl + InstallerSha256 after publishing a signed release asset.
 # SignatureSha256 is required for msix installers (the package signature hash):
 #   winget hash --msix <path-to-msix>
@@ -15,10 +13,6 @@ InstallModes:
   - silent
   - silentWithProgress
 PackageFamilyName: Refractored.TinyClips_vmshqmcyy894t
-Dependencies:
-  PackageDependencies:
-    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
-    - PackageIdentifier: Microsoft.WindowsAppRuntime.1.8
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/jamesmontemagno/tiny-clips/releases/download/v1.0.0-windows/TinyClips-1.0.0-x64.msix

--- a/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
+++ b/windows/src/TinyClips.App/Controls/Settings/VideoSettingsSection.xaml
@@ -7,6 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:TinyClips.App.Settings.Sections"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:services="using:TinyClips.Core.Services"
     xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
 
@@ -80,11 +81,16 @@
                                 <ComboBox
                                     AutomationProperties.AutomationId="MicrophoneDeviceCombo"
                                     AutomationProperties.Name="Microphone device"
-                                    DisplayMemberPath="Name"
                                     IsEnabled="{x:Bind ViewModel.MicrophoneSelectorEnabled, Mode=OneWay}"
                                     ItemsSource="{x:Bind ViewModel.Microphones, Mode=OneWay}"
                                     SelectedItem="{x:Bind ViewModel.SelectedMicrophone, Mode=TwoWay}"
-                                    Visibility="{x:Bind ViewModel.MicrophoneSelectorVisibility, Mode=OneWay}" />
+                                    Visibility="{x:Bind ViewModel.MicrophoneSelectorVisibility, Mode=OneWay}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="services:AudioInputDevice">
+                                            <TextBlock Text="{x:Bind Name}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
                             </Grid>
                         </controls:SettingsCard>
                         <controls:SettingsCard ContentAlignment="Left">
@@ -158,11 +164,16 @@
                         MinWidth="220"
                         AutomationProperties.AutomationId="WebcamDeviceCombo"
                         AutomationProperties.Name="Webcam device"
-                        DisplayMemberPath="Name"
                         IsEnabled="{x:Bind ViewModel.WebcamDeviceSelectorEnabled, Mode=OneWay}"
                         ItemsSource="{x:Bind ViewModel.Webcams, Mode=OneWay}"
                         SelectedItem="{x:Bind ViewModel.SelectedWebcam, Mode=TwoWay}"
-                        Visibility="{x:Bind ViewModel.WebcamSelectorVisibility, Mode=OneWay}" />
+                        Visibility="{x:Bind ViewModel.WebcamSelectorVisibility, Mode=OneWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="services:WebcamDeviceInfo">
+                                <TextBlock Text="{x:Bind Name}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
                 </Grid>
                 <controls:SettingsExpander.Items>
                     <controls:SettingsCard ContentAlignment="Left">

--- a/windows/src/TinyClips.App/Services/ClipsLibrary/ShareService.cs
+++ b/windows/src/TinyClips.App/Services/ClipsLibrary/ShareService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 
@@ -9,7 +10,7 @@ namespace TinyClips.App.Services.ClipsLibrary;
 /// Windows Share contract + drag-out payloads for clips. Share requires the window's HWND via the
 /// <c>IDataTransferManagerInterop</c> COM interface on WinUI 3 desktop.
 /// </summary>
-internal static class ShareService
+internal static partial class ShareService
 {
     private static readonly Guid DataTransferManagerIid = new("A5CAEE9B-8708-49D1-8D36-67D25A8DA00C");
 
@@ -24,7 +25,7 @@ internal static class ShareService
         {
             var interop = DataTransferManager.As<IDataTransferManagerInterop>();
             var iid = DataTransferManagerIid;
-            var manager = DataTransferManager.FromAbi(interop.GetForWindow(hwnd, ref iid));
+            var manager = DataTransferManager.FromAbi(interop.GetForWindow(hwnd, in iid));
 
             async void OnDataRequested(DataTransferManager sender, DataRequestedEventArgs args)
             {
@@ -100,12 +101,12 @@ internal static class ShareService
         });
     }
 
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("3A3DCD6C-3EAB-43DC-BCDE-45671CE800C8")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    private interface IDataTransferManagerInterop
+    internal partial interface IDataTransferManagerInterop
     {
-        nint GetForWindow([In] nint appWindow, [In] ref Guid riid);
+        nint GetForWindow(nint appWindow, in Guid riid);
 
         void ShowShareUIForWindow(nint appWindow);
     }

--- a/windows/src/TinyClips.App/TinyClips.App.csproj
+++ b/windows/src/TinyClips.App/TinyClips.App.csproj
@@ -14,6 +14,7 @@
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!--
@@ -32,10 +33,24 @@
       - true: Microsoft Store distribution
     -->
     <TinyClipsStoreBuild Condition="'$(TinyClipsStoreBuild)' == ''">false</TinyClipsStoreBuild>
+    <!-- Enables the NativeAOT, .NET self-contained, and Windows App SDK self-contained direct release profile. -->
+    <TinyClipsDirectReleaseBuild Condition="'$(TinyClipsDirectReleaseBuild)' == ''">false</TinyClipsDirectReleaseBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TinyClipsStoreBuild)' == 'true'">
     <DefineConstants>$(DefineConstants);TINYCLIPS_STORE_BUILD</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TinyClipsDirectReleaseBuild)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL3050</WarningsAsErrors>
+    <MSBuildWarningsAsErrors>$(MSBuildWarningsAsErrors);WMC1510</MSBuildWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TinyClipsStoreBuild)' == 'true'">
@@ -81,10 +96,8 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
     <!--
-      Pinned: the MSIX's WindowsAppRuntime MinVersion follows this SDK version, and winget's
-      Microsoft.WindowsAppRuntime.1.8 package (our declared dependency) currently tops out at the
-      runtime built from 1.8.260529003 (8000.879.2017.0). Newer 1.8 SDKs raise MinVersion above
-      what winget can install. Bump only after winget-pkgs ships the matching runtime version.
+      Keep the SDK version deliberate: direct releases bundle this Windows App SDK runtime,
+      while Store builds remain framework-dependent and must be validated separately.
     -->
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260529003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.1" />
@@ -112,8 +125,8 @@
   <PropertyGroup>
     <!--
       ReadyToRun pre-compiles IL so the first capture after launch doesn't pay JIT cost for every
-      overlay window type. It applies to `dotnet publish` and to the MSIX packaging path (the
-      packaging targets run the publish pipeline), so Release MSIX payloads ship R2R images.
+      overlay window type in ordinary Release builds. Direct release packages use NativeAOT
+      instead and explicitly disable ReadyToRun above.
     -->
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release'">True</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(PublishReadyToRun)' == ''">False</PublishReadyToRun>
@@ -124,4 +137,10 @@
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">False</PublishTrimmed>
   </PropertyGroup>
+
+  <Target Name="ValidateTinyClipsReleaseFlavor" BeforeTargets="PrepareForBuild">
+    <Error
+      Condition="'$(TinyClipsDirectReleaseBuild)' == 'true' and '$(TinyClipsStoreBuild)' == 'true'"
+      Text="TinyClipsDirectReleaseBuild and TinyClipsStoreBuild are mutually exclusive." />
+  </Target>
 </Project>

--- a/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml
@@ -2,7 +2,8 @@
 <Window
     x:Class="TinyClips.App.ScreenPickerWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TinyClips.App">
 
     <Window.SystemBackdrop>
         <DesktopAcrylicBackdrop />
@@ -24,7 +25,7 @@
                     ItemClick="OnScreenClick"
                     SelectionMode="None">
                     <GridView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="local:ScreenPickerItem">
                             <Border
                                 Width="200"
                                 Height="130"
@@ -45,12 +46,12 @@
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                                        Text="{Binding Title}" />
+                                        Text="{x:Bind Title}" />
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
-                                        Text="{Binding Subtitle}" />
+                                        Text="{x:Bind Subtitle}" />
                                 </StackPanel>
                             </Border>
                         </DataTemplate>

--- a/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ScreenPickerWindow.xaml.cs
@@ -6,13 +6,14 @@ using Windows.Graphics;
 
 namespace TinyClips.App;
 
+public sealed record ScreenPickerItem(MonitorInfo Monitor, string Title, string Subtitle);
+
 /// <summary>
 /// A centered overlay that lets the user pick which physical display to capture when
 /// more than one monitor is present. Resolves with the chosen monitor, or null on cancel.
 /// </summary>
 public sealed partial class ScreenPickerWindow : Window
 {
-    private sealed record ScreenItem(MonitorInfo Monitor, string Title, string Subtitle);
     private const int CornerRadiusDip = 8;
 
     private readonly TaskCompletionSource<MonitorInfo?> _result = new();
@@ -28,12 +29,12 @@ public sealed partial class ScreenPickerWindow : Window
         ConfigurePresenter();
         Activated += OnActivated;
 
-        var items = new List<ScreenItem>();
+        var items = new List<ScreenPickerItem>();
         for (var i = 0; i < monitors.Count; i++)
         {
             var m = monitors[i];
             var title = m.IsPrimary ? $"Display {i + 1} (Primary)" : $"Display {i + 1}";
-            items.Add(new ScreenItem(m, title, $"{m.Width} × {m.Height}"));
+            items.Add(new ScreenPickerItem(m, title, $"{m.Width} × {m.Height}"));
         }
 
         ScreenList.ItemsSource = items;
@@ -49,7 +50,7 @@ public sealed partial class ScreenPickerWindow : Window
 
     private void OnScreenClick(object sender, ItemClickEventArgs e)
     {
-        if (e.ClickedItem is ScreenItem item)
+        if (e.ClickedItem is ScreenPickerItem item)
         {
             Complete(item.Monitor);
         }

--- a/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml
+++ b/windows/src/TinyClips.App/Views/WindowPickerWindow.xaml
@@ -2,7 +2,8 @@
 <Window
     x:Class="TinyClips.App.WindowPickerWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TinyClips.App">
 
     <Window.SystemBackdrop>
         <DesktopAcrylicBackdrop />
@@ -35,7 +36,7 @@
                     ItemClick="OnWindowClick"
                     SelectionMode="None">
                     <ListView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="local:WindowEntry">
                             <StackPanel
                                 Padding="4,8"
                                 Orientation="Horizontal"
@@ -50,7 +51,7 @@
                                     VerticalAlignment="Center"
                                     MaxWidth="340"
                                     TextTrimming="CharacterEllipsis"
-                                    Text="{Binding Title}" />
+                                    Text="{x:Bind Title}" />
                             </StackPanel>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/windows/src/TinyClips.Core/Capture/IWebcamCaptureService.cs
+++ b/windows/src/TinyClips.Core/Capture/IWebcamCaptureService.cs
@@ -1,7 +1,5 @@
 using Windows.Graphics.Imaging;
-
 using Windows.Graphics.DirectX.Direct3D11;
-using Windows.Graphics.Imaging;
 
 namespace TinyClips.Core.Capture;
 

--- a/windows/src/TinyClips.Core/Services/ClipAnalyticsService.cs
+++ b/windows/src/TinyClips.Core/Services/ClipAnalyticsService.cs
@@ -1,10 +1,11 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Globalization;
 using TinyClips.Core.Models;
 
 namespace TinyClips.Core.Services;
 
-public sealed class ClipAnalyticsService : IClipAnalyticsService
+public sealed partial class ClipAnalyticsService : IClipAnalyticsService
 {
     private const string StorageKey = "captureAnalyticsHistoryV1";
     private const string LifetimeStorageKey = "captureAnalyticsLifetimeV1";
@@ -14,8 +15,6 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
     private readonly ISettingsService _settings;
     private readonly TimeProvider _timeProvider;
     private readonly object _gate = new();
-    private readonly JsonSerializerOptions _serializerOptions = new(JsonSerializerDefaults.Web);
-
     private Dictionary<string, DailyCountsState> _history;
     private LifetimeCountsState _lifetime;
     private Dictionary<int, int> _hourly;
@@ -167,7 +166,7 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
 
         try
         {
-            return JsonSerializer.Deserialize<Dictionary<string, DailyCountsState>>(raw, _serializerOptions)
+            return JsonSerializer.Deserialize(raw, AnalyticsJsonContext.Default.DictionaryStringDailyCountsState)
                 ?? new Dictionary<string, DailyCountsState>(StringComparer.Ordinal);
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
@@ -186,7 +185,7 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
 
         try
         {
-            return JsonSerializer.Deserialize<LifetimeCountsState>(raw, _serializerOptions)
+            return JsonSerializer.Deserialize(raw, AnalyticsJsonContext.Default.LifetimeCountsState)
                 ?? new LifetimeCountsState();
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
@@ -205,7 +204,7 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
 
         try
         {
-            return JsonSerializer.Deserialize<Dictionary<int, int>>(raw, _serializerOptions)
+            return JsonSerializer.Deserialize(raw, AnalyticsJsonContext.Default.DictionaryInt32Int32)
                 ?? new Dictionary<int, int>();
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
@@ -245,13 +244,13 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
 
     private void PersistInternal()
     {
-        var raw = JsonSerializer.Serialize(_history, _serializerOptions);
+        var raw = JsonSerializer.Serialize(_history, AnalyticsJsonContext.Default.DictionaryStringDailyCountsState);
         _settings.Set(StorageKey, raw);
 
-        var lifetimeRaw = JsonSerializer.Serialize(_lifetime, _serializerOptions);
+        var lifetimeRaw = JsonSerializer.Serialize(_lifetime, AnalyticsJsonContext.Default.LifetimeCountsState);
         _settings.Set(LifetimeStorageKey, lifetimeRaw);
 
-        var hourlyRaw = JsonSerializer.Serialize(_hourly, _serializerOptions);
+        var hourlyRaw = JsonSerializer.Serialize(_hourly, AnalyticsJsonContext.Default.DictionaryInt32Int32);
         _settings.Set(HourlyStorageKey, hourlyRaw);
     }
 
@@ -270,4 +269,10 @@ public sealed class ClipAnalyticsService : IClipAnalyticsService
         public int VideoCount { get; set; }
         public int GifCount { get; set; }
     }
+
+    [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+    [JsonSerializable(typeof(Dictionary<string, DailyCountsState>))]
+    [JsonSerializable(typeof(LifetimeCountsState))]
+    [JsonSerializable(typeof(Dictionary<int, int>))]
+    private sealed partial class AnalyticsJsonContext : JsonSerializerContext;
 }

--- a/windows/src/TinyClips.Core/Services/ClipsLibrary/JsonClipMetadataStore.cs
+++ b/windows/src/TinyClips.Core/Services/ClipsLibrary/JsonClipMetadataStore.cs
@@ -10,14 +10,8 @@ namespace TinyClips.Core.Services.ClipsLibrary;
 /// writes with a short debounce, and replaces the file atomically so a crash mid-write never
 /// leaves a truncated index behind.
 /// </summary>
-public sealed class JsonClipMetadataStore : IClipMetadataStore, IDisposable
+public sealed partial class JsonClipMetadataStore : IClipMetadataStore, IDisposable
 {
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private readonly string _filePath;
     private readonly TimeSpan _debounce;
     private readonly TimeProvider _timeProvider;
@@ -166,7 +160,9 @@ public sealed class JsonClipMetadataStore : IClipMetadataStore, IDisposable
             }
 
             var temporaryPath = _filePath + ".tmp";
-            File.WriteAllText(temporaryPath, JsonSerializer.Serialize(new MetadataFile(1, snapshot), SerializerOptions));
+            File.WriteAllText(
+                temporaryPath,
+                JsonSerializer.Serialize(new MetadataFile(1, snapshot), ClipMetadataJsonContext.Default.MetadataFile));
             File.Move(temporaryPath, _filePath, overwrite: true);
         }
         catch (Exception ex)
@@ -203,7 +199,9 @@ public sealed class JsonClipMetadataStore : IClipMetadataStore, IDisposable
                 return records;
             }
 
-            var file = JsonSerializer.Deserialize<MetadataFile>(File.ReadAllText(_filePath), SerializerOptions);
+            var file = JsonSerializer.Deserialize(
+                File.ReadAllText(_filePath),
+                ClipMetadataJsonContext.Default.MetadataFile);
             foreach (var record in file?.Clips ?? [])
             {
                 if (!string.IsNullOrWhiteSpace(record.Path) && !record.IsEmpty)
@@ -224,4 +222,10 @@ public sealed class JsonClipMetadataStore : IClipMetadataStore, IDisposable
         Path.GetFullPath(path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
 
     private sealed record MetadataFile(int Version, List<ClipMetadata> Clips);
+
+    [JsonSourceGenerationOptions(
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(MetadataFile))]
+    private sealed partial class ClipMetadataJsonContext : JsonSerializerContext;
 }

--- a/windows/src/TinyClips.Core/Services/GitHubReleaseUpdateService.cs
+++ b/windows/src/TinyClips.Core/Services/GitHubReleaseUpdateService.cs
@@ -4,13 +4,8 @@ using System.Text.Json.Serialization;
 
 namespace TinyClips.Core.Services;
 
-public sealed class GitHubReleaseUpdateService : IAppUpdateService
+public sealed partial class GitHubReleaseUpdateService : IAppUpdateService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     private readonly HttpClient _httpClient;
     private readonly string _releasesApiUrl;
 
@@ -43,7 +38,10 @@ public sealed class GitHubReleaseUpdateService : IAppUpdateService
             }
 
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            var releases = await JsonSerializer.DeserializeAsync<List<GitHubRelease>>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+            var releases = await JsonSerializer.DeserializeAsync(
+                stream,
+                GitHubReleaseJsonContext.Default.ListGitHubRelease,
+                cancellationToken).ConfigureAwait(false);
             if (releases is null || releases.Count == 0)
             {
                 return Save(AppUpdateCheckResult.Failed(currentVersion, "No releases were returned."));
@@ -165,4 +163,8 @@ public sealed class GitHubReleaseUpdateService : IAppUpdateService
         [JsonPropertyName("prerelease")]
         public bool PreRelease { get; init; }
     }
+
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+    [JsonSerializable(typeof(List<GitHubRelease>))]
+    private sealed partial class GitHubReleaseJsonContext : JsonSerializerContext;
 }

--- a/windows/src/TinyClips.Core/Services/RecentCaptureService.cs
+++ b/windows/src/TinyClips.Core/Services/RecentCaptureService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using TinyClips.Core.Models;
 
 namespace TinyClips.Core.Services;
@@ -12,7 +13,7 @@ public interface IRecentCaptureService
     void Remove(string path);
 }
 
-public sealed class RecentCaptureService : IRecentCaptureService
+public sealed partial class RecentCaptureService : IRecentCaptureService
 {
     private const string SettingsKey = "recentCapturesV1";
     private const int MaximumCount = 10;
@@ -83,7 +84,7 @@ public sealed class RecentCaptureService : IRecentCaptureService
 
         try
         {
-            return JsonSerializer.Deserialize<List<RecentCapture>>(json) ?? [];
+            return JsonSerializer.Deserialize(json, RecentCaptureJsonContext.Default.ListRecentCapture) ?? [];
         }
         catch (JsonException)
         {
@@ -91,5 +92,9 @@ public sealed class RecentCaptureService : IRecentCaptureService
         }
     }
 
-    private void Persist() => _settings.Set(SettingsKey, JsonSerializer.Serialize(_captures));
+    private void Persist() =>
+        _settings.Set(SettingsKey, JsonSerializer.Serialize(_captures, RecentCaptureJsonContext.Default.ListRecentCapture));
+
+    [JsonSerializable(typeof(List<RecentCapture>))]
+    private sealed partial class RecentCaptureJsonContext : JsonSerializerContext;
 }


### PR DESCRIPTION
## Summary

- compile the direct x64 and ARM64 GitHub Release/winget MSIX packages with .NET 10 NativeAOT (`PublishAot`, `SelfContained`, and trimming)
- bundle the Windows App SDK/WinUI runtime with `WindowsAppSDKSelfContained`, removing clean-machine .NET Desktop Runtime and Windows App Runtime prerequisites
- keep the Microsoft Store profile explicitly framework-dependent and non-AOT
- make app-owned JSON, COM, and XAML paths trimming/AOT-safe and add package-structure regression checks

This is an independent PR rebased directly on current `main` (`744cce2`); it does not include or depend on #325's auto-update changes.

## Runtime and distribution scope

Direct GitHub Release and winget packages now contain an architecture-specific native `TinyClips.App.exe`, reachable .NET code compiled by NativeAOT, `Microsoft.WindowsAppRuntime.dll`, `Microsoft.UI.Xaml.dll`, and the rest of the Windows App SDK self-contained payload. They contain no managed `TinyClips.App.dll`, CLR/JIT/runtime-host binaries, or `Microsoft.WindowsAppRuntime` framework dependency.

The Microsoft Store build remains `PublishAot=false`, `SelfContained=false`, and `WindowsAppSDKSelfContained=false`. Its package keeps the Store identity and Windows App Runtime framework dependency so Store acquisition/certification behavior does not change. Direct and Store profiles are mutually exclusive at build time.

## Regression protection

`Assert-DirectPackage.ps1` unpacks each candidate and checks:

- manifest and native PE architecture (`AMD64`/`ARM64`)
- native entry point and absence of a CLR header
- absence of the managed app DLL, CLR/JIT, and .NET host files
- bundled Windows App SDK and WinUI runtime DLLs
- absence of a Windows App Runtime framework dependency
- embedded registration-free WinRT activation metadata

The release, PR build, launch-smoke, and winget submission workflows run these assertions. The offline Windows Sandbox harness no longer installs runtime prerequisites, and winget manifests no longer declare them.

## Size tradeoff

| Package | Compressed | Expanded |
|---|---:|---:|
| x64 NativeAOT self-contained | 50.90 MiB | 126.43 MiB |
| x64 same-source framework-dependent baseline | 22.42 MiB | 72.12 MiB |
| ARM64 NativeAOT self-contained | 48.72 MiB | 130.53 MiB |

The x64 download grows by 28.48 MiB (2.27x). Most of the increase is the Windows App SDK self-contained payload, which includes optional runtime components; NativeAOT itself removes CLR/JIT deployment.

## Validation

- direct x64 Release NativeAOT MSIX build and package assertions
- direct ARM64 Release NativeAOT cross-build and package assertions
- exact framework-dependent Microsoft Store x64 + ARM64 `.msixupload` bundle build
- Store package inspection confirmed managed payload and `Microsoft.WindowsAppRuntime.1.8` framework dependency
- x64 NativeAOT payload registered as a Developer Mode loose package; its packaged executable ran for 64 seconds with no relevant Application Error, .NET Runtime, or Windows Error Reporting events
- Debug x64 app build with zero warnings/errors
- 227 TinyClips.Core tests passed
- modified PowerShell scripts and all workflow run blocks parsed successfully
- modified workflow YAML parsed successfully
- high-confidence WinUI and full-diff code review found no issues

## Caveats

Vortice/SharpGen 3.8.3 (the latest available version and marked AOT-compatible) still emits upstream `IL2067` and `IL2072` reflection-analysis warnings from `SharpGen.Runtime.TypeDataStorage`; these remain visible and are not broadly suppressed. App-owned `IL2026`, `IL3050`, and XAML `WMC1510` regressions are promoted to errors for the direct profile.

Windows Sandbox is not installed on the development host. A normal signed-MSIX install could not be completed unattended because the non-elevated session cannot trust a temporary signing root; unsigned packages with executable activations are rejected by Windows. The Developer Mode loose-package launch proves packaged activation/runtime startup but is not equivalent to installing the signed release MSIX, and this host already has both runtimes installed. The updated launch-smoke workflow is therefore still the clean x64/ARM64 install-and-launch evidence and deliberately installs neither runtime. No startup-time comparison is claimed.