### PR TITLE
Fix screenshot editor emoji field command routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - **Clips Manager UI review.** Double-clicking a clip now opens the editor/trimmer (Show in Finder stays on hover and in the context menu); the empty state distinguishes "No clips yet" (with Open Save Folder) from "No clips match your filters" (with Clear Filters); the Clear Filters toolbar button also resets search, collection and smart-collection selections; the sidebar is wider (170–280 pt) so section titles and counts don't truncate; video thumbnails are generated at 2× for Retina displays; search placeholder explains what is searched.
 - macOS screenshot editor now supports the standard ⌘W shortcut (File > Close) to close the Edit Screenshot window, with the same unsaved-changes confirmation you get when pressing Escape. The restored Close menu item also works for other app windows such as the Clips Manager.
 ### Fixed
+- Fixed macOS screenshot editor keyboard commands while the custom emoji field is focused, so Cut, Copy, Paste, Undo, and Redo target the field instead of the annotation canvas.
 - Fixed macOS "Window" screenshot mode not highlighting or capturing windows on secondary displays. The picker overlay on each non-primary display was offset twice, so it never covered that display and clicks fell through to the app underneath.
 
 ## v1.7.1.0-mac - 2026-08-24

--- a/mac/TinyClips/Views/ScreenshotEditorControls.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorControls.swift
@@ -56,6 +56,7 @@ struct ArrowStyleButton: View {
 struct EmojiPickerView: View {
     let selectedEmoji: String
     let recentEmoji: [String]
+    @Binding var isTextEntryFocused: Bool
     let onSelect: (String) -> Void
 
     @State private var customEntry = ""
@@ -76,6 +77,9 @@ struct EmojiPickerView: View {
                 TextField("Type or paste", text: $customEntry)
                     .textFieldStyle(.roundedBorder)
                     .focused($isEntryFocused)
+                    .onChange(of: isEntryFocused) { _, isFocused in
+                        isTextEntryFocused = isFocused
+                    }
                     .onChange(of: customEntry) { _, newValue in
                         guard let emoji = EmojiAnnotationMath.emoji(from: newValue) else { return }
                         onSelect(emoji)
@@ -101,6 +105,9 @@ struct EmojiPickerView: View {
             }
 
             emojiSection("Common", emoji: EmojiPalette.common)
+        }
+        .onDisappear {
+            isTextEntryFocused = false
         }
     }
 

--- a/mac/TinyClips/Views/ScreenshotEditorWindow.swift
+++ b/mac/TinyClips/Views/ScreenshotEditorWindow.swift
@@ -393,6 +393,7 @@ struct ScreenshotEditorView: View {
     @State private var zoomScale: CGFloat = 1
     @State private var panOffset: CGSize = .zero
     @State private var viewportSize: CGSize = .zero
+    @State private var isEmojiTextEntryFocused = false
 
     init(
         imageURL: URL,
@@ -567,7 +568,7 @@ struct ScreenshotEditorView: View {
                         )
 
                         ScreenshotEditorViewportEventMonitor(
-                            isEnabled: !viewModel.isEditingText,
+                            isEnabled: !isTextInputActive,
                             onZoom: { multiplier, focalPoint in
                                 setZoom(zoomScale * multiplier, focalPoint: focalPoint)
                             },
@@ -621,9 +622,9 @@ struct ScreenshotEditorView: View {
                 canRedo: viewModel.canRedo,
                 hasAnnotations: viewModel.hasAnnotations,
                 canApplyCrop: viewModel.canApplyCrop,
-                isEditingText: viewModel.isEditingText,
-                canZoomIn: !viewModel.isEditingText && zoomScale < ScreenshotEditorZoomMath.maximumScale,
-                canZoomOut: !viewModel.isEditingText && zoomScale > ScreenshotEditorZoomMath.minimumScale
+                isEditingText: isTextInputActive,
+                canZoomIn: !isTextInputActive && zoomScale < ScreenshotEditorZoomMath.maximumScale,
+                canZoomOut: !isTextInputActive && zoomScale > ScreenshotEditorZoomMath.minimumScale
             )
         )
         .onExitCommand {
@@ -881,7 +882,8 @@ struct ScreenshotEditorView: View {
             if viewModel.showsEmojiPicker {
                 EmojiPickerView(
                     selectedEmoji: viewModel.selectedEmojiValue() ?? viewModel.selectedEmoji,
-                    recentEmoji: viewModel.recentEmoji
+                    recentEmoji: viewModel.recentEmoji,
+                    isTextEntryFocused: $isEmojiTextEntryFocused
                 ) { emoji in
                     viewModel.chooseEmoji(emoji)
                 }
@@ -1126,7 +1128,7 @@ struct ScreenshotEditorView: View {
     }
 
     private func zoomIn() {
-        guard !viewModel.isEditingText else { return }
+        guard !isTextInputActive else { return }
         setZoom(ScreenshotEditorZoomMath.steppedScale(from: zoomScale, direction: 1))
     }
 
@@ -1136,8 +1138,12 @@ struct ScreenshotEditorView: View {
     }
 
     private func zoomOut() {
-        guard !viewModel.isEditingText else { return }
+        guard !isTextInputActive else { return }
         setZoom(ScreenshotEditorZoomMath.steppedScale(from: zoomScale, direction: -1))
+    }
+
+    private var isTextInputActive: Bool {
+        viewModel.isEditingText || isEmojiTextEntryFocused
     }
 
     private func fitZoom() {


### PR DESCRIPTION
## Summary
- route Cut, Copy, Paste, Undo, and Redo to the custom emoji field while it is focused
- prevent canvas zoom and input handling from intercepting commands during emoji entry
- clear the shared focus state when the emoji picker closes

## Validation
- `xcodebuild test` with the `TinyClips` scheme (57 tests)
- `xcodebuild build` with the `TinyClips` scheme
- `xcodebuild build` with the `TinyClipsMAS` scheme

Follow-up to the unresolved review comment on #326; the original PR merged before this fix was pushed.