### PR TITLE
Fix webcam overlay shape, processing popup, and trimmer scrubbing (Windows)

### DIFF
--- a/windows/CHANGELOG.md
+++ b/windows/CHANGELOG.md
@@ -5,6 +5,30 @@ own `CHANGELOG.md` at the repository root.
 
 ## [Unreleased]
 
+### Fixed
+- **Webcam picker preview is the right shape.** The live thumbnail next to the webcam toggle in
+  the recording setup bar was always 96×54, so choosing *Circle* rendered it as an oval. It now
+  becomes a square for Circle and keeps the 16:9 footprint for the rectangle shapes, and its
+  border is no longer clipped along the bottom edge.
+- **No more grey box around the circular webcam overlay while recording.** The floating webcam
+  preview drew an opaque window rectangle behind its rounded surface, plus the DWM window
+  hairline. The overlay window now uses a transparent backdrop, clears its DWM border and
+  rounded-corner treatment, and is clipped by a native region matching the selected shape
+  (elliptic for Circle, rounded-rect otherwise). The recording itself was never affected.
+- **The circular webcam overlay is actually circular.** The preview surface drew its shape with a
+  stretched `Rectangle`, which applies its corner radii to the pre-stretch geometry and so can
+  never render a true circle; Circle now uses a real `Ellipse`. The overlay also squares up its
+  window if Windows' minimum tracking size makes the requested size non-square, and insets the
+  shape slightly so the window region's hard, non-anti-aliased edge doesn't cut the smooth curve.
+- **Processing popup polish.** The "Processing…" panel shown after stopping a recording is now
+  clipped to its rounded corners (the acrylic backdrop no longer shows as a square frame), the
+  card fills the panel instead of floating inside it, and it positions just above/below the
+  recorded region like the recording panel does.
+- **Scrubbing in the video and GIF trimmers.** Clicking or dragging anywhere on the trim track now
+  moves the playhead. Previously a press inside the selected range dragged the whole range, and
+  since the range spans the whole clip by default there was no way to scrub. Hold **Shift** while
+  dragging inside the selection to move the range as a whole.
+
 ## [v1.7.5-windows] - 2026-08-27
 
 ### Added

--- a/windows/src/TinyClips.App/Controls/RecordingSetup/WebcamOptionsControl.xaml.cs
+++ b/windows/src/TinyClips.App/Controls/RecordingSetup/WebcamOptionsControl.xaml.cs
@@ -28,6 +28,8 @@ namespace TinyClips.App.RecordingSetup;
 public sealed partial class WebcamOptionsControl : UserControl
 {
     private static readonly double[] CornerRadiusOptions = { -1d, 8d, 12d, 16d, 24d, 32d, 48d };
+    private const double SetupPreviewHeight = 54;
+    private const double SetupPreviewWideWidth = 96;
 
     private readonly List<WebcamDeviceInfo> _webcams = new();
     private readonly List<ToggleMenuFlyoutItem> _cameraItems = new();
@@ -136,6 +138,7 @@ public sealed partial class WebcamOptionsControl : UserControl
 
         UpdateWebcamVisual();
         UpdateWebcamSettingsEnabled();
+        UpdateSetupPreviewShape();
         UpdateCameraSelectionVisuals();
         UpdateShapeSelectionVisuals();
         UpdateCornerSelectionVisuals();
@@ -291,7 +294,7 @@ public sealed partial class WebcamOptionsControl : UserControl
         if (sender is ToggleMenuFlyoutItem { Tag: WebcamShape shape })
         {
             _webcamShape = shape;
-            SetupPreview.ConfigureShape(_webcamShape, WebcamCornerRadiusOrNull);
+            UpdateSetupPreviewShape();
             UpdateShapeSelectionVisuals();
             UpdateRadiusMenuEnabled();
             UpdateWebcamSettingsSummary();
@@ -339,7 +342,7 @@ public sealed partial class WebcamOptionsControl : UserControl
         if (sender is ToggleMenuFlyoutItem { Tag: double radius })
         {
             _webcamCornerRadius = radius;
-            SetupPreview.ConfigureShape(_webcamShape, WebcamCornerRadiusOrNull);
+            UpdateSetupPreviewShape();
             UpdateRadiusSelectionVisuals();
             UpdateWebcamSettingsSummary();
         }
@@ -364,8 +367,18 @@ public sealed partial class WebcamOptionsControl : UserControl
     public void ShowPreview(IWebcamCaptureService capture)
     {
         SetupPreview.Visibility = Visibility.Visible;
-        SetupPreview.ConfigureShape(_webcamShape, WebcamCornerRadiusOrNull);
+        UpdateSetupPreviewShape();
         SetupPreview.Attach(capture);
+    }
+
+    /// <summary>Keeps the setup preview's footprint in step with the chosen shape: a circle needs a
+    /// square surface (otherwise the rounded corners turn it into an oval), while rectangles keep
+    /// the 16:9 thumbnail footprint.</summary>
+    private void UpdateSetupPreviewShape()
+    {
+        SetupPreview.Width = _webcamShape == WebcamShape.Circle ? SetupPreviewHeight : SetupPreviewWideWidth;
+        SetupPreview.Height = SetupPreviewHeight;
+        SetupPreview.ConfigureShape(_webcamShape, WebcamCornerRadiusOrNull);
     }
 
     public void HidePreview()

--- a/windows/src/TinyClips.App/Controls/TrimBar.xaml
+++ b/windows/src/TinyClips.App/Controls/TrimBar.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    AutomationProperties.HelpText="Use Left and Right Arrow to seek. Use Control plus Left or Right Arrow to adjust the start. Use Shift plus Left or Right Arrow to adjust the end. Use Page Up or Page Down to move the selected range. Use Home or End to seek to the beginning or end."
+    AutomationProperties.HelpText="Click or drag the track to scrub. Drag a handle to change the start or end. Hold Shift and drag inside the selection to move the whole range. Use Left and Right Arrow to seek. Use Control plus Left or Right Arrow to adjust the start. Use Shift plus Left or Right Arrow to adjust the end. Use Page Up or Page Down to move the selected range. Use Home or End to seek to the beginning or end."
     Height="44"
     IsTabStop="True"
     MinWidth="80"

--- a/windows/src/TinyClips.App/Controls/TrimBar.xaml.cs
+++ b/windows/src/TinyClips.App/Controls/TrimBar.xaml.cs
@@ -15,7 +15,9 @@ namespace TinyClips.App;
 /// normalized fractions in the range [0, 1]; the hosting window maps them to seconds or frames.
 /// </summary>
 /// <remarks>
-/// The control raises <see cref="StartFractionChanged"/>, <see cref="EndFractionChanged"/> and
+/// Pointer gestures: drag a handle to change the start/end, click or drag anywhere else on the
+/// track to scrub the playhead, and hold Shift while dragging inside the selection to move the
+/// whole range. The control raises <see cref="StartFractionChanged"/>, <see cref="EndFractionChanged"/> and
 /// <see cref="SeekRequested"/> only in response to direct user input. Assigning the matching
 /// properties (e.g. from the host while clamping) re-lays out without re-raising events, so there
 /// is no feedback loop. User input supports both pointer gestures and keyboard commands.
@@ -191,9 +193,11 @@ public sealed partial class TrimBar : UserControl
             _drag = DragMode.End;
             ApplyDrag(fraction);
         }
-        else if (x > sx && x < ex)
+        else if (x > sx && x < ex && IsKeyDown(VirtualKey.Shift))
         {
-            // Press inside the selected region: drag the whole selection, preserving its width.
+            // Shift+press inside the selected region: drag the whole selection, preserving its
+            // width. A plain press scrubs so the playhead is always reachable (the selection
+            // covers the entire clip by default).
             _drag = DragMode.Range;
             _rangeGrabFraction = fraction;
             _rangeStartAtGrab = _start;
@@ -353,7 +357,7 @@ public sealed partial class TrimBar : UserControl
         {
             ProtectedCursor = SizeCursor;
         }
-        else if (x > sx && x < ex)
+        else if (x > sx && x < ex && IsKeyDown(VirtualKey.Shift))
         {
             ProtectedCursor = MoveCursor;
         }

--- a/windows/src/TinyClips.App/Controls/WebcamPreviewSurface.xaml
+++ b/windows/src/TinyClips.App/Controls/WebcamPreviewSurface.xaml
@@ -4,15 +4,31 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Border
-        x:Name="PreviewBorder"
-        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-        BorderBrush="{ThemeResource TextFillColorPrimaryBrush}"
-        BorderThickness="2"
-        CornerRadius="0">
-        <Image
-            x:Name="PreviewImage"
+    <UserControl.Resources>
+        <!--  One brush instance shared by both shapes, so the frame pump only has to update a
+              single ImageSource regardless of which shape is currently visible.  -->
+        <ImageBrush x:Key="PreviewBrush" Stretch="UniformToFill" />
+    </UserControl.Resources>
+
+    <!--  Two shapes rather than one Rectangle with RadiusX/RadiusY: a stretched Rectangle applies
+          its radii to the pre-stretch geometry, so it never renders a true circle. Shapes are used
+          instead of a Border because a Border whose CornerRadius equals half its height clips the
+          bottom row of its own stroke. Only one shape is visible at a time, and neither has a
+          backing fill behind it — a stroked shape insets its geometry by half the stroke, so
+          anything behind it would peek out as a ring.  -->
+    <Grid>
+        <Ellipse
+            x:Name="CircleShape"
             AutomationProperties.Name="Live webcam preview"
-            Stretch="UniformToFill" />
-    </Border>
+            Fill="{StaticResource PreviewBrush}"
+            Stroke="{ThemeResource TextFillColorPrimaryBrush}"
+            StrokeThickness="2"
+            Visibility="Collapsed" />
+        <Rectangle
+            x:Name="RectangleShape"
+            AutomationProperties.Name="Live webcam preview"
+            Fill="{StaticResource PreviewBrush}"
+            Stroke="{ThemeResource TextFillColorPrimaryBrush}"
+            StrokeThickness="2" />
+    </Grid>
 </UserControl>

--- a/windows/src/TinyClips.App/Controls/WebcamPreviewSurface.xaml.cs
+++ b/windows/src/TinyClips.App/Controls/WebcamPreviewSurface.xaml.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using TinyClips.Core.Capture;
 using TinyClips.Core.Models;
@@ -38,7 +39,7 @@ public sealed partial class WebcamPreviewSurface : UserControl
         _capture = null;
         _bitmap = null;
         _lastTimestamp = TimeSpan.MinValue;
-        PreviewImage.Source = null;
+        PreviewBrush.ImageSource = null;
     }
 
     public void ConfigureShape(WebcamShape shape, double? cornerRadius)
@@ -50,16 +51,28 @@ public sealed partial class WebcamPreviewSurface : UserControl
 
     private void ApplyShape()
     {
-        var radius = _shape switch
+        var isCircle = _shape == WebcamShape.Circle;
+        CircleShape.Visibility = isCircle ? Visibility.Visible : Visibility.Collapsed;
+        RectangleShape.Visibility = isCircle ? Visibility.Collapsed : Visibility.Visible;
+        if (isCircle)
         {
-            WebcamShape.Circle => Math.Min(ActualWidth, ActualHeight) / 2,
-            WebcamShape.RoundedRectangle => _cornerRadius is { } configuredRadius
-                ? configuredRadius / Math.Max(1.0, XamlRoot?.RasterizationScale ?? 1.0)
-                : Math.Min(ActualWidth, ActualHeight) * 0.12,
-            _ => 0,
-        };
-        PreviewBorder.CornerRadius = new CornerRadius(Math.Max(0, radius));
+            // An Ellipse is always round; nothing to compute.
+            return;
+        }
+
+        // A stroked Rectangle fits its geometry inside the layout bounds deflated by half the
+        // stroke thickness on each side, so the radius must be measured against that geometry.
+        var inset = RectangleShape.StrokeThickness;
+        var minSide = Math.Max(0, Math.Min(ActualWidth, ActualHeight) - inset);
+        var radius = _shape == WebcamShape.RoundedRectangle
+            ? (_cornerRadius is { } configuredRadius
+                ? Math.Min(minSide / 2, configuredRadius / Math.Max(1.0, XamlRoot?.RasterizationScale ?? 1.0))
+                : minSide * 0.12)
+            : 0;
+        RectangleShape.RadiusX = RectangleShape.RadiusY = Math.Max(0, radius);
     }
+
+    private ImageBrush PreviewBrush => (ImageBrush)Resources["PreviewBrush"];
 
     private void OnTick(object? sender, object e)
     {
@@ -73,7 +86,7 @@ public sealed partial class WebcamPreviewSurface : UserControl
         if (_bitmap is null || _bitmap.PixelWidth != frame.Width || _bitmap.PixelHeight != frame.Height)
         {
             _bitmap = new WriteableBitmap(frame.Width, frame.Height);
-            PreviewImage.Source = _bitmap;
+            PreviewBrush.ImageSource = _bitmap;
         }
 
         if (frame.IsGpuFrame)

--- a/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
+++ b/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
@@ -35,6 +35,11 @@ internal static class OverlayWindowHelpers
     /// ownership of the HRGN and the caller must not delete it. On failure (or if
     /// <c>CreateRoundRectRgn</c> itself failed) the handle is released here.
     /// </para>
+    /// <para>
+    /// Call this only <em>after</em> the window's first present (see
+    /// <c>CountdownWindow.RunAsync</c>): applying <c>SetWindowRgn</c> before a WinUI window has
+    /// been shown can leave its surface blank.
+    /// </para>
     /// </summary>
     /// <param name="hwnd">Target window handle.</param>
     /// <param name="widthPx">Window width in physical pixels.</param>
@@ -53,8 +58,10 @@ internal static class OverlayWindowHelpers
     /// </summary>
     public static void ApplyRoundedRegionPx(nint hwnd, int widthPx, int heightPx, int cornerRadiusPx)
     {
-        var radius = Math.Max(0, cornerRadiusPx);
-        var hrgn = CreateRoundRectRgn(0, 0, widthPx + 1, heightPx + 1, radius, radius);
+        // CreateRoundRectRgn takes the width/height of the *ellipse* that forms the corners, i.e.
+        // the diameter — passing the radius directly would round the corners at half the value.
+        var diameter = Math.Max(0, cornerRadiusPx) * 2;
+        var hrgn = CreateRoundRectRgn(0, 0, widthPx + 1, heightPx + 1, diameter, diameter);
         ApplyRegion(hwnd, hrgn);
     }
 

--- a/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
+++ b/windows/src/TinyClips.App/Infrastructure/OverlayWindowHelpers.cs
@@ -12,6 +12,10 @@ namespace TinyClips.App;
 internal static class OverlayWindowHelpers
 {
     private const uint WdaExcludeFromCapture = 0x11;
+    private const int DwmwaWindowCornerPreference = 33;
+    private const int DwmwaBorderColor = 34;
+    private const int DwmWindowCornerDoNotRound = 1;
+    private const uint DwmColorNone = 0xFFFFFFFE;
 
     /// <summary>
     /// Applies <c>WDA_EXCLUDEFROMCAPTURE</c> to the window.
@@ -40,10 +44,35 @@ internal static class OverlayWindowHelpers
     public static void ApplyRoundedRegion(nint hwnd, int widthPx, int heightPx, double scale, int cornerRadiusDip)
     {
         var radius = (int)Math.Round(cornerRadiusDip * scale);
+        ApplyRoundedRegionPx(hwnd, widthPx, heightPx, radius);
+    }
+
+    /// <summary>
+    /// Clips a borderless overlay to a rounded rectangle whose corner radius is already expressed
+    /// in physical pixels. Same HRGN ownership rules as <see cref="ApplyRoundedRegion"/>.
+    /// </summary>
+    public static void ApplyRoundedRegionPx(nint hwnd, int widthPx, int heightPx, int cornerRadiusPx)
+    {
+        var radius = Math.Max(0, cornerRadiusPx);
         var hrgn = CreateRoundRectRgn(0, 0, widthPx + 1, heightPx + 1, radius, radius);
+        ApplyRegion(hwnd, hrgn);
+    }
+
+    /// <summary>
+    /// Clips a borderless overlay to an ellipse inscribed in the window bounds (a circle when the
+    /// window is square). Same HRGN ownership rules as <see cref="ApplyRoundedRegion"/>.
+    /// </summary>
+    public static void ApplyEllipticRegion(nint hwnd, int widthPx, int heightPx)
+    {
+        var hrgn = CreateEllipticRgn(0, 0, widthPx + 1, heightPx + 1);
+        ApplyRegion(hwnd, hrgn);
+    }
+
+    private static void ApplyRegion(nint hwnd, nint hrgn)
+    {
         if (hrgn == 0)
         {
-            // CreateRoundRectRgn failed; nothing to apply or free.
+            // Region creation failed; nothing to apply or free.
             return;
         }
 
@@ -55,15 +84,38 @@ internal static class OverlayWindowHelpers
         // On success Windows owns hrgn; do not delete.
     }
 
+    /// <summary>
+    /// Removes the DWM-drawn window outline from a borderless overlay: no rounded-corner treatment
+    /// and no border color. Without this the system paints a thin light/dark hairline around the
+    /// window rectangle that survives <see cref="ApplyEllipticRegion"/> clipping and reads as a
+    /// grey box around non-rectangular content.
+    /// </summary>
+    public static void RemoveSystemBorder(nint hwnd)
+    {
+        var doNotRound = DwmWindowCornerDoNotRound;
+        DwmSetWindowAttribute(hwnd, DwmwaWindowCornerPreference, ref doNotRound, sizeof(int));
+        var noBorder = DwmColorNone;
+        DwmSetWindowAttribute(hwnd, DwmwaBorderColor, ref noBorder, sizeof(uint));
+    }
+
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool SetWindowDisplayAffinity(nint hWnd, uint dwAffinity);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmSetWindowAttribute(nint hwnd, int attribute, ref int value, int size);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmSetWindowAttribute(nint hwnd, int attribute, ref uint value, int size);
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool redrawWindow);
 
     [DllImport("gdi32.dll")]
     private static extern nint CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
+
+    [DllImport("gdi32.dll")]
+    private static extern nint CreateEllipticRgn(int x1, int y1, int x2, int y2);
 
     [DllImport("gdi32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/windows/src/TinyClips.App/Infrastructure/TransparentBackdrop.cs
+++ b/windows/src/TinyClips.App/Infrastructure/TransparentBackdrop.cs
@@ -1,0 +1,33 @@
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+
+namespace TinyClips.App;
+
+/// <summary>
+/// A <see cref="SystemBackdrop"/> that paints nothing, making the window's own background fully
+/// transparent. Borderless overlays (such as the floating webcam preview) use it so that only the
+/// XAML content they draw is visible — without it, WinUI paints an opaque theme-colored rectangle
+/// behind the content that shows around any rounded or circular surface.
+/// </summary>
+public sealed partial class TransparentBackdrop : SystemBackdrop
+{
+    // SystemBackdrop targets take a Windows.UI.Composition brush, so this uses the system
+    // compositor (valid here because every WinUI thread already owns a DispatcherQueue).
+    private Windows.UI.Composition.Compositor? _compositor;
+
+    protected override void OnTargetConnected(ICompositionSupportsSystemBackdrop connectedTarget, XamlRoot xamlRoot)
+    {
+        base.OnTargetConnected(connectedTarget, xamlRoot);
+        _compositor ??= new Windows.UI.Composition.Compositor();
+        connectedTarget.SystemBackdrop = _compositor.CreateColorBrush(Windows.UI.Color.FromArgb(0, 0, 0, 0));
+    }
+
+    protected override void OnTargetDisconnected(ICompositionSupportsSystemBackdrop disconnectedTarget)
+    {
+        disconnectedTarget.SystemBackdrop = null;
+        _compositor?.Dispose();
+        _compositor = null;
+        base.OnTargetDisconnected(disconnectedTarget);
+    }
+}

--- a/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml
+++ b/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml
@@ -10,17 +10,11 @@
 
     <Grid Background="Transparent">
         <Border
-            Padding="16,12"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
+            Padding="16,0"
             Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
             BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
             BorderThickness="1"
             CornerRadius="{StaticResource OverlayCornerRadius}">
-            <Border.Shadow>
-                <ThemeShadow />
-            </Border.Shadow>
-
             <StackPanel
                 Orientation="Horizontal"
                 Spacing="12"
@@ -42,7 +36,8 @@
                         x:Name="CaptionText"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Finalizing your clip" />
+                        Text="Finalizing your clip"
+                        TextTrimming="CharacterEllipsis" />
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
@@ -15,9 +15,11 @@ namespace TinyClips.App;
 /// </summary>
 public sealed partial class ProcessingIndicatorWindow : Window
 {
-    private const int WidthDip = 220;
+    private const int WidthDip = 260;
     private const int HeightDip = 64;
     private const int TopOffsetDip = 24;
+    private const int RegionOutsideOffsetDip = 12;
+    private const int CornerRadiusDip = 8;
 
     private bool _closed;
 
@@ -76,16 +78,36 @@ public sealed partial class ProcessingIndicatorWindow : Window
         var width = AppWindowPlacement.DipToPixels(WidthDip, target.Scale);
         var height = AppWindowPlacement.DipToPixels(HeightDip, target.Scale);
         var topOffset = AppWindowPlacement.DipToPixels(TopOffsetDip, target.Scale);
+        var regionOutsideOffset = AppWindowPlacement.DipToPixels(RegionOutsideOffsetDip, target.Scale);
         var x = work.X + Math.Max(0, (work.Width - width) / 2);
         var y = work.Y + topOffset;
 
+        // Mirror RecordingIndicatorWindow: sit just above the recorded region when there is room,
+        // otherwise just below it, and only overlap the region as a last resort.
         if (regionInVirtualDesktop is { Width: > 0, Height: > 0 } region)
         {
             x = region.X + Math.Max(0, (region.Width - width) / 2);
-            y = region.Y + topOffset;
+            var preferredAbove = region.Y - height - regionOutsideOffset;
+            var preferredBelow = region.Y + region.Height + regionOutsideOffset;
+            if (preferredAbove >= work.Y)
+            {
+                y = preferredAbove;
+            }
+            else if (preferredBelow <= work.Y + Math.Max(0, work.Height - height))
+            {
+                y = preferredBelow;
+            }
+            else
+            {
+                y = region.Y + topOffset;
+            }
         }
 
         AppWindow.MoveAndResize(AppWindowPlacement.ClampToWorkArea(work, x, y, width, height));
+
+        // Clip the window to the card's rounded corners so the acrylic backdrop doesn't show as
+        // a square frame around the rounded border.
+        OverlayWindowHelpers.ApplyRoundedRegion(hwnd, width, height, target.Scale, CornerRadiusDip);
     }
 
     private void OnClosed(object sender, WindowEventArgs args)

--- a/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/ProcessingIndicatorWindow.xaml.cs
@@ -42,12 +42,18 @@ public sealed partial class ProcessingIndicatorWindow : Window
 
     public void ShowNear(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
     {
-        PositionNearMonitorWorkArea(monitor, regionInVirtualDesktop);
+        var scale = PositionNearMonitorWorkArea(monitor, regionInVirtualDesktop);
         AppWindow.Show(false);
 
         // Keep the panel out of any concurrent capture.
         var hwnd = WindowNative.GetWindowHandle(this);
         OverlayWindowHelpers.ExcludeFromCapture(hwnd);
+
+        // Clip the window to the card's rounded corners so the acrylic backdrop doesn't show as a
+        // square frame around the rounded border. This runs after the first present: applying
+        // SetWindowRgn beforehand can leave a WinUI surface blank (see CountdownWindow.RunAsync).
+        var size = AppWindow.Size;
+        OverlayWindowHelpers.ApplyRoundedRegion(hwnd, size.Width, size.Height, scale, CornerRadiusDip);
     }
 
     public void ClosePanel()
@@ -70,7 +76,7 @@ public sealed partial class ProcessingIndicatorWindow : Window
         AppWindow.IsShownInSwitchers = false;
     }
 
-    private void PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
+    private double PositionNearMonitorWorkArea(MonitorInfo? monitor, PixelRect? regionInVirtualDesktop)
     {
         var hwnd = WindowNative.GetWindowHandle(this);
         var target = AppWindowPlacement.PrepareForTargetMonitor(AppWindow, hwnd, monitor);
@@ -104,10 +110,7 @@ public sealed partial class ProcessingIndicatorWindow : Window
         }
 
         AppWindow.MoveAndResize(AppWindowPlacement.ClampToWorkArea(work, x, y, width, height));
-
-        // Clip the window to the card's rounded corners so the acrylic backdrop doesn't show as
-        // a square frame around the rounded border.
-        OverlayWindowHelpers.ApplyRoundedRegion(hwnd, width, height, target.Scale, CornerRadiusDip);
+        return target.Scale;
     }
 
     private void OnClosed(object sender, WindowEventArgs args)

--- a/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml
+++ b/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml
@@ -5,16 +5,25 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:TinyClips.App">
 
-    <Grid x:Name="RootGrid">
+    <Window.SystemBackdrop>
+        <local:TransparentBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid x:Name="RootGrid" Background="Transparent">
         <ContentControl
             x:Name="PreviewControl"
             IsTabStop="True"
             AutomationProperties.Name="Webcam preview. Drag or use arrow keys to move it between recording corners."
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
             KeyDown="OnKeyDown"
             PointerMoved="OnPointerMoved"
             PointerPressed="OnPointerPressed"
             PointerReleased="OnPointerReleased"
             TabFocusNavigation="Local">
+            <!--  Fills the window edge to edge: the stroked shape already insets itself by half its
+                  stroke, so any extra margin would leave a ring of window background inside the
+                  native elliptic/rounded window region.  -->
             <local:WebcamPreviewSurface x:Name="PreviewSurface" />
         </ContentControl>
     </Grid>

--- a/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
@@ -74,9 +74,12 @@ public sealed partial class WebcamPreviewWindow : Window
         }
 
         SnapTo(_corner);
-        ApplyWindowShape(hwnd);
         PreviewSurface.Attach(_capture);
         AppWindow.Show(false);
+
+        // Shape the window only after the first present: applying SetWindowRgn beforehand can
+        // leave a WinUI surface blank (see CountdownWindow.RunAsync).
+        ApplyWindowShape(hwnd);
     }
 
     /// <summary>

--- a/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
+++ b/windows/src/TinyClips.App/Views/WebcamPreviewWindow.xaml.cs
@@ -19,6 +19,9 @@ public sealed partial class WebcamPreviewWindow : Window
     private readonly IWebcamCaptureService _capture;
     private readonly RectInt32 _captureBounds;
     private readonly int _margin;
+    private readonly WebcamShape _shape;
+    private readonly double? _cornerRadius;
+    private const int ShapeInsetDip = 2;
     private WebcamCornerPosition _corner;
     private Action<WebcamCornerPosition>? _cornerChanged;
     private bool _closed;
@@ -41,26 +44,65 @@ public sealed partial class WebcamPreviewWindow : Window
         _capture = capture;
         _captureBounds = ResolveCaptureBounds(target, monitor, regionInVirtualDesktop);
         _corner = corner;
+        _shape = shape;
+        _cornerRadius = cornerRadius;
         _cornerChanged = cornerChanged;
         _margin = Math.Clamp((int)Math.Round(Math.Min(_captureBounds.Width, _captureBounds.Height) * 0.03), 12, 40);
 
         ConfigurePresenter();
         ResizePreview(size, shape);
         PreviewSurface.ConfigureShape(shape, cornerRadius);
+
+        // Non-rectangular shapes are clipped twice: by the anti-aliased XAML shape and by the
+        // window's GDI region, which has hard stair-stepped edges. Insetting the content keeps the
+        // region boundary off the visible curve so the smooth XAML edge is what shows; the exposed
+        // ring is transparent window background (see TransparentBackdrop + RemoveSystemBorder).
+        PreviewSurface.Margin = shape == WebcamShape.Rectangle
+            ? new Thickness(0)
+            : new Thickness(ShapeInsetDip);
+
         Closed += OnClosed;
     }
 
     public void Show()
     {
-        if (!OverlayWindowHelpers.ExcludeFromCapture(WindowNative.GetWindowHandle(this)))
+        var hwnd = WindowNative.GetWindowHandle(this);
+        if (!OverlayWindowHelpers.ExcludeFromCapture(hwnd))
         {
             ClosePanel();
             return;
         }
 
         SnapTo(_corner);
+        ApplyWindowShape(hwnd);
         PreviewSurface.Attach(_capture);
         AppWindow.Show(false);
+    }
+
+    /// <summary>
+    /// Clips the native window to the webcam shape. The XAML surface already rounds its own
+    /// corners, but the window itself still paints an opaque rectangular background behind them;
+    /// a matching HRGN keeps that rectangle from showing around a circle or rounded preview.
+    /// </summary>
+    private void ApplyWindowShape(nint hwnd)
+    {
+        if (_shape == WebcamShape.Rectangle)
+        {
+            return;
+        }
+
+        OverlayWindowHelpers.RemoveSystemBorder(hwnd);
+        var size = AppWindow.Size;
+        if (_shape == WebcamShape.Circle)
+        {
+            OverlayWindowHelpers.ApplyEllipticRegion(hwnd, size.Width, size.Height);
+            return;
+        }
+
+        var radiusPx = _cornerRadius is { } configured
+            ? (int)Math.Round(configured)
+            : (int)Math.Round(Math.Min(size.Width, size.Height) * 0.12);
+        OverlayWindowHelpers.ApplyRoundedRegionPx(hwnd, size.Width, size.Height, radiusPx);
     }
 
     public void ClosePanel()
@@ -116,6 +158,19 @@ public sealed partial class WebcamPreviewWindow : Window
         }
 
         AppWindow.Resize(new SizeInt32(width, height));
+
+        // Windows can enforce a minimum tracking size, so the window may come back non-square. A
+        // circular preview stretched into a non-square window renders as an oval, so square it up
+        // against whatever size actually took effect.
+        if (shape == WebcamShape.Circle)
+        {
+            var actual = AppWindow.Size;
+            if (actual.Width != actual.Height)
+            {
+                var side = Math.Max(actual.Width, actual.Height);
+                AppWindow.Resize(new SizeInt32(side, side));
+            }
+        }
     }
 
     private void ConfigurePresenter()


### PR DESCRIPTION
Fixes four Windows issues reported while recording a video with the webcam overlay enabled.

## Webcam preview shape

- The live thumbnail next to the webcam toggle in the recording setup bar was fixed at 96×54, so choosing **Circle** rendered it as an oval. It now uses a square footprint for Circle and keeps 16:9 for the rectangle shapes.
- The preview surface drew its shape with a `Border`. A `Border` whose `CornerRadius` equals half its height clips the bottom row of its own stroke, which is why the picker thumbnail lost its bottom border pixels. It now uses shapes instead:
  - a real `Ellipse` for **Circle** — a stretched `Rectangle` applies `RadiusX`/`RadiusY` to its *pre-stretch* geometry, so it can never render a true circle;
  - a `Rectangle` for **Rectangle** / **Rounded rectangle**, with the radius measured against the stroke-deflated geometry.

  Both share a single `ImageBrush`, so the frame pump still updates one `ImageSource`.

## Webcam overlay while recording

A grey box was visible around the circular overlay (never in the recorded output — the overlay is composited separately).

- The overlay window painted an opaque rectangle behind its rounded surface. It now uses a `TransparentBackdrop`.
- Windows also drew its own DWM hairline and rounded-corner treatment, which survives region clipping. `OverlayWindowHelpers.RemoveSystemBorder` clears both (`DWMWCP_DONOTROUND` + `DWMWA_COLOR_NONE`).
- The window is clipped by a native region matching the shape — new `ApplyEllipticRegion` for Circle, `ApplyRoundedRegionPx` otherwise.
- The window squares itself up if Windows' minimum tracking size makes the requested size non-square (a circle stretched into a non-square window is an oval), and the shape is inset 2 DIP so the region's hard, non-anti-aliased edge doesn't cut into the smooth XAML curve.

## Processing popup

- Clipped to its rounded corners, so the acrylic backdrop no longer shows as a square frame around the card.
- The card fills the panel instead of floating inside it, and the panel is a little wider so the caption isn't cramped.
- Positions just above/below the recorded region, matching `RecordingIndicatorWindow`.

## Trimmer scrubbing

The video and GIF trimmers could only adjust start/end — there was no way to scrub. A press inside the selected range dragged the whole range, and since the range spans the entire clip by default, every press landed inside it.

- Clicking or dragging anywhere on the track now moves the playhead.
- **Shift**+drag inside the selection moves the range as a whole (the previous default). Hover cursor and automation help text updated to match.

## Validation

- `dotnet build windows/src/TinyClips.App/TinyClips.App.csproj -c Debug -p:Platform=x64` — succeeded
- `dotnet test windows/tests/TinyClips.Core.Tests/TinyClips.Core.Tests.csproj -c Debug` — 248 passed
- Manually verified end to end: setup-bar thumbnail shape/border, live circular overlay during recording, processing popup, and scrubbing in the video trimmer.