### PR TITLE
Revert the explicit msstore upload timeout now that msstore-cli#162 is fixed

### DIFF
--- a/.github/workflows/windows-store-publish.yml
+++ b/.github/workflows/windows-store-publish.yml
@@ -201,7 +201,5 @@ jobs:
 
           # Pass the package file itself. Pointing msstore at a directory makes it look for a
           # project to infer a publisher from, which does not exist in this workflow.
-          # --uploadTimeout must be set explicitly: when omitted the CLI has defaulted it to 0,
-          # which cancels the blob upload immediately. See microsoft/msstore-cli#162.
-          msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID --uploadTimeout 900
+          msstore publish $upload.FullName --appId $env:STORE_PRODUCT_ID
           if ($LASTEXITCODE -ne 0) { throw "msstore publish failed." }


### PR DESCRIPTION
[microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162) is fixed and released, so the workaround added in #321 can come out.

### Background

`--uploadTimeout` was added in msstore-cli v0.4.0 with a `CustomParser` but no `DefaultValueFactory`. System.CommandLine only runs a `CustomParser` when the option is present on the command line, so omitting it left the value at `default(long)` — `0` — which became the Azure blob client's `Retry.NetworkTimeout`, cancelling every request the instant it started.

### Why it is safe to revert now

- Fixed by [microsoft/msstore-cli#163](https://github.com/microsoft/msstore-cli/pull/163), released in **msstore-cli v0.4.2** on 2026-09-02.
- This workflow uses `microsoft/microsoft-store-apppublisher@v1.4` without a `version:` input, which defaults to `latest` — so the runner now gets v0.4.2 and the documented 100 s default applies.
- Your published packages are ~22 MB per architecture. The CLI sets no `StorageTransferOptions`, so a package under 256 MiB uploads as a **single PUT** and the timeout has to cover the whole transfer rather than one chunk — at 22 MB that needs a sustained ~224 kB/s, which is comfortable on a hosted runner.

### Note

Because the action tracks `latest`, a future CLI regression could reach this workflow again with nothing pinned to stop it. Adding an explicit `version:` pin is worth considering separately.

Sent as part of a sweep across the repos that referenced msstore-cli#162.
